### PR TITLE
Metadata block refactor

### DIFF
--- a/lawlibrary/templates/peachjam/layouts/document_detail.html
+++ b/lawlibrary/templates/peachjam/layouts/document_detail.html
@@ -3,14 +3,14 @@
 
 {% block document-metadata-content-author %}
   {% if document.doc_type == 'judgment' %}
-    <dt class="col-4">{% trans 'Court' %}</dt>
-    <dd class="col-8 text-muted">
+    <dt>{% trans 'Court' %}</dt>
+    <dd class="text-muted">
       <a href="{% url 'court_detail' document.court.code %}">{{ document.court.name }}</a>
     </dd>
 
     {% if document.judges_string %}
-      <dt class="col-4">{% trans 'Judges' %}</dt>
-      <dd class="col-8 text-muted">{{ document.judges_string }}</dd>
+      <dt>{% trans 'Judges' %}</dt>
+      <dd class="text-muted">{{ document.judges_string }}</dd>
     {% endif %}
 
   {% else %}

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -294,21 +294,25 @@
   }
 
 }
-
-$dt-width: 150px;
-
 .document-metadata-list {
+  --dt-width: 100px;
+
+  @media (min-width: 425px) {
+    --dt-width: 150px;
+  }
+
   margin-bottom: 0px;
   display: flex;
   flex-wrap: wrap;
 
   dt {
-    width: $dt-width;
-    flex: 0 0 $dt-width;
+    width: var(--dt-width);
+    flex: 0 0 var(--dt-width);
   }
   dd {
     padding-left: 0.5rem;
-    width: calc(100% - #{$dt-width});
-    flex: 0 0 calc(100% - #{$dt-width});
+    width: calc(100% - var(--dt-width));
+    flex: 0 0 calc(100% - var(--dt-width));
   }
+
 }

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -295,7 +295,7 @@
 
 }
 
-$dt-width: 125px;
+$dt-width: 150px;
 
 .document-metadata-list {
   margin-bottom: 0px;
@@ -307,6 +307,7 @@ $dt-width: 125px;
     flex: 0 0 $dt-width;
   }
   dd {
+    padding-left: 0.5rem;
     width: calc(100% - #{$dt-width});
     flex: 0 0 calc(100% - #{$dt-width});
   }

--- a/peachjam/templates/peachjam/judgment_detail.html
+++ b/peachjam/templates/peachjam/judgment_detail.html
@@ -5,8 +5,8 @@
   {{ block.super }}
 
   {% if document.mnc %}
-    <dt class="col-4">{% trans 'Media Neutral Citation' %}</dt>
-    <dd class="col-8 text-muted">
+    <dt>{% trans 'Media Neutral Citation' %}</dt>
+    <dd class="text-muted">
       {{ document.mnc }}
       <button type="button" class="btn btn-secondary btn-xs ms-2"
               title="{% trans "Copy to clipboard" %}" data-component="CopyToClipboard"
@@ -16,16 +16,16 @@
   {% endif %}
 
   {% if document.hearing_date %}
-    <dt class="col-4">{% trans 'Hearing date' %}</dt>
-    <dd class="col-8 text-muted">
+    <dt>{% trans 'Hearing date' %}</dt>
+    <dd class="text-muted">
       {{ document.hearing_date }}
     </dd>
   {% endif %}
 
   {% with document.case_numbers.all as case_numbers %}
     {% if case_numbers %}
-      <dt class="col-4">{% trans 'Case number' %}</dt>
-      <dd class="col-8 text-muted">
+      <dt>{% trans 'Case number' %}</dt>
+      <dd class="text-muted">
         {% for cn in case_numbers %}
           {{ cn.string }}{% if not forloop.last %}; {% endif %}
         {% endfor %}

--- a/peachjam/templates/peachjam/legislation_detail.html
+++ b/peachjam/templates/peachjam/legislation_detail.html
@@ -31,8 +31,8 @@
 
 {% block document-metadata-content-date %}
   {% if document.parent_work %}
-    <dt class="col-4">{% trans 'Primary work' %}</dt>
-    <dd class="col-8 text-muted">
+    <dt>{% trans 'Primary work' %}</dt>
+    <dd class="text-muted">
       <a href="{% url 'document_detail' document.parent_work.frbr_uri|strip_first_character %}">{{ document.parent_work.title }}</a>
     </dd>
   {% endif %}


### PR DESCRIPTION
https://www.loom.com/share/2989392353fe4d5b9c21699b8ea7a774

- Increased width of dt slightly so Media citation title text would not wrap
- removed uneccesary col on `dt` and `dd` elements
- Added mobile styling to decrease `dt` column slightly

Used a fixed width value that makes the key value space look close enough

resolves https://github.com/laws-africa/peachjam/issues/486