### PR TITLE
Tweaks on pages

### DIFF
--- a/peachjam/templates/peachjam/article_detail.html
+++ b/peachjam/templates/peachjam/article_detail.html
@@ -5,7 +5,7 @@
 
 {% block page-content %}
 <div class="container pb-5">
-  <nav aria-label="breadcrumb">
+  <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb">
       <li class="breadcrumb-item"><a href={% url 'article_list' %}>{% trans "Articles" %}</a></li>
       <li class="breadcrumb-item active" aria-current="page">{{ article.title }}</li>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -24,7 +24,7 @@
         {% endblock %}
 
         {% block document-title %}
-          <div class="d-md-flex justify-md-content-between py-4">
+          <div class="d-md-flex justify-content-md-between py-4">
             <h1>{{ document.title }}</h1>
             <div class="d-flex align-items-center">
               <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri }}"


### PR DESCRIPTION
- Correct class to justify-content-md-between in document detail page: (Im an idiot, I got the class name wrong)
Desktop:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/15995210/207839254-26c44d68-ca15-462a-a0ce-e52dedf0c13b.png">
Mobile:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/15995210/207839424-88301caa-cdd2-4e53-981a-c7217f749024.png">

- Correct spacing between content and breadcrumbs in article page
<img width="953" alt="image" src="https://user-images.githubusercontent.com/15995210/207839814-5092b6b4-15f6-4065-891d-abe069f3fb4c.png">
