### PR TITLE
Sentry APM for Background Tasks

### DIFF
--- a/peachjam/apps.py
+++ b/peachjam/apps.py
@@ -9,6 +9,7 @@ class PeachJamConfig(AppConfig):
         import jazzmin.settings
 
         import peachjam.adapters  # noqa
+        import peachjam.signals  # noqa
 
         jazzmin.settings.THEMES["peachjam"] = "stylesheets/peachjam-jazzmin.css"
 

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -247,20 +247,6 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 10,
 }
 
-# Elastic APM
-APM_SERVER_URL = os.environ.get("APM_SERVER_URL", "")
-ELASTIC_APM = {
-    "SERVICE_NAME": os.environ.get("APM_SERVICE_NAME", PEACHJAM["APP_NAME"]),
-    "SERVER_URL": APM_SERVER_URL,
-}
-if not DEBUG and APM_SERVER_URL:
-    INSTALLED_APPS = INSTALLED_APPS + ["elasticapm.contrib.django"]
-    MIDDLEWARE = [
-        "elasticapm.contrib.django.middleware.TracingMiddleware",
-        "elasticapm.contrib.django.middleware.Catch404Middleware",
-    ] + MIDDLEWARE
-
-
 # Sentry
 if not DEBUG:
     sentry_logging = LoggingIntegration(
@@ -272,7 +258,7 @@ if not DEBUG:
         environment=PEACHJAM["SENTRY_ENVIRONMENT"],
         integrations=[DjangoIntegration(), sentry_logging],
         send_default_pii=True,
-        traces_sample_rate=0.5,  # sample 50% of the requests for performance metrics
+        traces_sample_rate=0.5,  # sample 50% of requests for performance metrics
     )
 
 DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}

--- a/peachjam/signals.py
+++ b/peachjam/signals.py
@@ -1,0 +1,41 @@
+import sentry_sdk
+from background_task.signals import (
+    task_error,
+    task_finished,
+    task_started,
+    task_successful,
+)
+from django.dispatch import receiver
+
+
+# monitor background tasks with elastic-apm
+@receiver(task_started)
+def bg_task_started(sender, **kwargs):
+    transaction = sentry_sdk.start_transaction(op="task")
+    # fake an entry into the context
+    transaction.__enter__()
+
+
+@receiver(task_successful)
+def bg_task_success(sender, completed_task, **kwargs):
+    transaction = sentry_sdk.Hub.current.scope.transaction
+    if transaction:
+        transaction.name = completed_task.task_name
+
+
+@receiver(task_error)
+def bg_task_error(sender, task, **kwargs):
+    transaction = sentry_sdk.Hub.current.scope.transaction
+    if transaction:
+        transaction.name = task.task_name
+
+    # report error to sentry
+    sentry_sdk.capture_exception()
+
+
+@receiver(task_finished)
+def bg_task_finished(sender, **kwargs):
+    transaction = sentry_sdk.Hub.current.scope.transaction
+    if transaction:
+        # fake an exit from the transaction context
+        transaction.__exit__(None, None, None)

--- a/peachjam/tasks.py
+++ b/peachjam/tasks.py
@@ -1,22 +1,8 @@
 import logging
 
-import sentry_sdk
 from background_task import background
-from background_task.signals import task_error, task_started, task_successful
-from django.apps import apps
-from django.dispatch import receiver
 
 log = logging.getLogger(__name__)
-
-
-def get_elasticapm_client():
-    try:
-        return apps.get_app_config("elasticapm").client
-    except LookupError:
-        log.warning(
-            "Django app elasticapm not installed. Background tasks will not have metrics."
-        )
-        return None
 
 
 @background(remove_existing_tasks=True)
@@ -53,32 +39,3 @@ def run_ingestors():
             ingestor.check_for_updates()
 
     log.info("Running ingestors done")
-
-
-# monitor background tasks with elastic-apm
-@receiver(task_started)
-def bg_task_started(sender, **kwargs):
-    client = get_elasticapm_client()
-    if client:
-        client.begin_transaction(transaction_type="task")
-
-
-@receiver(task_successful)
-def bg_task_success(sender, completed_task, **kwargs):
-    client = get_elasticapm_client()
-    if client:
-        client.end_transaction(name=completed_task.task_name, result="success")
-
-
-@receiver(task_error)
-def bg_task_error(sender, task, **kwargs):
-    # report errors to elasticapm
-    client = get_elasticapm_client()
-    if client:
-        client.capture_exception()
-        client.end_transaction(name=task.task_name, result="error")
-
-    # report errors to sentry
-    with sentry_sdk.push_scope() as scope:
-        scope.transaction = task.task_name
-        sentry_sdk.capture_exception()


### PR DESCRIPTION
This PR configures Sentry APM for background tasks and drops the previous Elastic APM configuration.

closes #482 