### PR TITLE
Slugify filenames 

### DIFF
--- a/peachjam/resources.py
+++ b/peachjam/resources.py
@@ -8,6 +8,7 @@ from cobalt import FrbrUri
 from countries_plus.models import Country
 from django.core.files.base import File
 from django.forms import ValidationError
+from django.utils.text import slugify
 from import_export import fields, resources
 from import_export.widgets import (
     BooleanWidget,
@@ -130,7 +131,8 @@ class BaseDocumentResource(resources.ModelResource):
                         document=instance,
                         defaults={
                             "file": File(
-                                source_file, name=f"{instance.title[-250:]}{file_ext}"
+                                source_file,
+                                name=f"{slugify(instance.title[-250:])}{file_ext}",
                             ),
                             "mimetype": mime,
                         },
@@ -263,7 +265,9 @@ class JudgmentResource(BaseDocumentResource):
             AttachedFiles.objects.update_or_create(
                 document=judgment,
                 defaults={
-                    "file": File(summary_file, name=f"{judgment.title[-250:]}{ext}"),
+                    "file": File(
+                        summary_file, name=f"{slugify(judgment.title[-250:])}{ext}"
+                    ),
                     "nature": media_summary_file_nature,
                     "mimetype": mime,
                 },


### PR DESCRIPTION
- This slugifies filenames before saving. 
This is because of this error
[https://sentry.io/organizations/lawsafrica/issues/3709867453/events/1d1b57e1cde345979699a1be02e43d95/](https://sentry.io/organizations/lawsafrica/issues/3709867453/events/1d1b57e1cde345979699a1be02e43d95/)

that occurs when filenames have a colon in them.

