### PR TITLE
Cache Search Results

### DIFF
--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 from django_elasticsearch_dsl_drf.filter_backends import (
     CompoundSearchFilterBackend,
@@ -12,6 +14,8 @@ from elasticsearch_dsl import DateHistogramFacet
 
 from peachjam_search.documents import SearchableDocument
 from peachjam_search.serializers import SearchableDocumentSerializer
+
+CACHE_SECS = 15 * 60
 
 
 class SearchView(TemplateView):
@@ -97,3 +101,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
             }
         },
     }
+
+    @method_decorator(cache_page(CACHE_SECS))
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
Send cache headers so that the client caches the search response for 15 minutes.

### Screenshot
<img width="997" alt="Screenshot 2022-06-07 at 09 25 35" src="https://user-images.githubusercontent.com/8082197/172310564-8df3c5eb-8215-4c78-8623-67eff1c9dcd2.png">

closes #157 