### PR TITLE
Fix year nav

### DIFF
--- a/peachjam/static/stylesheets/components/_index.scss
+++ b/peachjam/static/stylesheets/components/_index.scss
@@ -10,3 +10,4 @@
 @import "terms-of-use";
 @import "diffs";
 @import "gutter";
+@import "year_nav";


### PR DESCRIPTION
This PR fixes the wonky display of the years on the judgments and gazette listing pages.

To test locally:
- Delete staticfiles folder: `rm -rf staticfiles`
- Compile sass: `python manage.py compilescss`

Before:
`/judgments/court_code`
![image](https://user-images.githubusercontent.com/15012985/220059129-e153521b-efba-4747-9f6b-6d9048a20717.png)

`/gazettes/code/year/`
![image](https://user-images.githubusercontent.com/15012985/220059659-587f7603-9c26-4ff3-bf8a-bbb0386eca57.png)


After:
`/judgments/court_code`
![image](https://user-images.githubusercontent.com/15012985/220058919-82330bf5-bb64-471c-b926-96d668100b82.png)

`/gazettes/code/year/`
![image](https://user-images.githubusercontent.com/15012985/220059358-dd5cd9d2-568a-4a1b-be4e-4f074d4063fa.png)



