### PR TITLE
Fix:Pagination bug skipping items

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -112,7 +112,7 @@ class BaseDocumentFilterForm(forms.Form):
         registries = self.params.getlist("registries")
 
         # Order by date descending initially
-        queryset = queryset.order_by("-date")
+        queryset = queryset.order_by("-date", "title")
 
         if years and exclude != "years":
             queryset = queryset.filter(date__year__in=years)


### PR DESCRIPTION
- This one was a little tricky to reproduce.
- This seems to be a problem with how Django is handling pagination and ordering. The SQL works by setting limits and offsets depending on the pagination size. For some reason, some items get lost if they have similar dates and fall across the offset boundary.
- By adding another ordering clause for `title` this problem seems to go away. 
- I still don't fully understand the cause for this, but this fix seems to work, at least locally.

Loom: [https://www.loom.com/share/bcadd61bc8904cacba55842095f9c7c6](https://www.loom.com/share/bcadd61bc8904cacba55842095f9c7c6)
fixes #929 