### PR TITLE
Show static files links on Pocketlaw

### DIFF
--- a/peachjam/templates/peachjam/_footer.html
+++ b/peachjam/templates/peachjam/_footer.html
@@ -3,6 +3,7 @@
 
 <footer class="pt-4 pb-4">
   <div class="container">
+    <a href="{% url 'pocketlaw_resources' %}" style="display: none"></a>
     {% block newsletter-form %}
     {% endblock %}
     <div class="row">

--- a/peachjam/templates/peachjam/pocket_law_resources.html
+++ b/peachjam/templates/peachjam/pocket_law_resources.html
@@ -1,0 +1,15 @@
+{% extends 'peachjam/layouts/base.html' %}
+
+<title>{% block title %}PocketLaw Resources{% endblock %} - {{ APP_NAME }}</title>
+
+{% block head-css %}{% endblock %}
+
+{% block head-js %}
+  <script src="/static/lib/pdfjs/pdf.worker.js"></script>
+{% endblock %}
+
+{% block header %}{% endblock %}
+
+{% block body-content %}{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -52,6 +52,7 @@ from peachjam.views import (
     LegalInstrumentListView,
     LegislationListView,
     PlaceDetailView,
+    PocketLawResources,
     TaxonomyDetailView,
     TermsOfUsePageView,
     TopLevelTaxonomyListView,
@@ -178,6 +179,9 @@ urlpatterns = [
         TemplateView.as_view(
             template_name="peachjam/robots.txt", content_type="text/plain"
         ),
+    ),
+    path(
+        "pocketlaw-resources", PocketLawResources.as_view(), name="pocketlaw_resources"
     ),
 ]
 

--- a/peachjam/views/__init__.py
+++ b/peachjam/views/__init__.py
@@ -12,5 +12,6 @@ from .judgment import *
 from .legal_instrument import *
 from .legislation import *
 from .place import *
+from .pocketlaw import *
 from .taxonomy import *
 from .terms_of_use import *

--- a/peachjam/views/pocketlaw.py
+++ b/peachjam/views/pocketlaw.py
@@ -1,0 +1,5 @@
+from django.views.generic import TemplateView
+
+
+class PocketLawResources(TemplateView):
+    template_name = "peachjam/pocket_law_resources.html"


### PR DESCRIPTION
This PR aims to resolve static files links to show correctly on Pocketlaw.

Previously, PDFs on Pocketlaw, while offline, would not load due to how Django handles static files by adding hash values to the names, e.g. `https://lawlibrary.org.za/static/lib/pdfjs/pdf.worker.js` becomes `https://lawlibrary.org.za/static/lib/pdfjs/pdf.4a2a1c0fb5fb.js` and the worker.js is not available in the archive produced by Wget.



