### PR TITLE
Date Widget

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -113,6 +113,7 @@ class DocumentForm(forms.ModelForm):
     content_html = forms.CharField(widget=CKEditorWidget(), required=False)
     flynote = forms.CharField(widget=CKEditorWidget(), required=False)
     headnote_holding = forms.CharField(widget=CKEditorWidget(), required=False)
+    date = forms.DateField(widget=forms.SelectDateWidget())
 
     def __init__(self, data=None, *args, **kwargs):
         if data:


### PR DESCRIPTION
- Adds date widget

The django select widget has dropdowns that show year, date and day in separate inputs. That may be more useful and faster for the editors than the calendar.
<img width="484" alt="date" src="https://user-images.githubusercontent.com/25079238/191952670-c01b8347-1867-433d-9463-4c1985544db3.PNG">

closes #439