### PR TITLE
Optimize judgments query

### DIFF
--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -14,6 +14,7 @@ class CourtDetailView(FilteredDocumentListView):
     model = Judgment
     template_name = "peachjam/court_detail.html"
     navbar_link = "judgments"
+    queryset = Judgment.objects.prefetch_related("judges")
 
     def get_base_queryset(self):
         qs = super().get_base_queryset().filter(court=self.court)


### PR DESCRIPTION
This PR aims to optimise the N+1 issue in LawLibrary at `/judgments/{code}/`

Before:
![image](https://user-images.githubusercontent.com/15012985/202167985-2923b7d4-0c9d-4369-9f37-ccebf10c323e.png)


After:
![image](https://user-images.githubusercontent.com/15012985/202168085-e3c8defa-13a3-4914-8800-1694f96dd3cc.png)


Closes https://github.com/laws-africa/peachjam/issues/685