### PR TITLE
Match  anchor color to their type respective type of alert

### DIFF
--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -117,3 +117,14 @@ footer {
 .twitter-background {
   color: $twitter-color;
 }
+
+
+@each $state, $value in $theme-colors {
+  $alert-color: shift-color($value, $alert-color-scale);
+  a {
+    color: shade-color($alert-color, 20%);
+    &:hover {
+      color: shade-color($alert-color, 20%);
+    }
+  }
+}

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -120,11 +120,15 @@ footer {
 
 
 @each $state, $value in $theme-colors {
-  $alert-color: shift-color($value, $alert-color-scale);
-  a {
-    color: shade-color($alert-color, 20%);
-    &:hover {
+  .alert-#{$state} {
+    $alert-color: shift-color($value, $alert-color-scale);
+
+    a {
       color: shade-color($alert-color, 20%);
+
+      &:hover {
+        color: shade-color($alert-color, 20%);
+      }
     }
   }
 }


### PR DESCRIPTION
Bootstrap has a class called `.alert-link` which is used for links inside `.alert`so apply that styling of `.anchor-link` to change child anchor elements of `.alert`

DEMO:
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/15995210/193609243-4bbd425a-becf-4d4a-98db-9cab964b8fef.png">

resolves https://github.com/laws-africa/peachjam/issues/321
