### PR TITLE
Keep work languages up to date; add tests

### DIFF
--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -67,6 +67,18 @@ class Work(models.Model):
         verbose_name_plural = _("works")
         ordering = ["title"]
 
+    def update_languages(self):
+        """Update this work's languages to reflect the distinct languages of its related documents."""
+        langs = list(
+            CoreDocument.objects.filter(work=self)
+            .distinct("language__iso_639_3")
+            .values_list("language__iso_639_3", flat=True)
+            .order_by("language__iso_639_3")
+        )
+        if langs != self.languages:
+            self.languages = langs
+            self.save()
+
     def __str__(self):
         return f"{self.frbr_uri} - {self.title}"
 

--- a/peachjam/tests/test_preferred_language.py
+++ b/peachjam/tests/test_preferred_language.py
@@ -1,4 +1,7 @@
 from django.test import TestCase
+from languages_plus.models import Language
+
+from peachjam.models import Legislation
 
 
 class TestPreferredLanguage(TestCase):
@@ -10,3 +13,32 @@ class TestPreferredLanguage(TestCase):
 
         assert response.context.get("documents").count() == 2
         assert response.context.get("LANGUAGE_CODE") == "en"
+
+    def test_update_work_languages(self):
+        doc = Legislation.objects.get(
+            expression_frbr_uri="/akn/aa-au/act/1969/civil-aviation-commission/eng@1969-01-17"
+        )
+        work = doc.work
+        work.update_languages()
+        self.assertEqual(["eng"], work.languages)
+
+        # create a french copy
+        doc2 = Legislation.objects.create(
+            jurisdiction=doc.jurisdiction,
+            locality=doc.locality,
+            frbr_uri_doctype="act",
+            frbr_uri_date=doc.frbr_uri_date,
+            frbr_uri_number=doc.frbr_uri_number,
+            title=doc.title,
+            date=doc.date,
+            language=Language.objects.get(pk="fr"),
+            metadata_json={},
+        )
+        self.assertNotEqual(doc.pk, doc2.pk)
+
+        work.refresh_from_db()
+        self.assertEqual(["eng", "fra"], sorted(work.languages))
+
+        doc2.delete()
+        work.refresh_from_db()
+        self.assertEqual(["eng"], sorted(work.languages))


### PR DESCRIPTION
Previously we weren't handling deleted documents.