### PR TITLE
Judgments Page N+1 Fix

### DIFF
--- a/lawlibrary/templates/lawlibrary/judgment_list.html
+++ b/lawlibrary/templates/lawlibrary/judgment_list.html
@@ -10,13 +10,13 @@
 
       {% if grouped_courts %}
         <div class="row mb-3">
-          {% for group in grouped_courts %}
+          {% for court_class, courts in grouped_courts.items %}
             <div class="col-md-4 col-12 mb-3">
               <h4 class="heading-underlined">
-              {{ group.title }}
+              {{ court_class }}
               </h4>
-              {% if group.items|length > 0 %}
-                {% for item in group.items %}
+              {% if courts|length > 0 %}
+                {% for item in courts %}
                     <div>
                       <a href="{% url 'court_detail' item.code  %}">{{ item.title }}</a>
                     </div>

--- a/lawlibrary/views/judgment.py
+++ b/lawlibrary/views/judgment.py
@@ -12,19 +12,19 @@ class JudgmentListView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         court_classes = (
-            CourtClass.objects.prefetch_related("courts")
+            CourtClass.objects.select_related("courts")
             .order_by("name", "courts__name")
             .values("name", "courts__name", "courts__code")
             .all()
         )
-        grouped_court_classes = {}
+        grouped_courts = {}
         for c_c in court_classes:
-            grouped_court_classes.setdefault(c_c["name"], [])
+            grouped_courts.setdefault(c_c["name"], [])
             if c_c.get("courts__name") and c_c.get("courts__code"):
-                grouped_court_classes[c_c["name"]].append(
+                grouped_courts[c_c["name"]].append(
                     {"title": c_c["courts__name"], "code": c_c["courts__code"]}
                 )
 
-        context["grouped_courts"] = grouped_court_classes
+        context["grouped_courts"] = grouped_courts
         context["recent_judgments"] = Judgment.objects.order_by("-date")[:30]
         return context


### PR DESCRIPTION
This PR fixes [Lawlibrary-11 on Sentry](https://sentry.io/share/issue/79c82b1a552f4e018456977887b929d9/). 

Cause:
- When populating the court class dict, an additional query was made to fetch all courts for that court class

### Screenshots
* **Before:**
  <img width="1677" alt="Screenshot 2022-11-10 at 10 54 55" src="https://user-images.githubusercontent.com/8082197/201050398-b621a862-0eb6-4f9c-8e20-8b650d6ff922.png">

* **After:**
  <img width="1677" alt="Screenshot 2022-11-10 at 11 39 03" src="https://user-images.githubusercontent.com/8082197/201050440-7fcc0963-8dae-4ef7-b95b-b649c104cb26.png">
