### PR TITLE
Tweaks for Pocketlaw

### DIFF
--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -142,6 +142,6 @@ footer {
   }
 }
 
-[data-user-agent*='pocketlaw'] .pocketlaw-hidden {
+html[data-user-agent*='pocketlaw'] .pocketlaw-hidden {
   display: none;
 }

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -141,3 +141,7 @@ footer {
     }
   }
 }
+
+[data-user-agent*='Pocketlaw'] {
+  display: none;
+}

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -142,6 +142,6 @@ footer {
   }
 }
 
-[data-user-agent*='Pocketlaw'] {
+[data-user-agent*='pocketlaw'] {
   display: none;
 }

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -142,6 +142,6 @@ footer {
   }
 }
 
-[data-user-agent*='pocketlaw'] {
+[data-user-agent*='pocketlaw'] .pocketlaw-hidden {
   display: none;
 }

--- a/peachjam/templates/peachjam/layouts/document_list.html
+++ b/peachjam/templates/peachjam/layouts/document_list.html
@@ -44,7 +44,7 @@
     <div class="row">
       <div class="col-lg-3 d-none d-lg-block">
         <div>{% block desktop-taxonomy-list %}{% endblock %}</div>
-        <div data-list-facets></div>
+        <div class="pocketlaw-hidden" data-list-facets></div>
       </div>
       <div class="col-lg-9">
         <div class="position-relative">

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -17,7 +17,7 @@
     document.addEventListener("DOMContentLoaded", function () {
       const pocketlawElements = document.querySelectorAll('.pocketlaw-hidden');
       pocketlawElements.forEach(el => {
-        el.setAttribute('data-user-agent', navigator.userAgent);
+        el.setAttribute('data-user-agent', navigator.userAgent.toLowerCase());
       });
     });
   </script>

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -12,6 +12,16 @@
   <!--  app-prod.js depends on pdf.js to be loaded-->
   <script defer src="{% static 'js/app-prod.js' %}"></script>
 
+ <!-- Small script to add the current user agent to all elements with the class name 'pocketlaw-hidden'. -->
+  <script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+      const pocketlawElements = document.querySelectorAll('.pocketlaw-hidden');
+      pocketlawElements.forEach(el => {
+        el.setAttribute('data-user-agent', navigator.userAgent);
+      });
+    });
+  </script>
+
   {% if not DEBUG %}
     <!-- sentry -->
     <script

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -12,13 +12,10 @@
   <!--  app-prod.js depends on pdf.js to be loaded-->
   <script defer src="{% static 'js/app-prod.js' %}"></script>
 
- <!-- Small script to add the current user agent to all elements with the class name 'pocketlaw-hidden'. -->
+ <!-- Small script to add the current user agent to the root HTML element -->
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function () {
-      const pocketlawElements = document.querySelectorAll('.pocketlaw-hidden');
-      pocketlawElements.forEach(el => {
-        el.setAttribute('data-user-agent', navigator.userAgent.toLowerCase());
-      });
+      document.documentElement.setAttribute('data-user-agent', navigator.userAgent.toLowerCase());
     });
   </script>
 


### PR DESCRIPTION
This PR adds support for disabling elements when Peachjam is running on Pocketlaw.
* [x] New class for elements to be hidden `pocketlaw-hidden`
* [x] CSS rule to hide the elements
* [x] JS functionality to attach user agent details to pocketlaw elements

### Screenshots
* **Chrome user agent:**
  <img width="1651" alt="Screenshot 2022-11-23 at 18 24 55" src="https://user-images.githubusercontent.com/8082197/203584738-ea90b6e0-8414-4a40-a740-1ff2a547c9bf.png">

* **Pocketlaw user agent:**
  <img width="1676" alt="Screenshot 2022-11-23 at 19 48 30" src="https://user-images.githubusercontent.com/8082197/203602923-7438ccbd-29a8-48c0-bd2e-a83ae0c2921b.png">


ref #668 