### PR TITLE
Improve search accuracy

### DIFF
--- a/peachjam/js/components/FindDocuments/SearchResult.vue
+++ b/peachjam/js/components/FindDocuments/SearchResult.vue
@@ -11,7 +11,7 @@
     <div>
       {{ item.matter_type }}
     </div>
-    <div>
+    <div v-if="item.citation && item.citation !== item.title">
       <i>{{ item.citation }}</i>
     </div>
     <div class="text-muted">

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -78,6 +78,10 @@ class SearchableDocument(Document):
     def prepare_doc_type(self, instance):
         return instance.get_doc_type_display()
 
+    def prepare_citation(self, instance):
+        # if there is no citation, fall back to the title so as not to penalise documents that don't have a citation
+        return instance.citation or instance.title
+
     def prepare_judges(self, instance):
         if instance.doc_type == "judgment":
             return [j.name for j in instance.judges.all()]

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -119,9 +119,9 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
     }
 
     search_fields = {
-        "title": {"boost": 2},
+        "title": {"boost": 6},
         "author": None,
-        "citation": None,
+        "citation": {"boost": 4},
         "judges": None,
         "content": None,
         "court": None,


### PR DESCRIPTION
1. Docs without citations are being penalised, so index the title as the citation in that case, and only show the citation if it's different to the title
2. Boost title and citation scoring

Fixes #596

Requires re-indexing once merged.


Before:
![image](https://user-images.githubusercontent.com/4178542/197995157-90b36257-8c13-4c48-bc10-acb5b93627b9.png)


After:
![image](https://user-images.githubusercontent.com/4178542/197995038-2c9cdf3d-8d26-4e8e-935b-c792a8db5048.png)


Before:
![image](https://user-images.githubusercontent.com/4178542/197995710-2cc96d85-0915-4eb0-8f90-036c44ae8fda.png)


After:
![image](https://user-images.githubusercontent.com/4178542/197995788-4d082292-020b-4fc2-9b5b-45d9a1a5e9c4.png)
