### PR TITLE
Remove Lawlib pagination on recent judgments

### DIFF
--- a/lawlibrary/templates/lawlibrary/judgment_list.html
+++ b/lawlibrary/templates/lawlibrary/judgment_list.html
@@ -37,8 +37,6 @@
         {% endif %}
       </h4>
       {% include 'peachjam/_recent_document_list.html' with documents=recent_judgments %}
-
-      {% include 'peachjam/_pagination.html' %}
     </div>
   </section>
 {% endblock %}

--- a/lawlibrary/templates/lawlibrary/judgment_list.html
+++ b/lawlibrary/templates/lawlibrary/judgment_list.html
@@ -1,7 +1,7 @@
 {% extends "peachjam/layouts/main.html" %}
 {% load i18n %}
 
-{% block title %}{% trans 'Judgements' %}{% endblock %}
+{% block title %}{% trans 'Judgments' %}{% endblock %}
 
 {% block page-content %}
   <section class="pb-5">


### PR DESCRIPTION
- removes the pagination for recent judgments
- fixes a small typo. 