### PR TITLE
Improve progress loading bar logic for pdf content

### DIFF
--- a/peachjam/js/components/pdf-renderer.ts
+++ b/peachjam/js/components/pdf-renderer.ts
@@ -115,7 +115,7 @@ class PdfRenderer {
     loadingTask.onProgress = (data: { loaded: number }) => {
       if(this.pdfSize) {
         /*
-        * The progress bar represents the progress of two process
+        * The progress bar represents the progress of two processes
         *  1) loading the pdf data (first 50%)
         *  2) creating the pdf associating html and inserting it into the DOM (last 50%)
         * */


### PR DESCRIPTION
HTML creation of pdf content also takes a bit of time to finish. So I have accounted for progress in the progress bar.
 The progress bar now represents the progress of two processes
 - Loading the pdf data (first 50%)
- Creating the pdf associating html and inserting it into the DOM (last 50%)