### PR TITLE
Subsidiary legislation in provincial legislation listing

### DIFF
--- a/lawlibrary/templates/lawlibrary/provincial_legislation_list.html
+++ b/lawlibrary/templates/lawlibrary/provincial_legislation_list.html
@@ -25,6 +25,9 @@
           <a class="nav-link {% if view.variant == 'repealed' %}active{% endif %}" href="{% url 'provincial_legislation_list_repealed' locality.code  %}">Repealed legislation</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link {% if view.variant == 'subleg' %}active{% endif %}" href="{% url 'provincial_legislation_list_subsidiary' locality.code  %}">{{ PEACHJAM_SETTINGS.subleg_label }}</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link {% if view.variant == 'all' %}active{% endif %}" href="{% url 'provincial_legislation_list_all' locality.code %}">All legislation</a>
         </li>
       </nav>

--- a/lawlibrary/urls.py
+++ b/lawlibrary/urls.py
@@ -32,6 +32,11 @@ urlpatterns = [
         name="provincial_legislation_list_repealed",
     ),
     path(
+        "legislation/<str:code>/subsidiary",
+        views.ProvincialLegislationListView.as_view(variant="subleg"),
+        name="provincial_legislation_list_subsidiary",
+    ),
+    path(
         "legislation/<str:code>/all",
         views.ProvincialLegislationListView.as_view(variant="all"),
         name="provincial_legislation_list_all",


### PR DESCRIPTION
- Adds a subsidiary legislation tab to the provincial legislation listing

closes #847


![image](https://user-images.githubusercontent.com/25079238/214233113-b807e4f1-333d-4ac7-9c01-d1ab9a8b4daf.png)
