### PR TITLE
Treat recommendation as a legal instrument, not legis

### DIFF
--- a/peachjam/adapters/adapters.py
+++ b/peachjam/adapters/adapters.py
@@ -161,7 +161,13 @@ class IndigoAdapter(Adapter):
             raise Exception("FRBR URIs do not match.")
 
         if document["nature"] == "act":
-            if document["subtype"] in ["charter", "protocol", "convention", "treaty"]:
+            if document["subtype"] in [
+                "charter",
+                "protocol",
+                "convention",
+                "treaty",
+                "recommendation",
+            ]:
                 model = LegalInstrument
                 document_nature_name = " ".join(
                     [name for name in document["subtype"].split("-")]


### PR DESCRIPTION
This means that https://edit.laws.africa/works/akn/za/act/rules/2016/national-assembly/ is treated as a legal instrument, not legislation.