### PR TITLE
Hide source file tab on new document

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -341,6 +341,14 @@ class DocumentAdmin(admin.ModelAdmin):
 
     new_document_form_mixin = NewDocumentFormMixin
 
+    def get_inlines(self, request, obj):
+        inlines = self.inlines
+        if obj is None and SourceFileInline in inlines:
+            inlines.remove(SourceFileInline)
+        elif obj is not None and SourceFileInline not in inlines:
+            inlines.append(SourceFileInline)
+        return inlines
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.prefetch_related("locality", "jurisdiction")


### PR DESCRIPTION
Fixes #978 

- We hide the source file tab if when adding a new document because user can use the upload document button. 
