### PR TITLE
Show enabled field in admin for Ingestor

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -420,7 +420,6 @@ class IngestorAdmin(admin.ModelAdmin):
     actions = ["refresh_all_content"]
     fields = ("adapter", "name", "last_refreshed_at", "enabled")
     list_display = ("name", "last_refreshed_at", "enabled")
-    list_editable = ("enabled",)
 
     def refresh_all_content(self, request, queryset):
         from peachjam.tasks import run_ingestors

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -418,6 +418,9 @@ class IngestorAdmin(admin.ModelAdmin):
     readonly_fields = ("last_refreshed_at",)
     form = IngestorForm
     actions = ["refresh_all_content"]
+    fields = ("adapter", "name", "last_refreshed_at", "enabled")
+    list_display = ("name", "last_refreshed_at", "enabled")
+    list_editable = ("enabled",)
 
     def refresh_all_content(self, request, queryset):
         from peachjam.tasks import run_ingestors


### PR DESCRIPTION
Adds the `enabled` field to the admin page. #444 did not include the necessary changes.

![image](https://user-images.githubusercontent.com/15012985/192752260-fbe3fd0e-7cc7-46b0-ba80-ed6156967e8a.png)
![image](https://user-images.githubusercontent.com/15012985/192736387-2a8a61ca-f5e6-4446-9874-40e506c0fc28.png)
