### PR TITLE
bump number of pages ES will index.

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -228,6 +228,8 @@ if not DEBUG:
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# effectively, max pages we'll index from documents
+ELASTICSEARCH_DSL_INDEX_SETTINGS = {"index.mapping.nested_objects.limit": "50000"}
 ELASTICSEARCH_DSL = {
     "default": {
         "hosts": os.environ.get("ELASTICSEARCH_HOST", "localhost:9200"),


### PR DESCRIPTION
I did this directly on the index via kibana, and some local testing shows this will do it always.


```
$ python manage.py search_index --delete
Are you sure you want to delete the 'peachjam' indexes? [y/N]: y
Deleting index 'peachjam'
(peachjam)➜  ~/coding/laws.africa/peachjam search-index-settings*
$ python manage.py search_index --create
Creating index 'peachjam'
$ http localhost:9200/peachjam/_settings
HTTP/1.1 200 OK
X-elastic-product: Elasticsearch
content-encoding: gzip
content-length: 248
content-type: application/json; charset=UTF-8

{
    "peachjam": {
        "settings": {
            "index": {
                "creation_date": "1667564395397",
                "mapping": {
                    "nested_objects": {
                        "limit": "50000"
                    }
                },
                "number_of_replicas": "1",
                "number_of_shards": "1",
                "provided_name": "peachjam",
                "routing": {
                    "allocation": {
                        "include": {
                            "_tier_preference": "data_content"
                        }
                    }
                },
                "uuid": "HmNkA5p5S3yFPSnb-UnqoA",
                "version": {
                    "created": "7160299"
                }
            }
        }
    }
}
```

