### PR TITLE
Add gazettes to ulii site navigation

### DIFF
--- a/ulii/templates/peachjam/_header.html
+++ b/ulii/templates/peachjam/_header.html
@@ -25,6 +25,11 @@
     </a>
   </li>
   <li class="nav-item">
+    <a class="nav-link {% if view.navbar_link == 'gazettes' %}active{% endif %}" href="{% url 'gazettes' %}">
+      {% trans 'Gazettes' %}
+    </a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'about' %}active{% endif%}" href="{% url 'about' %}">
       {% trans 'About' %}
     </a>


### PR DESCRIPTION
This PR adds gazettes to the ULII site navigation.

![image](https://user-images.githubusercontent.com/15012985/212683261-e8f41d88-8f7b-47eb-8d1b-02eead9c8991.png)
