### PR TITLE
When importing word, strip font and line-height

### DIFF
--- a/peachjam/pipelines.py
+++ b/peachjam/pipelines.py
@@ -1,6 +1,7 @@
 from docpipe.html import BodyToDiv, SerialiseHtml, parse_and_clean
-from docpipe.pipeline import Pipeline, PipelineContext
+from docpipe.pipeline import Pipeline, PipelineContext, Stage
 from docpipe.soffice import DocToHtml
+from docpipe.xmlutils import unwrap_element
 
 DOC_MIMETYPES = [
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -12,11 +13,52 @@ class ImportContext(PipelineContext):
     source_file = None
 
 
+class RemoveTags(Stage):
+    """Unwraps certain tags.
+
+    Reads: context.html
+    Writes: context.html
+    """
+
+    tags = ["font"]
+
+    def __call__(self, context):
+        xpath = " | ".join(f"//{x}" for x in self.tags)
+        for font in context.html.xpath(xpath):
+            unwrap_element(font)
+
+
+class CleanStyles(Stage):
+    # styles we explicitly want to remove
+    style_blacklist = {"p": set("line-height".split()), None: set()}
+
+    def __call__(self, context):
+        for elem in context.html.xpath(".//*[@style]"):
+            style = self.clean_style_string(elem.tag, elem.get("style"))
+            if not style:
+                del elem.attrib["style"]
+            else:
+                elem.set("style", style)
+
+    def clean_style_string(self, tag, s):
+        blacklist = self.style_blacklist.get(tag, self.style_blacklist[None])
+
+        # split style string into rules, and rules into pairs
+        # color: red; margin: 0px -> {'color': 'red', 'margin': '0px'}
+        pairs = [a.split(":") for a in s.split(";") if ":" in a]
+        styles = {k.strip(): v.strip() for (k, v) in pairs}
+
+        styles = "; ".join(f"{k}: {v}" for k, v in styles.items() if k not in blacklist)
+        return styles
+
+
 word_pipeline = Pipeline(
     [
         DocToHtml(),
         parse_and_clean,
         BodyToDiv(),
+        RemoveTags(),
+        CleanStyles(),
         SerialiseHtml(),
     ]
 )

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -1,5 +1,10 @@
 .document-content {
 
+  .content.content__html {
+    // content
+    line-height: normal;
+  }
+
   .document-content__toggle {
     @extend .mb-4;
     position: sticky;

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -1,7 +1,7 @@
 .document-content {
 
   .content.content__html {
-    // content
+    // reset line height so html documents use their default, rather than bootstrap's adjusted line height
     line-height: normal;
   }
 

--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -141,7 +141,7 @@
           </la-akoma-ntoso>
         {% endif %}
         {% if display_type == 'html' %}
-          <div class="content" data-document-element>
+          <div class="content content__html" data-document-element>
             {{ document.content_html|safe }}
           </div>
         {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.0.12
 cobalt==6.0.0
 cryptography==36.0.1
 defusedxml==0.7.1
-git+https://github.com/laws-africa/docpipe.git@fd74de94f722a69058315e09a6a6cde18ae2609a#egg=docpipe
+git+https://github.com/laws-africa/docpipe.git@85a67a91709d44cf46af0d85fcd1b14afb7c8a08#egg=docpipe
 dj-database-url==0.5.0
 Django==3.2.14
 django-allauth==0.49.0


### PR DESCRIPTION
Also reset line-height to normal for the document text. Otherwise it uses bootstrap's adjusted line height.

Before:
![image](https://user-images.githubusercontent.com/4178542/182591154-c976f708-e7e6-47c2-8205-5f344e0c9b95.png)


After:
![image](https://user-images.githubusercontent.com/4178542/182591203-92d0b488-a0e2-4b0a-b97a-d4114e41794c.png)
