### PR TITLE
correct la-akoma-ntoso attribute

### DIFF
--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -116,7 +116,7 @@
         {% if display_type == 'akn' %}
           <la-akoma-ntoso
           data-document-element
-          expression-frbr-uri="{{ document.expression_frbr_uri }}"
+          frbr-expression-uri="{{ document.expression_frbr_uri }}"
           class="flash-target"
           >
           <la-decorate-terms popup-definitions link-terms></la-decorate-terms>


### PR DESCRIPTION
Otherwise the per-country formatting isn't applied.

Before:

![image](https://user-images.githubusercontent.com/4178542/224669404-1cde9bb7-89d5-4747-9976-909f01b48caa.png)


After:
![image](https://user-images.githubusercontent.com/4178542/224669304-ca76c6b2-4074-481d-a2d4-a81f31f1fc8f.png)
