### PR TITLE
Ingestor update fix

### DIFF
--- a/peachjam/resources.py
+++ b/peachjam/resources.py
@@ -33,11 +33,18 @@ class JurisdictionWidget(ForeignKeyWidget):
         return None
 
 
+class AuthorWidget(ForeignKeyWidget):
+    def clean(self, value, row=None, *args, **kwargs):
+        if value:
+            return self.model.objects.get(code__iexact=value)
+        return None
+
+
 class BaseDocumentResource(resources.ModelResource):
     author = fields.Field(
         column_name="author",
         attribute="author",
-        widget=ForeignKeyWidget(Author, field="code"),
+        widget=AuthorWidget(Author),
     )
     language = fields.Field(
         attribute="language",
@@ -72,7 +79,6 @@ class BaseDocumentResource(resources.ModelResource):
         row["frbr_uri_date"] = frbr_uri.date
 
         if frbr_uri.actor:
-            Author.objects.update_or_create(code=frbr_uri.actor)
             row["frbr_uri_actor"] = frbr_uri.actor
             row["author"] = frbr_uri.actor
 


### PR DESCRIPTION
- The issue here was that the frbr uris coming from indigo and the ones that we are generating on peachjam do not match.
- The adapter tries to create a new document from the frbr_uri provided by indigo since it can't find a match on peachjam
- This results in db integrity errors when performing the update from the ingestor.
- By reusing the frbr_uri generation methods on the core document model, we can now get the correct value and perform the update.