### PR TITLE
Guard against a document existing but as the wrong document type

### DIFF
--- a/peachjam/adapters/adapters.py
+++ b/peachjam/adapters/adapters.py
@@ -166,6 +166,21 @@ class IndigoAdapter(Adapter):
             )[0]
 
         logger.info(model)
+
+        # the document may already be in the database, but not as the right document type.
+        # It's unlikely, but does happen and is confusing to debug, so let's check for it explicitly.
+        core_doc = CoreDocument.objects.filter(
+            expression_frbr_uri=expression_frbr_uri
+        ).first()
+        existing_doc = model.objects.filter(
+            expression_frbr_uri=expression_frbr_uri
+        ).first()
+        if core_doc and not existing_doc:
+            raise Exception(
+                f"The document {expression_frbr_uri} already exists as {existing_doc.doc_type}"
+                f" but not as {model}. Delete the existing document (CoreDocument #{core_doc.pk})."
+            )
+
         created_doc, new = model.objects.update_or_create(
             expression_frbr_uri=expression_frbr_uri,
             defaults={**field_data, **frbr_uri_data},


### PR DESCRIPTION
There are about 86 lawlibrary imports that are failing because of this.