### PR TITLE
Multiple Document Versions Support

### DIFF
--- a/africanlii/templates/africanlii/layouts/document_detail.html
+++ b/africanlii/templates/africanlii/layouts/document_detail.html
@@ -19,10 +19,42 @@
                   <dt class="col-4">Author</dt>
                   <dd class="col-8 text-muted">{{ document.authoring_body }}</dd>
                 {% endif %}
+
                 <dt class="col-4">Date</dt>
-                <dd class="col-8 text-muted">{{ document.date }}</dd>
+                {% if date_versions %}
+                  <dd class="col-8">
+                    <div class="dropdown">
+                      <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                        {{ document.date }}
+                      </a>
+                      <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                        {% for version in date_versions %}
+                          <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.date }}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </dd>
+                {% else %}
+                  <dd class="col-8 text-muted">{{ document.date }}</dd>
+                {% endif %}
+
                 <dt class="col-4">Language</dt>
-                <dd class="col-8 text-muted">{{ document.language }}</dd>
+                {% if language_versions %}
+                  <dd class="col-8">
+                    <div class="dropdown">
+                      <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                        {{ document.language }}
+                      </a>
+                      <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                        {% for version in language_versions %}
+                          <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.language }}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </dd>
+                {% else %}
+                  <dd class="col-8 text-muted">{{ document.language }} </dd>
+                {% endif %}
               </dl>
             {% endblock %}
 

--- a/africanlii/views/generic_document.py
+++ b/africanlii/views/generic_document.py
@@ -1,9 +1,7 @@
-from django.views.generic import DetailView
-
 from africanlii.models import GenericDocument
 from africanlii.registry import registry
 from africanlii.views.generic_views import (
-    DocumentVersionsMixin,
+    BaseDocumentDetailView,
     FilteredDocumentListView,
 )
 
@@ -20,9 +18,6 @@ class GenericDocumentListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("generic_document")
-class GenericDocumentDetailView(DocumentVersionsMixin, DetailView):
+class GenericDocumentDetailView(BaseDocumentDetailView):
     model = GenericDocument
-    slug_field = "expression_frbr_uri"
-    slug_url_kwarg = "expression_frbr_uri"
     template_name = "africanlii/generic_document_detail.html"
-    context_object_name = "document"

--- a/africanlii/views/generic_document.py
+++ b/africanlii/views/generic_document.py
@@ -2,7 +2,10 @@ from django.views.generic import DetailView
 
 from africanlii.models import GenericDocument
 from africanlii.registry import registry
-from africanlii.views.generic_views import FilteredDocumentListView
+from africanlii.views.generic_views import (
+    DocumentVersionsMixin,
+    FilteredDocumentListView,
+)
 
 
 class GenericDocumentListView(FilteredDocumentListView):
@@ -17,7 +20,7 @@ class GenericDocumentListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("generic_document")
-class GenericDocumentDetailView(DetailView):
+class GenericDocumentDetailView(DocumentVersionsMixin, DetailView):
     model = GenericDocument
     slug_field = "expression_frbr_uri"
     slug_url_kwarg = "expression_frbr_uri"

--- a/africanlii/views/generic_views.py
+++ b/africanlii/views/generic_views.py
@@ -1,4 +1,4 @@
-from django.views.generic import ListView
+from django.views.generic import DetailView, ListView
 
 from africanlii.forms import BaseDocumentFilterForm
 from africanlii.models import AuthoringBody, Court
@@ -56,10 +56,10 @@ class FilteredDocumentListView(ListView, BaseDocumentFilterForm):
         return context
 
 
-class DocumentVersionsMixin:
-    """Helper mixin for document detail views to fetch other versions of a document based
-    on the document's work_frbr_uri and separate them based on language and date.
-    """
+class BaseDocumentDetailView(DetailView):
+    slug_field = "expression_frbr_uri"
+    slug_url_kwarg = "expression_frbr_uri"
+    context_object_name = "document"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -72,6 +72,8 @@ class DocumentVersionsMixin:
         context["language_versions"] = all_versions.filter(date=self.object.date)
 
         # date versions that match current document language
-        context["date_versions"] = all_versions.filter(language=self.object.language)
+        context["date_versions"] = all_versions.filter(
+            language=self.object.language
+        ).order_by("-date")
 
         return context

--- a/africanlii/views/judgment.py
+++ b/africanlii/views/judgment.py
@@ -1,9 +1,7 @@
-from django.views.generic import DetailView
-
 from africanlii.models import Judgment
 from africanlii.registry import registry
 from africanlii.views.generic_views import (
-    DocumentVersionsMixin,
+    BaseDocumentDetailView,
     FilteredDocumentListView,
 )
 
@@ -20,9 +18,6 @@ class JudgmentListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("judgment")
-class JudgmentDetailView(DocumentVersionsMixin, DetailView):
+class JudgmentDetailView(BaseDocumentDetailView):
     model = Judgment
-    slug_field = "expression_frbr_uri"
-    slug_url_kwarg = "expression_frbr_uri"
     template_name = "africanlii/judgment_detail.html"
-    context_object_name = "document"

--- a/africanlii/views/judgment.py
+++ b/africanlii/views/judgment.py
@@ -2,7 +2,10 @@ from django.views.generic import DetailView
 
 from africanlii.models import Judgment
 from africanlii.registry import registry
-from africanlii.views.generic_views import FilteredDocumentListView
+from africanlii.views.generic_views import (
+    DocumentVersionsMixin,
+    FilteredDocumentListView,
+)
 
 
 class JudgmentListView(FilteredDocumentListView):
@@ -17,7 +20,7 @@ class JudgmentListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("judgment")
-class JudgmentDetailView(DetailView):
+class JudgmentDetailView(DocumentVersionsMixin, DetailView):
     model = Judgment
     slug_field = "expression_frbr_uri"
     slug_url_kwarg = "expression_frbr_uri"

--- a/africanlii/views/legal_instrument.py
+++ b/africanlii/views/legal_instrument.py
@@ -2,7 +2,10 @@ from django.views.generic import DetailView
 
 from africanlii.models import LegalInstrument
 from africanlii.registry import registry
-from africanlii.views.generic_views import FilteredDocumentListView
+from africanlii.views.generic_views import (
+    DocumentVersionsMixin,
+    FilteredDocumentListView,
+)
 
 
 class LegalInstrumentListView(FilteredDocumentListView):
@@ -17,7 +20,7 @@ class LegalInstrumentListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("legal_instrument")
-class LegalInstrumentDetailView(DetailView):
+class LegalInstrumentDetailView(DocumentVersionsMixin, DetailView):
     model = LegalInstrument
     slug_field = "expression_frbr_uri"
     slug_url_kwarg = "expression_frbr_uri"

--- a/africanlii/views/legal_instrument.py
+++ b/africanlii/views/legal_instrument.py
@@ -1,9 +1,7 @@
-from django.views.generic import DetailView
-
 from africanlii.models import LegalInstrument
 from africanlii.registry import registry
 from africanlii.views.generic_views import (
-    DocumentVersionsMixin,
+    BaseDocumentDetailView,
     FilteredDocumentListView,
 )
 
@@ -20,9 +18,6 @@ class LegalInstrumentListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("legal_instrument")
-class LegalInstrumentDetailView(DocumentVersionsMixin, DetailView):
+class LegalInstrumentDetailView(BaseDocumentDetailView):
     model = LegalInstrument
-    slug_field = "expression_frbr_uri"
-    slug_url_kwarg = "expression_frbr_uri"
     template_name = "africanlii/legal_instrument_detail.html"
-    context_object_name = "document"

--- a/africanlii/views/legislation.py
+++ b/africanlii/views/legislation.py
@@ -2,7 +2,10 @@ from django.views.generic import DetailView
 
 from africanlii.models import Legislation
 from africanlii.registry import registry
-from africanlii.views.generic_views import FilteredDocumentListView
+from africanlii.views.generic_views import (
+    DocumentVersionsMixin,
+    FilteredDocumentListView,
+)
 
 
 class LegislationListView(FilteredDocumentListView):
@@ -13,7 +16,7 @@ class LegislationListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("legislation")
-class LegislationDetailView(DetailView):
+class LegislationDetailView(DocumentVersionsMixin, DetailView):
     model = Legislation
     slug_field = "expression_frbr_uri"
     slug_url_kwarg = "expression_frbr_uri"

--- a/africanlii/views/legislation.py
+++ b/africanlii/views/legislation.py
@@ -1,9 +1,7 @@
-from django.views.generic import DetailView
-
 from africanlii.models import Legislation
 from africanlii.registry import registry
 from africanlii.views.generic_views import (
-    DocumentVersionsMixin,
+    BaseDocumentDetailView,
     FilteredDocumentListView,
 )
 
@@ -16,9 +14,6 @@ class LegislationListView(FilteredDocumentListView):
 
 
 @registry.register_doc_type("legislation")
-class LegislationDetailView(DocumentVersionsMixin, DetailView):
+class LegislationDetailView(BaseDocumentDetailView):
     model = Legislation
-    slug_field = "expression_frbr_uri"
-    slug_url_kwarg = "expression_frbr_uri"
     template_name = "africanlii/legislation_detail.html"
-    context_object_name = "document"


### PR DESCRIPTION
This PR adds support for multiple document versions based on date and language.

* [x] Make the current date in the `Date: xxx` metadata block a bootstrap dropdown, that shows the alternate date versions as links.
* [x] Make the current language in the `Language: English` metadata block a bootstrap dropdown, that shows the alternate language versions as links.


### Screenshots
* **Multiple language versions for the same date:**
  <img width="908" alt="image" src="https://user-images.githubusercontent.com/8082197/172584663-01223ace-78d7-490a-95fc-d3d2f227f1bc.png">

* **Multiple date versions for the same language:**
  <img width="998" alt="image" src="https://user-images.githubusercontent.com/8082197/172584529-0489dc95-3ced-42f2-b5b6-e6e962c75cba.png">

* **Document without other date or language versions:**
  <img width="866" alt="image" src="https://user-images.githubusercontent.com/8082197/172584851-b6396e6d-f146-4f58-b5c4-34a9f80aa303.png">

closes #128 
closes #129