### PR TITLE
Import content from uploaded files

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -12,7 +12,7 @@ from import_export.admin import ImportMixin
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory
 
-from peachjam.forms import IngestorForm, RelationshipForm
+from peachjam.forms import IngestorForm, NewDocumentFormMixin, RelationshipForm
 from peachjam.models import (
     Author,
     CaseNumber,
@@ -129,6 +129,28 @@ class DocumentAdmin(admin.ModelAdmin):
         ),
         ("Advanced", {"classes": ("collapse",), "fields": ["toc_json"]}),
     ]
+
+    new_document_form_mixin = NewDocumentFormMixin
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super().get_fieldsets(request, obj)
+        if obj is None:
+            fieldsets = self.new_document_form_mixin.adjust_fieldsets(fieldsets)
+        return fieldsets
+
+    def get_form(self, request, obj=None, **kwargs):
+        if obj is None:
+            kwargs["fields"] = self.new_document_form_mixin.adjust_fields(
+                kwargs["fields"]
+            )
+            form = super().get_form(request, obj, **kwargs)
+
+            class NewForm(self.new_document_form_mixin, form):
+                pass
+
+            return NewForm
+
+        return super().get_form(request, obj, **kwargs)
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name

--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -1,3 +1,5 @@
+import copy
+
 from django import forms
 
 from peachjam.models import CoreDocument, Ingestor, Relationship, Work
@@ -37,3 +39,39 @@ class IngestorForm(forms.ModelForm):
     class Meta:
         model = Ingestor
         fields = ("adapter", "name")
+
+
+class NewDocumentFormMixin:
+    """Mixin for the admin view when creating a new document that adds a new field to allow the user to upload a
+    file from which key data can be extracted.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["upload_file"] = forms.FileField(required=False)
+
+    def save(self, commit=True):
+        if "upload_file" in self.cleaned_data:
+            self.process_upload_file(self.cleaned_data["upload_file"])
+        return super().save(commit)
+
+    def process_upload_file(self, upload_file):
+        # TODO: .doc content type
+        if (
+            upload_file.content_type
+            == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ):
+            # TODO: read the uploaded file and extract its contents
+            self.instance.content_html = "contents of file"
+
+    @classmethod
+    def adjust_fieldsets(cls, fieldsets):
+        # add the upload_file to the first set of fields to include on the page
+        fieldsets = copy.deepcopy(fieldsets)
+        fieldsets[0][1]["fields"].append("upload_file")
+        return fieldsets
+
+    @classmethod
+    def adjust_fields(cls, fields):
+        # don't include 'upload_field' when generating the form
+        return [f for f in fields if f != "upload_file"]

--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -114,7 +114,10 @@ class CoreDocument(models.Model):
             not hasattr(self, "work") or self.work.frbr_uri != self.work_frbr_uri
         ):
             self.work, _ = Work.objects.get_or_create(
-                frbr_uri=self.work_frbr_uri, title=self.title
+                frbr_uri=self.work_frbr_uri,
+                defaults={
+                    "title": self.title,
+                },
             )
 
         # keep work title in sync with English documents

--- a/peachjam/pipelines.py
+++ b/peachjam/pipelines.py
@@ -1,0 +1,22 @@
+from docpipe.html import BodyToDiv, SerialiseHtml, parse_and_clean
+from docpipe.pipeline import Pipeline, PipelineContext
+from docpipe.soffice import DocToHtml
+
+DOC_MIMETYPES = [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/msword",
+]
+
+
+class ImportContext(PipelineContext):
+    source_file = None
+
+
+word_pipeline = Pipeline(
+    [
+        DocToHtml(),
+        parse_and_clean,
+        BodyToDiv(),
+        SerialiseHtml(),
+    ]
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ charset-normalizer==2.0.12
 cobalt==5.0.0
 cryptography==36.0.1
 defusedxml==0.7.1
+git+https://github.com/laws-africa/docpipe.git@fac46c6f7ffe51f23e96b63488cb1cc45d2de6a7#egg=docpipe
 dj-database-url==0.5.0
 Django==3.2.13
 django-allauth==0.49.0


### PR DESCRIPTION
* add a new "upload file" input element when creating (not editing) a document
* the content is processed through a document pipeline to clean the HTML and stored as `content_html`
* the uploaded file is stored as the source file