### PR TITLE
Add request id logging to middleware

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "log_request_id.middleware.RequestIDMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
Otherwise request ids aren't fetched from nginx