### PR TITLE
Use stored file size rather than getting size from storage

### DIFF
--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -81,8 +81,8 @@
 
   {% if display_type == 'pdf' %}
     <div data-pdf="{% url 'document_source_pdf' document.expression_frbr_uri|strip_first_character %}"
-         data-pdf-size="{{ document.source_file.file.size }}"
-         {% if document.source_file.file.size > 5242880 %}
+         data-pdf-size="{{ document.source_file.size }}"
+         {% if document.source_file.size > 5242880 %}
             data-large-pdf
          {% endif %}
          data-pdf-standby>
@@ -156,7 +156,7 @@
             <div class="pdf-content"></div>
             <div class="pdf-large-prompt">
               <p>
-                {% blocktrans with filesize=document.source_file.file.size|filesizeformat trimmed %}
+                {% blocktrans with filesize=document.source_file.size|filesizeformat trimmed %}
                   This document is {{ filesize }}. Do you want to load it?
                 {% endblocktrans %}
               </p>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -182,7 +182,7 @@
                               <a href="{% url 'document_source' document.expression_frbr_uri|strip_first_character %}"
                                  target="_blank"
                               >{% trans "Download" %} {{ document.source_file.filename_extension|upper }}</a>
-                              ({{ document.source_file.file.size|filesizeformat }})
+                              ({{ document.source_file.size|filesizeformat }})
                             </div>
 
                             {% if document.source_file.filename_extension != "pdf" %}


### PR DESCRIPTION
This saves multiple calls to S3, and is why we store the file size locally.

![image](https://user-images.githubusercontent.com/4178542/215806265-f463d98b-992b-4b96-b5b9-7fc76ca7fb8b.png)
