### PR TITLE
Taxonomy tweaks

### DIFF
--- a/lawlibrary/templates/peachjam/_header.html
+++ b/lawlibrary/templates/peachjam/_header.html
@@ -31,8 +31,8 @@
     </a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{% url 'taxonomy_detail' first_level_topic="collections" topics="sexual-and-gender-based-violence" %}">
-      SGBV Library
+    <a class="nav-link" href="{% url 'first_level_taxonomy_list' "collections" %}">
+      Collections
     </a>
   </li>
 


### PR DESCRIPTION
This PR changes "SGBV Library" in the top-level navbar into "Collections" on LawLibrary.

Before:
![image](https://user-images.githubusercontent.com/15012985/214047722-94ebb84f-14cf-4040-930f-f3a88b1f99eb.png)

After:
![image](https://user-images.githubusercontent.com/15012985/214047474-678c0523-fbf2-4920-be15-07605f20bd45.png)
