### PR TITLE
provincial legislation template must use normal legislation template

### DIFF
--- a/lawlibrary/templates/lawlibrary/provincial_legislation_list.html
+++ b/lawlibrary/templates/lawlibrary/provincial_legislation_list.html
@@ -1,45 +1,34 @@
-{% extends "peachjam/layouts/main.html" %}
+{% extends "liiweb/legislation_list.html" %}
 {% load i18n %}
 {% block title %} {% trans 'Provincial Legislation' %} {% endblock %}
 
-{% block page-content %}
-  <section class="pb-5">
-    <div class="container">
-      {% block breadcrumbs %}
-        <nav aria-label="breadcrumb">
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'provincial_legislation' %}">{% trans 'Provincial Legislation' %}</a></li>
-          </ol>
-        </nav>
-      {% endblock %}
+{% block breadcrumbs %}
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="{% url 'provincial_legislation' %}">{% trans 'Provincial Legislation' %}</a></li>
+    </ol>
+  </nav>
+{% endblock %}
 
-      <h1 class="my-4">{% blocktrans with locality=locality.name %}{{ locality }} Legislation{% endblocktrans %}</h1>
+{% block page-heading %}
+  <h1 class="my-4">{% blocktrans with locality=locality.name %}{{ locality }} Legislation{% endblocktrans %}</h1>
 
-      {% include 'lawlibrary/_legislation_alert.html' %}
+  {% include 'lawlibrary/_legislation_alert.html' %}
+{% endblock %}
 
-      <nav class="nav nav-tabs mb-3 border-bottom">
-        <li class="nav-item">
-          <a class="nav-link {% if view.variant == 'current' %}active{% endif %}" href="{% url 'provincial_legislation_list' locality.code %}">Current legislation</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link {% if view.variant == 'repealed' %}active{% endif %}" href="{% url 'provincial_legislation_list_repealed' locality.code  %}">Repealed legislation</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link {% if view.variant == 'subleg' %}active{% endif %}" href="{% url 'provincial_legislation_list_subsidiary' locality.code  %}">{{ PEACHJAM_SETTINGS.subleg_label }}</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link {% if view.variant == 'all' %}active{% endif %}" href="{% url 'provincial_legislation_list_all' locality.code %}">All legislation</a>
-        </li>
-      </nav>
-
-      {% if view.variant == 'repealed' %}
-        <div class="alert alert-danger">
-          You are viewing repealed legislation which is no longer in force.
-        </div>
-      {% endif %}
-
-      <div data-vue-component="LegislationTable" data-show-side-facets></div>
-      {{ legislation_table|json_script:"legislation-table" }}
-    </div>
-  </section>
+{% block legislation-nav %}
+  <nav class="nav nav-tabs mb-3 border-bottom">
+    <li class="nav-item">
+      <a class="nav-link {% if view.variant == 'current' %}active{% endif %}" href="{% url 'provincial_legislation_list' locality.code %}">Current legislation</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {% if view.variant == 'repealed' %}active{% endif %}" href="{% url 'provincial_legislation_list_repealed' locality.code  %}">Repealed legislation</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {% if view.variant == 'subleg' %}active{% endif %}" href="{% url 'provincial_legislation_list_subsidiary' locality.code  %}">{{ PEACHJAM_SETTINGS.subleg_label }}</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {% if view.variant == 'all' %}active{% endif %}" href="{% url 'provincial_legislation_list_all' locality.code %}">All legislation</a>
+    </li>
+  </nav>
 {% endblock %}


### PR DESCRIPTION
Otherwise we don't get the full functionality required for pocketlaw.

With javascript disabled (required for pocketlaw):

Before:
![image](https://user-images.githubusercontent.com/4178542/219063923-0fc04efb-1696-4276-846c-1b0ded395c03.png)

After:
![image](https://user-images.githubusercontent.com/4178542/219063755-df6ce95a-1590-4643-bb1f-1cffd7dfd8e6.png)
