### PR TITLE
On report errors from whitelist urls in sentry

### DIFF
--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -17,11 +17,11 @@
     <script defer src="https://browser.sentry-cdn.com/6.18.1/bundle.min.js" integrity="sha384-XOitiDSsTajhNQgwzQ7iHMlM2Q2ODCW6aw3m1QgMVrDOqsNhFao1VjB39qXNMOZW" crossorigin="anonymous"></script>
     <script>
     window.addEventListener('load', function() {
-        Sentry.init({
+      Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        whitelistUrls: [`${window.location.origin}/static/js/app-prod.js`]
-      });
+        whitelistUrls: [`${window.location.hostname}/static/js/.+.js$`]
+        });
     });
     </script>
     {% if GOOGLE_ANALYTICS_ID %}

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -20,10 +20,10 @@
       Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        beforeSend (event){
-        return event.request.url.includes(window.location.host) ? event : null;
-      }
-        });
+        beforeSend (event) {
+          return event.request.url === window.location.href ? event : null;
+        }
+      });
     });
     </script>
     {% if GOOGLE_ANALYTICS_ID %}

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -20,8 +20,11 @@
         Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        blacklistUrls: [],
-        });
+        whitelistUrls: [
+          /https?:\/\/agp\.africanlii\.org/,
+          /https?:\/\/lawlibrary\.org\.za/,
+        ]
+      });
     });
     </script>
     {% if GOOGLE_ANALYTICS_ID %}

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -20,7 +20,9 @@
       Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        whitelistUrls: [`${window.location.hostname}/static/js/.+.js$`]
+        beforeSend (event){
+        return event.request.url.includes(window.location.host) ? event : null;
+      }
         });
     });
     </script>

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -20,7 +20,7 @@
         Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        whitelistUrls: [window.location.origin]
+        whitelistUrls: [`${window.location.origin}/static/js/app-prod.js`]
       });
     });
     </script>

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -20,6 +20,7 @@
         Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
+        // The list will expand as we add more sites
         whitelistUrls: [
           /https?:\/\/agp\.africanlii\.org/,
           /https?:\/\/lawlibrary\.org\.za/,

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -20,11 +20,7 @@
         Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        // The list will expand as we add more sites
-        whitelistUrls: [
-          /https?:\/\/agp\.africanlii\.org/,
-          /https?:\/\/lawlibrary\.org\.za/,
-        ]
+        whitelistUrls: [window.location.origin]
       });
     });
     </script>

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -14,15 +14,19 @@
 
   {% if not DEBUG %}
     <!-- sentry -->
-    <script defer src="https://browser.sentry-cdn.com/6.18.1/bundle.min.js" integrity="sha384-XOitiDSsTajhNQgwzQ7iHMlM2Q2ODCW6aw3m1QgMVrDOqsNhFao1VjB39qXNMOZW" crossorigin="anonymous"></script>
+    <script
+        src="https://browser.sentry-cdn.com/7.19.0/bundle.min.js"
+        integrity="sha384-ztBHD5Kyf+YJqkbZijnUhyS5dYdQDCEfB2QjYao1rVJ1qBpQn+WMbafstDcVTHnB"
+        crossorigin="anonymous"
+    ></script>
     <script>
     window.addEventListener('load', function() {
       Sentry.init({
         dsn: '{{ SENTRY_DSN_KEY }}',
         environment: '{{ SENTRY_ENVIRONMENT }}',
-        beforeSend (event) {
-          return event.request.url === window.location.href ? event : null;
-        }
+        allowUrls: [
+          new RegExp(window.location.host.replace(".", "\\.") + "/static/")
+        ]
       });
     });
     </script>


### PR DESCRIPTION
The intention here is to only report js sentry errors js files in the domain's `static/js`

Hypothetical demo:
https://www.loom.com/share/2b522b47f61c409294610ddce1b72fac

resolves #623 