### PR TITLE
Store concept of most recent doc, and keep up to date

### DIFF
--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -426,6 +426,7 @@ export default {
           params.append('page', this.page);
           params.append('ordering', this.ordering);
           params.append('highlight', 'content');
+          params.append('is_most_recent', 'true');
 
           for (const key of Object.keys(this.filters)) {
             for (const x of this.filters[key]) {

--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -296,6 +296,19 @@ class CoreDocument(models.Model):
 
             return True
 
+    def is_most_recent(self):
+        """Is this the most recent document for this work?
+
+        Note that there can be multiple most recent documents, all at the same data but in different languages.
+        """
+        return (
+            self.work.documents.filter(language=self.language)
+            .order_by("-date")
+            .values_list("pk", flat=True)
+            .first()
+            == self.pk
+        )
+
 
 def file_location(instance, filename):
     if not instance.document.pk:

--- a/peachjam_search/apps.py
+++ b/peachjam_search/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class PeachjamSearchConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "peachjam_search"
+
+    def ready(self):
+        import peachjam_search.signals  # noqa

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -28,6 +28,7 @@ class SearchableDocument(Document):
     locality = fields.KeywordField(attr="locality.name")
     expression_frbr_uri = fields.KeywordField()
     work_frbr_uri = fields.KeywordField()
+    is_most_recent = fields.BooleanField()
     created_at = fields.DateField()
     updated_at = fields.DateField()
 

--- a/peachjam_search/serializers.py
+++ b/peachjam_search/serializers.py
@@ -28,6 +28,7 @@ class SearchableDocumentSerializer(DocumentSerializer):
             "court",
             "judges",
             "highlight",
+            "is_most_recent",
         ]
 
     def get_highlight(self, obj):

--- a/peachjam_search/signals.py
+++ b/peachjam_search/signals.py
@@ -1,0 +1,18 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from peachjam.models import CoreDocument
+
+
+@receiver(post_save)
+def document_saved(sender, instance, **kwargs):
+    if isinstance(instance, CoreDocument) and not kwargs["raw"]:
+        # if there are multiple documents under this same work, and this is the most recent one,
+        # then the previously most recent one may be invalid; pretend we've re-saved the other docs to
+        # re-index them into elasticsearch.
+        if instance.is_most_recent():
+            # get all non-most-recent docs (ie. docs before this date)
+            for doc in CoreDocument.objects.filter(
+                work=instance.work, date__lt=instance.date
+            ):
+                post_save.send(doc.__class__, instance=doc, created=False, raw=False)

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -108,6 +108,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
         "nature": "nature",
         "language": "language",
         "year": "year",
+        "is_most_recent": "is_most_recent",
     }
 
     search_fields = {


### PR DESCRIPTION
Ref #403

This allows us to only search for the most recent document when the are multiple documents for a work, at different dates. This means we'll show only the most recent piece of legislation in a search result, and not older documents.

We do this by calculating and storing (only in ES) a new field -- `is_most_recent`. A document is the most recent if it has the latest date of all documents linked to the same work. Note that there can be multiple most-recent documents, since there may be documents at the latest date in different languages.

In order to keep this field up-to-date, we need to detect when an old most-recent-document is now out of date. A signal handler checks when a document has been saved -- if it's the current most recent, it assumes that all the previous documents of the same work could potentially have been the old  most recent one, so it fakes a post-save signal to trigger a re-index.

