### PR TITLE
Bump search timeout to 30 sec

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -229,7 +229,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 ELASTICSEARCH_DSL = {
     "default": {
         "hosts": os.environ.get("ELASTICSEARCH_HOST", "localhost:9200"),
-        "timeout": 5,
+        "timeout": 30,
     },
 }
 ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = (


### PR DESCRIPTION
This PR extends the search endpoint timeout from `5 seconds` to `30 seconds` to fix the search `ReadTimeoutError` on Sentry

closes #354 