### PR TITLE
Use polymorphic documents for elasticsearch

### DIFF
--- a/peachjam/models/generic_document.py
+++ b/peachjam/models/generic_document.py
@@ -29,6 +29,9 @@ class GenericDocument(CoreDocument):
     def __str__(self):
         return self.title
 
+    def get_doc_type_display(self):
+        return "Document"
+
     def save(self, *args, **kwargs):
         self.doc_type = "generic_document"
         return super().save(*args, **kwargs)

--- a/peachjam/views/authors.py
+++ b/peachjam/views/authors.py
@@ -12,7 +12,6 @@ class AuthorDetailView(FilteredDocumentListView):
         return CoreDocument.objects.filter(
             Q(genericdocument__author=self.author)
             | Q(legalinstrument__author=self.author)
-            | Q(judgment__author=self.author)
         )
 
     def get_queryset(self):

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -33,16 +33,16 @@ class SearchableDocument(Document):
     updated_at = fields.DateField()
 
     # Judgment
-    matter_type = fields.KeywordField(attr="judgment.matter_type.name")
-    case_number_string = fields.KeywordField(attr="judgment.case_number_string")
-    court = fields.KeywordField(attr="judgment.court.name")
-    headnote_holding = fields.TextField(attr="judgment.headnote_holding")
-    flynote = fields.TextField(attr="judgment.flynote")
+    matter_type = fields.KeywordField(attr="matter_type.name")
+    case_number_string = fields.KeywordField()
+    court = fields.KeywordField(attr="court.name")
+    headnote_holding = fields.TextField()
+    flynote = fields.TextField()
     judges = fields.TextField()
 
     # GenericDocument, LegalInstrument
-    author = fields.KeywordField()
-    nature = fields.KeywordField()
+    author = fields.KeywordField(attr="author.name")
+    nature = fields.KeywordField(attr="nature.name")
 
     pages = fields.NestedField(
         properties={
@@ -52,52 +52,30 @@ class SearchableDocument(Document):
     )
 
     class Index:
-        # TODO: make this configurable per website
         name = settings.PEACHJAM["ES_INDEX"]
 
     class Django:
+        # Because CoreDocument's default manager is a polymorphic manager, the actual instances
+        # that will be prepared for searching will be subclasses of CoreDocument (eg. Judgment, etc.)
         model = CoreDocument
+
         # to ensure the CoreDocument will be re-saved when Judgment, Legislation etc is updated
         related_models = [GenericDocument, Judgment, LegalInstrument, Legislation]
-
-    def get_queryset(self):
-        return (
-            super()
-            .get_queryset()
-            .select_related(
-                "judgment", "legalinstrument", "legislation", "genericdocument"
-            )
-        )
 
     def get_instances_from_related(self, related_instance):
         """Retrieve the CoreDocument instance from the related instance to ensure it is re-indexed
         when the related instance is updated.
         """
-        if isinstance(
-            related_instance, (GenericDocument, Judgment, LegalInstrument, Legislation)
-        ):
-            return related_instance.coredocument_ptr
+        # if this extends CoreDocument, update it
+        if isinstance(related_instance, CoreDocument):
+            return related_instance
 
     def prepare_doc_type(self, instance):
         return instance.get_doc_type_display()
 
-    def prepare_author(self, instance):
-        if instance.doc_type == "generic_document":
-            if instance.genericdocument.author:
-                return instance.genericdocument.author.name
-        elif instance.doc_type == "legal_instrument":
-            if instance.legalinstrument.author:
-                return instance.legalinstrument.author.name
-
-    def prepare_nature(self, instance):
-        if instance.doc_type == "generic_document":
-            return instance.genericdocument.nature.name
-        elif instance.doc_type == "legal_instrument":
-            return instance.legalinstrument.nature.name
-
     def prepare_judges(self, instance):
         if instance.doc_type == "judgment":
-            return [j.name for j in instance.judgment.judges.all()]
+            return [j.name for j in instance.judges.all()]
 
     def prepare_content(self, instance):
         if instance.content_html:

--- a/peachjam_search/serializers.py
+++ b/peachjam_search/serializers.py
@@ -21,7 +21,7 @@ class SearchableDocumentSerializer(DocumentSerializer):
             "citation",
             "expression_frbr_uri",
             "work_frbr_uri",
-            "authoring_body",
+            "author",
             "nature",
             "matter_type",
             "case_number_string",


### PR DESCRIPTION
This does:

* because we now use the polymorphic object managers, we don't need to jump through hoops with elasticsearch and can just rely on inheritance
* when accessing fields specific to CoreDocument subtypes, we can rely on the fact that ES will ignore missing attributes and just return None
* use overrides to change the "doc_type" label for GenericDocument to "Document" rather than "GenericDocument"
* correctly return `author` in the serializer, not `authoring_body`