### PR TITLE
Correctly set parent work when importing

### DIFF
--- a/peachjam/adapters/adapters.py
+++ b/peachjam/adapters/adapters.py
@@ -186,7 +186,21 @@ class IndigoAdapter(Adapter):
             # the source file is the PDF version
             self.download_source_file(f"{url}.pdf", created_doc, title)
 
+        self.set_parent(document, created_doc)
         self.fetch_relationships(document, created_doc)
+
+    def set_parent(self, imported_document, created_document):
+        # handle parent as a special relationship
+        if imported_document["parent_work"]:
+            parent_work, _ = Work.objects.get_or_create(
+                frbr_uri=imported_document["parent_work"]["frbr_uri"],
+                defaults={"title": imported_document["parent_work"]["title"]},
+            )
+            created_document.parent_work = parent_work
+        else:
+            created_document.parent_work = None
+        logger.info(f"Set parent to {parent_work}")
+        created_document.save()
 
     def fetch_relationships(self, imported_document, created_document):
         subject_work = created_document.work
@@ -194,7 +208,7 @@ class IndigoAdapter(Adapter):
         if imported_document["repeal"]:
             repealing_work, _ = Work.objects.get_or_create(
                 frbr_uri=imported_document["repeal"]["repealing_uri"],
-                title=imported_document["repeal"]["repealing_title"],
+                defaults={"title": imported_document["repeal"]["repealing_title"]},
             )
             self.create_relationship(
                 "repealed-by",
@@ -207,7 +221,7 @@ class IndigoAdapter(Adapter):
                 if amendment["amending_uri"] and amendment["amending_title"]:
                     amending_work, _ = Work.objects.get_or_create(
                         frbr_uri=amendment["amending_uri"],
-                        title=amendment["amending_title"],
+                        defaults={"title": amendment["amending_title"]},
                     )
                     self.create_relationship(
                         "amended-by",
@@ -223,7 +237,7 @@ class IndigoAdapter(Adapter):
                 ):
                     commencing_work, _ = Work.objects.get_or_create(
                         frbr_uri=commencement["commencing_frbr_uri"],
-                        title=commencement["commencing_title"],
+                        defaults={"title": commencement["commencing_title"]},
                     )
                     self.create_relationship(
                         "commenced-by",

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -346,6 +346,8 @@ class LegislationAdmin(ImportMixin, DocumentAdmin):
     fieldsets = copy.deepcopy(DocumentAdmin.fieldsets)
     fieldsets[3][1]["fields"].extend(["metadata_json"])
     fieldsets[2][1]["classes"] = ("collapse",)
+    fieldsets[4][1]["fields"].extend(["parent_work"])
+    readonly_fields = ["parent_work"] + list(DocumentAdmin.readonly_fields)
 
 
 class CaseNumberAdmin(admin.TabularInline):


### PR DESCRIPTION
Also avoid potential conflict when checking for existing related works.