### PR TITLE
Citations

### DIFF
--- a/africanlii/apps.py
+++ b/africanlii/apps.py
@@ -8,9 +8,9 @@ class AfricanliiConfig(AppConfig):
     def ready(self):
         from docpipe.citations import AchprResolutionMatcher, ActMatcher
 
+        from liiweb.citations import MncMatcher
         from peachjam.analysis.citations import citation_analyser
 
-        # TODO: for plain text, we care about the regex and how to extract the right run and FRBR URI from it
-        # TODO: for html, we care about the regex and how to markup the right run and FRBR URI from it
         citation_analyser.matchers.append(AchprResolutionMatcher)
         citation_analyser.matchers.append(ActMatcher)
+        citation_analyser.matchers.append(MncMatcher)

--- a/liiweb/apps.py
+++ b/liiweb/apps.py
@@ -4,3 +4,13 @@ from django.apps import AppConfig
 class LiiwebConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "liiweb"
+
+    def ready(self):
+        from docpipe.citations import AchprResolutionMatcher, ActMatcher
+
+        from liiweb.citations import MncMatcher
+        from peachjam.analysis.citations import citation_analyser
+
+        citation_analyser.matchers.append(AchprResolutionMatcher)
+        citation_analyser.matchers.append(ActMatcher)
+        citation_analyser.matchers.append(MncMatcher)

--- a/liiweb/citations.py
+++ b/liiweb/citations.py
@@ -1,0 +1,23 @@
+import re
+
+from docpipe.matchers import CitationMatcher
+
+
+class MncMatcher(CitationMatcher):
+    """Finds references to commonly-formatted MNCS of the form [YYYY] COURT NUM
+
+    example: [2022] ZASCA 126
+    """
+
+    pattern_re = re.compile(
+        r"\[(?P<year>\d{4})\]\s+(?P<court>(ZA|KE)[A-Z]{1,5})\s+(?P<num>\d+)\b"
+    )
+    href_pattern = "/akn/{place}/judgment/{court}/{year}/{num}"
+    html_candidate_xpath = ".//text()[contains(., '[') and not(ancestor::a)]"
+    xml_candidate_xpath = ".//text()[contains(., '[') and not(ancestor::ns:ref)]"
+
+    def href_pattern_args(self, match):
+        args = super().href_pattern_args(match)
+        args["place"] = args["court"][:2].lower()
+        args["court"] = args["court"].lower()
+        return args

--- a/liiweb/tests/test_mnc_matcher.py
+++ b/liiweb/tests/test_mnc_matcher.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+import lxml.html
+from cobalt.uri import FrbrUri
+
+from liiweb.citations import MncMatcher
+
+
+class MncMatcherTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.marker = MncMatcher()
+        self.frbr_uri = FrbrUri.parse("/akn/za-wc/act/2021/509")
+
+    def test_html_matches(self):
+        html = lxml.html.fromstring(
+            """
+<div>
+  <p>2 Commissioner for the South African Revenue Service v Toneleria Nacional RSA (Pty) Ltd [2021] ZASCA 65; [2021] 3 All SA 299 (SCA); 2021 (5) SA 68 (SCA) para 25.</p>
+  <p>Kenya: [2022] KESC 12</p>
+  <p>Some string that has [2021] code 65</p>
+  <p>A place that isn't trusted [1988] NACC 12.</p>
+</div>
+"""  # noqa
+        )
+        self.marker.markup_html_matches(self.frbr_uri, html)
+
+        self.assertMultiLineEqual(
+            """<div>
+  <p>2 Commissioner for the South African Revenue Service v Toneleria Nacional RSA (Pty) Ltd <a href="/akn/za/judgment/zasca/2021/65">[2021] ZASCA 65</a>; [2021] 3 All SA 299 (SCA); 2021 (5) SA 68 (SCA) para 25.</p>
+  <p>Kenya: <a href="/akn/ke/judgment/kesc/2022/12">[2022] KESC 12</a></p>
+  <p>Some string that has [2021] code 65</p>
+  <p>A place that isn't trusted [1988] NACC 12.</p>
+</div>""",  # noqa
+            lxml.html.tostring(html, encoding="unicode", pretty_print=True).strip(),
+        )

--- a/liiweb/tests/test_mnc_matcher.py
+++ b/liiweb/tests/test_mnc_matcher.py
@@ -20,6 +20,8 @@ class MncMatcherTest(TestCase):
   <p>2 Commissioner for the South African Revenue Service v Toneleria Nacional RSA (Pty) Ltd [2021] ZASCA 65; [2021] 3 All SA 299 (SCA); 2021 (5) SA 68 (SCA) para 25.</p>
   <p>Kenya: [2022] KESC 12</p>
   <p>Some string that has [2021] code 65</p>
+  <p>Some string that has [2021] code 6-5a</p>
+  <p>Some string that has [2021] ZA SC 6</p>
   <p>A place that isn't trusted [1988] NACC 12.</p>
 </div>
 """  # noqa
@@ -31,6 +33,8 @@ class MncMatcherTest(TestCase):
   <p>2 Commissioner for the South African Revenue Service v Toneleria Nacional RSA (Pty) Ltd <a href="/akn/za/judgment/zasca/2021/65">[2021] ZASCA 65</a>; [2021] 3 All SA 299 (SCA); 2021 (5) SA 68 (SCA) para 25.</p>
   <p>Kenya: <a href="/akn/ke/judgment/kesc/2022/12">[2022] KESC 12</a></p>
   <p>Some string that has [2021] code 65</p>
+  <p>Some string that has [2021] code 6-5a</p>
+  <p>Some string that has [2021] ZA SC 6</p>
   <p>A place that isn't trusted [1988] NACC 12.</p>
 </div>""",  # noqa
             lxml.html.tostring(html, encoding="unicode", pretty_print=True).strip(),

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -334,7 +334,7 @@ class JudgmentMediaSummaryFileInline(BaseAttachmentFileInline):
     model = JudgmentMediaSummaryFile
 
 
-class JudgmentAdminForm(forms.ModelForm):
+class JudgmentAdminForm(DocumentForm):
     hearing_date = forms.DateField(widget=forms.SelectDateWidget(), required=False)
 
     class Meta:
@@ -350,8 +350,8 @@ class JudgmentAdmin(ImportMixin, DocumentAdmin):
     fieldsets = copy.deepcopy(DocumentAdmin.fieldsets)
     fieldsets[0][1]["fields"].insert(3, "author")
     fieldsets[0][1]["fields"].insert(4, "case_name")
-    fieldsets[0][1]["fields"].insert(4, "hearing_date")
     fieldsets[0][1]["fields"].insert(7, "mnc")
+    fieldsets[0][1]["fields"].append("hearing_date")
     fieldsets[1][1]["fields"].insert(0, "judges")
     fieldsets[2][1]["classes"] = ["collapse"]
     fieldsets[3][1]["fields"].extend(


### PR DESCRIPTION
* extract MNC-style citations
* fix forms for judgments

We can guess at FRBR URIs for well-known MNC formats. Currently this only works for ZA and KE, which we know use this scheme.