### PR TITLE
Remove cards from document detail view

### DIFF
--- a/peachjam/static/stylesheets/components/_timeline.scss
+++ b/peachjam/static/stylesheets/components/_timeline.scss
@@ -8,7 +8,7 @@
     position: absolute;
     width: 6px;
     background-color: $gray-200;
-    top: 0;
+    top: 20px;
     bottom: 0;
     left: 0;
     margin-left: -3px;
@@ -23,14 +23,14 @@
   &:before {
     content: " ";
     position: absolute;
-    top: 22px;
+    top: 18px;
     z-index: 1;
     left: 30px;
     width: 0;
     height: 0;
     border-top: 10px solid transparent;
     border-bottom: 10px solid transparent;
-    border-right: 10px solid $gray-100;
+    border-right: 10px solid $border-color;
   }
 
   &:after {

--- a/peachjam/templates/peachjam/_timeline_events.html
+++ b/peachjam/templates/peachjam/_timeline_events.html
@@ -1,57 +1,54 @@
 {% load peachjam i18n %}
 
-<div class="card">
-  <div class="card-body">
-    <h4>History of this document</h4>
-    {% if timeline_events %}
-      <div class="vertical-timeline">
-        {% for history_item in timeline_events %}
-          <div class="vertical-timeline__item">
-            <div class="card">
-              <div class="card-header">
-                <h5 class="mb-0">
-                  {{ history_item.date|parse_string_date|date:"d F Y" }}
-                  {% if history_item.date == current_object_date %}
-                    <span class="badge rounded-pill bg-primary">this version</span>
-                  {% endif %}
-                </h5>
-              </div>
-              <div class="card-body">
-                {% for event in history_item.events %}
-                  <div>
-                    {% if event.event == "amendment" %}
-                      Amended by
-                      <a href="{{ event.amending_uri }}/eng/"><i>{{ event.amending_title }}</i></a>
+<h4>History of this document</h4>
 
-                    {% elif event.event == "assent" %}
-                      Assented to by council.
+{% if timeline_events %}
+  <div class="vertical-timeline ms-5 mt-4">
+    {% for history_item in timeline_events %}
+      <div class="vertical-timeline__item">
+        <div class="card mb-3">
+          <div class="card-header">
+            <h5 class="mb-0">
+              {{ history_item.date|parse_string_date|date:"d F Y" }}
+              {% if history_item.date == current_object_date %}
+                <span class="badge rounded-pill bg-primary">this version</span>
+              {% endif %}
+            </h5>
+          </div>
+          <div class="card-body">
+            {% for event in history_item.events %}
+              <div>
+                {% if event.event == "amendment" %}
+                  Amended by
+                  <a href="{{ event.amending_uri }}"><i>{{ event.amending_title }}</i></a>
 
-                    {% elif event.event == "commencement" %}
-                      {{ friendly_type }} commences.
+                {% elif event.event == "assent" %}
+                  Assented to by council.
 
-                    {% elif event.event == "publication" %}
-                      Published in
-                      <a href="{{ event.publication_url }}">{{ event.publication_name }} no. {{ event.publication_number }}</a>
+                {% elif event.event == "commencement" %}
+                  {{ friendly_type }} commences.
 
-                    {% elif event.event == "repeal" %}
-                      Repealed by
-                      <a href="{{ event.repealing_uri }}/eng/"><i>{{ event.repealing_title }}</i></a>
-                    {% endif %}
-                  </div>
-                {% endfor %}
+                {% elif event.event == "publication" %}
+                  Published in
+                  <a href="{{ event.publication_url }}">{{ event.publication_name }} no. {{ event.publication_number }}</a>
 
-                {% if history_item.date != current_object_date %}
-                  {% if document.expression_frbr_uri %}
-                    <a class="btn btn-outline-primary mt-2" href="{{ document.expression_frbr_uri }}/">Read this version</a>
-                  {% endif %}
+                {% elif event.event == "repeal" %}
+                  Repealed by
+                  <a href="{{ event.repealing_uri }}"><i>{{ event.repealing_title }}</i></a>
                 {% endif %}
               </div>
+            {% endfor %}
+
+            {% if history_item.date != current_object_date %}
+              {% if history_item.expression_frbr_uri %}
+                <a class="btn btn-outline-primary mt-2" href="{{ history_item.expression_frbr_uri }}">Read this version</a>
+              {% endif %}
+            {% endif %}
           </div>
-        </div>
-        {% endfor %}
       </div>
-    {% else %}
-      <div>No events</div>
-    {% endif %}
+    </div>
+    {% endfor %}
   </div>
-</div>
+{% else %}
+  <div>No history is available for this document.</div>
+{% endif %}

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -17,7 +17,7 @@
         <a href="{{ document|admin_url:'change' }}">Edit</a>
       {% endif %}
 
-      <ul style="margin-bottom: 1px;" class="nav nav-tabs" id="myTab" role="tablist">
+      <ul class="nav nav-tabs border-bottom" role="tablist">
         <li class="nav-item" role="presentation">
           <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#document-detail-tab" type="button" role="tab" aria-controls="document-detail-tab" aria-selected="true">
             Document detail
@@ -33,117 +33,111 @@
       </ul>
     </div>
 
-    <div class="tab-content">
+    <div class="tab-content mt-3">
       <div class="tab-pane fade show active" id="document-detail-tab" role="tabpanel" aria-labelledby="document-detail-tab">
         <div class="container">
-          <div class="mb-5">
-            <div class="card">
-              <div class="card-body">
-                {% block document-metadata %}
-                  <div class="row">
-                    <div class="col-md-6">
-                      {% block document-metadata-content %}
-                        <dl class="row document-metadata-list">
+          {% block document-metadata %}
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                {% block document-metadata-content %}
+                  <dl class="row document-metadata-list">
 
-                          {% block document-metadata-content-jurisdiction %}
-                            {% if document.jurisdiction %}
-                              <dt class="col-4">{% trans 'Jurisdiction' %}</dt>
-                              <dd class="col-8 text-muted">{{ document.jurisdiction }} {% if document.locality %} · {{ document.locality }}</dd>{% endif %}
-                            {% endif %}
-                          {% endblock %}
-
-                          {% block document-metadata-content-author %}
-                            {% if document.author %}
-                              <dt class="col-4">{% trans 'Author' %}</dt>
-                              <dd class="col-8 text-muted">{{ document.author }}</dd>
-                            {% endif %}
-                          {% endblock %}
-
-
-                          {% block document-metadata-content-date %}
-                            <dt class="col-4">{% trans 'Date' %}</dt>
-                            {% if date_versions %}
-                              <dd class="col-8">
-                                <div class="dropdown">
-                                  <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-                                    {{ document.date }}
-                                  </a>
-                                  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-                                    {% for version in date_versions %}
-                                      <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.date }}</a></li>
-                                    {% endfor %}
-                                  </ul>
-                                </div>
-                              </dd>
-                            {% else %}
-                              <dd class="col-8 text-muted">{{ document.date }}</dd>
-                            {% endif %}
-                          {% endblock %}
-
-                          {% block document-metadata-content-language %}
-                            <dt class="col-4">{% translate 'Language' %}</dt>
-                            {% if language_versions %}
-                              <dd class="col-8">
-                                <div class="dropdown">
-                                  <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-                                    {{ document.language }}
-                                  </a>
-                                  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-                                    {% for version in language_versions %}
-                                      <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.language }}</a></li>
-                                    {% endfor %}
-                                  </ul>
-                                </div>
-                              </dd>
-                            {% else %}
-                              <dd class="col-8 text-muted">{{ document.language }} </dd>
-                            {% endif %}
-                          {% endblock %}
-                        </dl>
-                      {% endblock %}
-
-                      {% if document.source_file %}
-                        <div>
-                          <a class="card-link" href="{% url 'document_source' document.expression_frbr_uri|strip_first_character %}">Download document</a> ({{ document.source_file.file.size|filesizeformat }})
-                        </div>
+                    {% block document-metadata-content-jurisdiction %}
+                      {% if document.jurisdiction %}
+                        <dt class="col-4">{% trans 'Jurisdiction' %}</dt>
+                        <dd class="col-8 text-muted">{{ document.jurisdiction }} {% if document.locality %} · {{ document.locality }}</dd>{% endif %}
                       {% endif %}
-                    </div>
+                    {% endblock %}
 
-                    <div class="col-md-6">
-                      {% block document-relationships-content %}
-                        {% if document.relationships_as_subject or document.relationships_as_object %}
-                          <h5>{% translate 'Related documents' %}</h5>
+                    {% block document-metadata-content-author %}
+                      {% if document.author %}
+                        <dt class="col-4">{% trans 'Author' %}</dt>
+                        <dd class="col-8 text-muted">{{ document.author }}</dd>
+                      {% endif %}
+                    {% endblock %}
 
-                          <ul class="list-unstyled">
-                            {% for rel in document.relationships_as_subject %}
-                              {% if rel.object_work %}
-                                <li>
-                                  {% translate rel.predicate.verb as verb %}
-                                  {{ verb|capfirst }}
-                                  <a href="{% url 'document_detail' frbr_uri=rel.object_work.frbr_uri|strip_first_character %}">{{ rel.object_work.title }}</a>
-                                </li>
-                              {% endif %}
-                            {% endfor %}
+                    {% block document-metadata-content-date %}
+                      <dt class="col-4">{% trans 'Date' %}</dt>
+                      {% if date_versions %}
+                        <dd class="col-8">
+                          <div class="dropdown">
+                            <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                              {{ document.date }}
+                            </a>
+                            <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                              {% for version in date_versions %}
+                                <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.date }}</a></li>
+                              {% endfor %}
+                            </ul>
+                          </div>
+                        </dd>
+                      {% else %}
+                        <dd class="col-8 text-muted">{{ document.date }}</dd>
+                      {% endif %}
+                    {% endblock %}
 
-                            {% for rel in document.relationships_as_object %}
-                              {% if rel.subject_work %}
-                                <li>
-                                  {% translate rel.predicate.reverse_verb as verb %}
-                                  {{ verb|capfirst }}
-                                  <a href="{% url 'document_detail' frbr_uri=rel.subject_work.frbr_uri|strip_first_character %}">{{ rel.subject_work.title }}</a>
-                                </li>
-                              {% endif %}
-                            {% endfor %}
-                          </ul>
-                        {% endif %}
-                      {% endblock %}
-                    </div>
+                    {% block document-metadata-content-language %}
+                      <dt class="col-4">{% translate 'Language' %}</dt>
+                      {% if language_versions %}
+                        <dd class="col-8">
+                          <div class="dropdown">
+                            <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                              {{ document.language }}
+                            </a>
+                            <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                              {% for version in language_versions %}
+                                <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.language }}</a></li>
+                              {% endfor %}
+                            </ul>
+                          </div>
+                        </dd>
+                      {% else %}
+                        <dd class="col-8 text-muted">{{ document.language }} </dd>
+                      {% endif %}
+                    {% endblock %}
+                  </dl>
+                {% endblock %}
+
+                {% if document.source_file %}
+                  <div>
+                    <a class="card-link" href="{% url 'document_source' document.expression_frbr_uri|strip_first_character %}">Download document</a> ({{ document.source_file.file.size|filesizeformat }})
                   </div>
+                {% endif %}
+              </div>
+
+              <div class="col-md-6">
+                {% block document-relationships-content %}
+                  {% if document.relationships_as_subject or document.relationships_as_object %}
+                    <h5>{% translate 'Related documents' %}</h5>
+
+                    <ul class="list-unstyled">
+                      {% for rel in document.relationships_as_subject %}
+                        {% if rel.object_work %}
+                          <li>
+                            {% translate rel.predicate.verb as verb %}
+                            {{ verb|capfirst }}
+                            <a href="{% url 'document_detail' frbr_uri=rel.object_work.frbr_uri|strip_first_character %}">{{ rel.object_work.title }}</a>
+                          </li>
+                        {% endif %}
+                      {% endfor %}
+
+                      {% for rel in document.relationships_as_object %}
+                        {% if rel.subject_work %}
+                          <li>
+                            {% translate rel.predicate.reverse_verb as verb %}
+                            {{ verb|capfirst }}
+                            <a href="{% url 'document_detail' frbr_uri=rel.subject_work.frbr_uri|strip_first_character %}">{{ rel.subject_work.title }}</a>
+                          </li>
+                        {% endif %}
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
                 {% endblock %}
               </div>
             </div>
-          </div>
+          {% endblock %}
 
+          <hr class="mb-3">
         </div>
 
         <div class="container-fluid">

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -137,7 +137,7 @@
             </div>
           {% endblock %}
 
-          <hr class="mb-3">
+          <hr class="mb-5">
         </div>
 
         <div class="container-fluid">


### PR DESCRIPTION
* remove cards surrounding the document metadata and document history; this makes the views a bit simpler without having to put everything in a box (it's a slippery slope otherwise)
* put an HR between the metadata and the content
* fix incorrect links in the timeline view
* increase spacing between timeline cards so that they're visually grouped
* make timeline arrows stand out more, align arrow with center of circle
* push top of timeline "line" to fall inside first circle

![image](https://user-images.githubusercontent.com/4178542/188932826-19f9d8c2-04e6-45d4-99ae-dc71abc9f5d8.png)

![image](https://user-images.githubusercontent.com/4178542/188933236-68be7d21-c1da-4add-8a91-b89e4b165545.png)
