### PR TITLE
Social media share for twitter and facebook

### DIFF
--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -124,7 +124,11 @@ footer {
 }
 
 .twitter-background {
-  color: $twitter-color;
+  background-color: $twitter-color;
+}
+
+.share-icon {
+  font-size: 22px;
 }
 
 

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -21,7 +21,23 @@
         {% endblock %}
 
         {% block document-title %}
-          <h1 class="py-4">{{ document.title }}</h1>
+          <div class="d-flex justify-content-between py-4">
+            <h1>{{ document.title }}</h1>
+            <div class="d-flex align-items-center">
+              <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri }}"
+                 class="btn btn-link"
+                 target="_blank"
+              >
+                <i class="bi bi-twitter twitter-forecolor share-icon"></i>
+              </a>
+              <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}"
+                 class="btn btn-link"
+                 target="_blank"
+              >
+                <i class="bi bi-facebook facebook-forecolor share-icon"></i>
+              </a>
+            </div>
+          </div>
         {% endblock %}
 
         {% include 'peachjam/_notices.html' with messages=notices %}

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -11,6 +11,9 @@
   {% if document.author %}
     <meta property="book:author" content="{{ document.author }}" />
   {% endif %}
+
+  <meta name="twitter:card" content="summary"/>
+  <meta name="twitter:title" content="{{ document.title }}"/>
 {% endblock %}
 
 {% block page-content %}


### PR DESCRIPTION
Added social media sharing links to a document for twitter and facebook. Partially tackles https://github.com/laws-africa/peachjam/issues/609

Screenshots:
Twitter share
<img width="634" alt="image" src="https://user-images.githubusercontent.com/15995210/207542444-94d2c129-9abc-4a00-a961-c1abc148380f.png">

Facebook share
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/15995210/207542593-a2ab282b-e4a7-42c1-aef5-ad10ec3812a0.png">