### PR TITLE
Strip "position: *" when importing docx

### DIFF
--- a/peachjam/pipelines.py
+++ b/peachjam/pipelines.py
@@ -30,7 +30,11 @@ class RemoveTags(Stage):
 
 class CleanStyles(Stage):
     # styles we explicitly want to remove
-    style_blacklist = {"p": set("line-height".split()), None: set()}
+    style_blacklist = {
+        "p": set("line-height".split()),
+        # disallow "position: *" everywhere as it can move content outside of the document borders
+        None: set("position".split()),
+    }
 
     def __call__(self, context):
         for elem in context.html.xpath(".//*[@style]"):


### PR DESCRIPTION
Fixes #456 

Disallow any "position" attribute in imported docx HTML since it could move content anywhere on the page.

Before:

![image](https://user-images.githubusercontent.com/4178542/191904036-bebf7336-3959-4a2f-81da-764af0995a1a.png)


After:

![image](https://user-images.githubusercontent.com/4178542/191904088-bcb5df36-7dea-4fa4-82f3-9335ca51c6a3.png)
