### PR TITLE
Show all versions, highlight current one

### DIFF
--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -58,7 +58,7 @@
 
                     {% block document-metadata-content-date %}
                       <dt class="col-4">{% trans 'Date' %}</dt>
-                      {% if date_versions %}
+                      {% if date_versions|length > 1 %}
                         <dd class="col-8">
                           <div class="dropdown">
                             <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
@@ -66,7 +66,7 @@
                             </a>
                             <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
                               {% for version in date_versions %}
-                                <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.date }}</a></li>
+                                <li><a class="dropdown-item {% if version.pk == document.pk %}active{% endif %}" href="{{ version.get_absolute_url }}">{{ version.date }}</a></li>
                               {% endfor %}
                             </ul>
                           </div>
@@ -78,7 +78,7 @@
 
                     {% block document-metadata-content-language %}
                       <dt class="col-4">{% translate 'Language' %}</dt>
-                      {% if language_versions %}
+                      {% if language_versions|length > 1 %}
                         <dd class="col-8">
                           <div class="dropdown">
                             <a class="btn btn-outline-secondary btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
@@ -86,7 +86,7 @@
                             </a>
                             <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
                               {% for version in language_versions %}
-                                <li><a class="dropdown-item" href="{{ version.get_absolute_url }}">{{ version.language }}</a></li>
+                                <li><a class="dropdown-item {% if version.pk == document.pk %}active{% endif %}" href="{{ version.get_absolute_url }}">{{ version.language }}</a></li>
                               {% endfor %}
                             </ul>
                           </div>

--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -80,10 +80,6 @@ class BaseDocumentDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        # get all versions that match current document work_frbr_uri
-        all_versions = CoreDocument.objects.filter(
-            work_frbr_uri=self.object.work_frbr_uri
-        ).exclude(pk=self.object.pk)
 
         # citation links for a document
         doc = get_object_or_404(CoreDocument, pk=self.object.pk)
@@ -92,6 +88,10 @@ class BaseDocumentDetailView(DetailView):
             citation_links, many=True
         ).data
 
+        # get all versions that match current document work_frbr_uri
+        all_versions = CoreDocument.objects.filter(
+            work_frbr_uri=self.object.work_frbr_uri
+        )
         # language versions that match current document date
         context["language_versions"] = all_versions.filter(date=self.object.date)
 


### PR DESCRIPTION
Version and language dropdowns show all versions, including the current one, and mark the current one as active. This makes it easier (for older dates in particular) to see which one the current one is.

![image](https://user-images.githubusercontent.com/4178542/189079897-b786532b-6a6e-4d52-8df3-1fa6251882fb.png)
