### PR TITLE
Add max width to content-and-enrichments__inner

### DIFF
--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -73,6 +73,9 @@
   }
 
   .content-and-enrichments__inner {
+    max-width: 80em;
+    margin-left: auto;
+    margin-right: auto;
     .content {
       flex: 80%;
       max-width: 80%;

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -3,6 +3,7 @@
   .content.content__html {
     // reset line height so html documents use their default, rather than bootstrap's adjusted line height
     line-height: normal;
+    font-size: 15px;
   }
 
   .document-content__toggle {
@@ -73,7 +74,7 @@
   }
 
   .content-and-enrichments__inner {
-    max-width: 80em;
+    max-width: 70em;
     margin-left: auto;
     margin-right: auto;
     .content {


### PR DESCRIPTION
Wide screen photo:
![image](https://user-images.githubusercontent.com/15995210/206122025-89db32b0-cfd1-4f22-85af-d8375e5e27ab.png)


resolves # https://github.com/laws-africa/peachjam/issues/643