### PR TITLE
Faceting on registries is breaking search

### DIFF
--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -216,7 +216,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
         "nature": "nature",
         "year": "year",
         "judges": "judges",
-        "registry": "registry",
+        # "registry": "registry",
         "attorneys": "attorneys",
     }
 
@@ -228,7 +228,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
         "content": None,
         "court": None,
         "alternative_names": {"boost": 4},
-        "registry": None,
+        # "registry": None,
         "attorneys": None,
     }
 
@@ -269,7 +269,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
         },
         "court": {"field": "court", "options": {"size": 100}},
         "judges": {"field": "judges", "options": {"size": 100}},
-        "registry": {"field": "registry", "options": {"size": 100}},
+        # "registry": {"field": "registry", "options": {"size": 100}},
         "attorneys": {"field": "attorneys", "options": {"size": 100}},
     }
 


### PR DESCRIPTION
We need to re-build the search index with updated mappings to allow faceting on registry, because it must be created in the mapping as a keyword field.

Without this, search results for most queries are coming back empty or very limited.

To easily re-index all documents, we need to delete and re-creating the mapping, and then run background tasks to re-index for search. That's easiest once https://github.com/laws-africa/peachjam/pull/975 is merged.