### PR TITLE
Fix compiling scss error which is block deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ cython_debug/
 staticfiles
 .DS_Store
 .sass-cache
+
+#Ignore app static build styles
+peachjam/static/stylesheets/peachjam.css
+africanlii/static/stylesheets/africanlii.css
+lawlibrary/static/stylesheets/lawlibrary.css
+liiweb/static/stylesheets/liiweb.css

--- a/africanlii/settings.py
+++ b/africanlii/settings.py
@@ -3,5 +3,3 @@ from peachjam.settings import *  # noqa
 ROOT_URLCONF = "peachjam.urls"
 
 INSTALLED_APPS = ["africanlii.apps.AfricanliiConfig"] + INSTALLED_APPS  # noqa
-
-APP_STYLES = "stylesheets/africanlii.scss"

--- a/africanlii/templates/peachjam/layouts/main.html
+++ b/africanlii/templates/peachjam/layouts/main.html
@@ -1,0 +1,7 @@
+{% extends 'peachjam/layouts/main.html' %}
+
+{% load sass_tags %}
+
+{% block head-css %}
+    <link rel="stylesheet" href="{% sass_src 'stylesheets/africanlii.scss' %}" type="text/css">
+{% endblock %}

--- a/lawlibrary/settings.py
+++ b/lawlibrary/settings.py
@@ -3,5 +3,3 @@ from peachjam.settings import *  # noqa
 INSTALLED_APPS = ["lawlibrary", "liiweb"] + INSTALLED_APPS  # noqa
 
 ROOT_URLCONF = "lawlibrary.urls"
-
-APP_STYLES = "stylesheets/lawlibrary.scss"

--- a/lawlibrary/templates/peachjam/layouts/main.html
+++ b/lawlibrary/templates/peachjam/layouts/main.html
@@ -1,4 +1,10 @@
 {% extends "peachjam/layouts/main.html" %}
 
+{% load sass_tags %}
+
 {% block head-meta %}
+{% endblock %}
+
+{% block head-css %}
+  <link rel="stylesheet" href="{% sass_src 'stylesheets/lawlibrary.scss' %}" type="text/css">
 {% endblock %}

--- a/liiweb/settings.py
+++ b/liiweb/settings.py
@@ -1,7 +1,3 @@
 from peachjam.settings import *  # noqa
 
 INSTALLED_APPS = ["liiweb"] + INSTALLED_APPS  # noqa
-
-ROOT_URLCONF = "liiweb.urls"
-
-APP_STYLES = "stylesheets/liiweb.scss"

--- a/liiweb/templates/peachjam/layouts/main.html
+++ b/liiweb/templates/peachjam/layouts/main.html
@@ -1,0 +1,7 @@
+{% extends 'peachjam/layouts/main.html' %}
+
+{% load sass_tags %}
+
+{% block head-css %}
+  <link rel="stylesheet" href="{% sass_src 'stylesheets/liiweb.scss' %}" type="text/css">
+{% endblock %}

--- a/peachjam/context_processors.py
+++ b/peachjam/context_processors.py
@@ -12,5 +12,4 @@ def general(request):
         "SENTRY_DSN_KEY": settings.PEACHJAM["SENTRY_DSN_KEY"],
         "SENTRY_ENVIRONMENT": settings.PEACHJAM["SENTRY_ENVIRONMENT"],
         "GOOGLE_ANALYTICS_ID": settings.GOOGLE_ANALYTICS_ID,
-        "APP_STYLES": settings.APP_STYLES,
     }

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -351,5 +351,3 @@ if DEBUG:
 GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID")
 
 CKEDITOR_CONFIGS = {"default": {"removePlugins": ["image"]}}
-
-APP_STYLES = "stylesheets/peachjam.scss"

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -3,7 +3,7 @@
 {% load sass_tags %}
 
 {% block head-css %}
-    <link rel="stylesheet" href="{% sass_src APP_STYLES  %}" type="text/css">
+    <link rel="stylesheet" href="{% sass_src 'stylesheets/peachjam.scss' %}" type="text/css">
 {% endblock %}
 
 {% block head-js %}


### PR DESCRIPTION
During deploy, `python manage.py compilescss` scans all through all django templates for `scss` link references and finds the corresponding `scss file` in static to compile. The problem is that it is not intelligent enough to decipher what we had. (Not able to decipher `APP_STYLES`)
```
<link rel="stylesheet" href="{% sass_src APP_STYLES  %}" type="text/css">
```
Hence deploys are blocked

**Solution:**
We have to put an actual value. I took the alternative approach to solve this problem which was extending `main.html` and override `block head-css` in each sub app of `peachjam` (`liiweb, africanlii, lawlibrary`)

resolves https://github.com/laws-africa/peachjam/issues/283