### PR TITLE
Make page-based searching work

### DIFF
--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -101,8 +101,9 @@ class SearchableDocument(Document):
 
     def prepare_pages(self, instance):
         """Extract pages from PDF"""
-        if hasattr(instance, "source_file"):
-
+        if hasattr(instance, "source_file") and instance.source_file.filename.endswith(
+            ".pdf"
+        ):
             text = pdf_to_text(instance.source_file.file.path)
 
             if not text:

--- a/peachjam_search/serializers.py
+++ b/peachjam_search/serializers.py
@@ -19,7 +19,6 @@ class SearchableDocumentSerializer(DocumentSerializer):
             "jurisdiction",
             "locality",
             "citation",
-            "content",
             "expression_frbr_uri",
             "work_frbr_uri",
             "authoring_body",
@@ -27,11 +26,8 @@ class SearchableDocumentSerializer(DocumentSerializer):
             "matter_type",
             "case_number_string",
             "court",
-            "headnote_holding",
-            "flynote",
             "judges",
             "highlight",
-            "pages",
         ]
 
     def get_highlight(self, obj):


### PR DESCRIPTION
* create a simple compound filter backend that will correctly join the field-based search with the nested page query search into a single "should" statement
* don't return large source fields which are not shown in the search results (and remove from serializer)
* boost title field
* use SimpleQueryString search which handles quoted searches for us


Produces a search like this:

```
"query": {
    "bool": {
      "should": [
        {
          "simple_query_string": {
            "fields": [
              "title^2",
              "author",
              "citation",
              "judges",
              "content"
            ],
            "query": "africa"
          }
        },
        {
          "nested": {
            "inner_hits": {
              "_source": [
                "pages.page_num"
              ],
              "highlight": {
                "fields": {
                  "pages.body": {}
                },
                "fragment_size": 80,
                "number_of_fragments": 2,
                "post_tags": [
                  "</mark>"
                ],
                "pre_tags": [
                  "<mark>"
                ]
              }
            },
            "path": "pages",
            "query": {
              "bool": {
                "must": [
                  {
                    "simple_query_string": {
                      "default_operator": "and",
                      "fields": [
                        "pages.body"
                      ],
                      "query": "africa",
                      "quote_field_suffix": ".exact"
                    }
                  }
                ],
                "should": [
                  {
                    "match_phrase": {
                      "pages.body": {
                        "query": "africa",
                        "slop": 2
                      }
                    }
                  }
                ]
              }
            }
          }
```