### PR TITLE
Multi-language search indexes

### DIFF
--- a/peachjam_search/apps.py
+++ b/peachjam_search/apps.py
@@ -7,3 +7,6 @@ class PeachjamSearchConfig(AppConfig):
 
     def ready(self):
         import peachjam_search.signals  # noqa
+        from peachjam_search.documents import setup_language_indexes
+
+        setup_language_indexes()

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -1,3 +1,4 @@
+import copy
 from tempfile import NamedTemporaryFile
 
 from django.conf import settings
@@ -5,6 +6,7 @@ from django.utils.functional import classproperty
 from django_elasticsearch_dsl import Document, Text, fields
 from django_elasticsearch_dsl.registries import registry
 from docpipe.pdf import pdf_to_text
+from elasticsearch_dsl.index import Index
 from lxml import etree
 
 from peachjam.models import CoreDocument
@@ -119,3 +121,42 @@ class SearchableDocument(Document):
                     if page:
                         pages.append({"page_num": i, "body": page})
                 return pages
+
+    def _prepare_action(self, object_instance, action):
+        info = super()._prepare_action(object_instance, action)
+        # choose a language-specific index
+        lang = object_instance.language.iso_639_2T
+        if lang in ANALYZERS:
+            info["_index"] = f"{self._index._name}_{lang}"
+        return info
+
+
+# These are the language-specific indexes we create and their associated analyzers for text fields.
+# Documents in other languages are stored in a general index with the "standard" analyzer
+ANALYZERS = {
+    "ara": "arabic",
+    "eng": "english",
+    "fra": "french",
+    "por": "portuguese",
+}
+
+
+def setup_language_indexes():
+    """Setup multi-language indexes."""
+    main_index = SearchableDocument._index
+    mappings = main_index.to_dict()["mappings"]
+
+    def set_analyzer(fields, analyzer):
+        """Recursively set analyzer for text fields."""
+        for fld in fields:
+            if fld["type"] == "text":
+                fld["analyzer"] = analyzer
+            elif fld["type"] == "nested":
+                set_analyzer(fld["properties"].values(), analyzer)
+
+    for lang, analyzer in ANALYZERS.items():
+        new_mappings = copy.deepcopy(mappings)
+        set_analyzer(new_mappings["properties"].values(), analyzer)
+        index = Index(name=f"{main_index._name}_{lang}")
+        index.get_or_create_mapping()._update_from_dict(new_mappings)
+        registry.register(index, SearchableDocument)

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -19,7 +19,7 @@ from elasticsearch_dsl import DateHistogramFacet
 from elasticsearch_dsl.query import MatchPhrase, Q, SimpleQueryString
 from rest_framework.permissions import AllowAny
 
-from peachjam_search.documents import SearchableDocument
+from peachjam_search.documents import ANALYZERS, SearchableDocument
 from peachjam_search.serializers import SearchableDocumentSerializer
 
 CACHE_SECS = 15 * 60
@@ -47,7 +47,7 @@ class MultiFieldSearchQueryBackend(SimpleQueryStringQueryBackend):
                 self.query_type,
                 query=search_term,
                 fields=[self.get_field(field, view_search_fields[field])],
-                **self.get_query_options(request, view, search_backend)
+                **self.get_query_options(request, view, search_backend),
             )
             for field, search_term in query_params.items()
         ]
@@ -252,6 +252,14 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
 
     # TODO perhaps better to explicitly include specific fields
     source = {"excludes": ["pages", "content", "flynote", "headnote_holding"]}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # search multiple language indexes
+        self.index = [self.document._index._name] + [
+            f"{self.document._index._name}_{lang}" for lang in ANALYZERS.keys()
+        ]
+        self.search = self.search.index(self.index)
 
     @method_decorator(cache_page(CACHE_SECS))
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
* configure language-based search indexes that use language-specific analyzers to index text fields
* configure the search view to search all indexes
* documents not in one of the supported languages are indexed into the old language-agnostic index using the default "standard" analyzer.

Index mappings:

![image](https://user-images.githubusercontent.com/4178542/212461235-e37567da-0d98-43fa-b498-4d3494558d79.png)

![image](https://user-images.githubusercontent.com/4178542/212461259-bc8f1b0b-27e4-4871-b0f2-be9fd55ef7bf.png)
