### PR TITLE
Build publication URL manually so as to show correct URL

### DIFF
--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -130,15 +130,19 @@ class LegislationDetailView(BaseDocumentDetailView):
 
         publication_date = self.object.metadata_json.get("publication_date", None)
         if publication_date:
+            api_url = "https://api.laws.africa/v2/"
+            commons_url = "https://commons.laws.africa/"
+            publication_url = work.get("publication_document", {}).get("url")
+            if publication_url and api_url in publication_url:
+                publication_url = publication_url.replace(api_url, commons_url)
+
             events.append(
                 {
                     "date": publication_date,
                     "event": "publication",
                     "publication_name": work.get("publication_name"),
                     "publication_number": work.get("publication_number"),
-                    "publication_url": work.get("publication_document", {}).get("url")
-                    if work.get("publication_document")
-                    else None,
+                    "publication_url": publication_url,
                 }
             )
 


### PR DESCRIPTION
This PR aims to show the correct "published in" URL by building it beforehand.

NB: See the link at the bottom left corner
![image](https://user-images.githubusercontent.com/15012985/206128073-a6109883-5477-43c5-9e6c-2c0c01822d6c.png)

The example links to [https://commons.laws.africa/akn/za/act/genn/2022/806/media/publication/za-act-genn-2022-806-publication-document.pdf](https://commons.laws.africa/akn/za/act/genn/2022/806/media/publication/za-act-genn-2022-806-publication-document.pdf) with the relevant resource.