### PR TITLE
citation popups

### DIFF
--- a/peachjam/js/components/DocumentContent/index.ts
+++ b/peachjam/js/components/DocumentContent/index.ts
@@ -43,6 +43,10 @@ class DocumentContent {
     this.setupPdf();
     this.setupSearch();
     this.setupEnrichments();
+    if (this.root.getAttribute('data-display-type') !== 'pdf') {
+      // for PDFs, this will be done once the pages are rendered
+      this.setupPopups();
+    }
   }
 
   setupTabs () {
@@ -106,6 +110,7 @@ class DocumentContent {
         if (this.enchrichmentsManager) {
           this.enchrichmentsManager.setupPdfCitationLinks();
         }
+        this.setupPopups();
 
         const urlParams = new URLSearchParams(window.location.search);
         const targetPage = urlParams.get('page');
@@ -230,6 +235,26 @@ class DocumentContent {
     const contentAndEnrichmentsElement = this.root.querySelector('.content-and-enrichments');
     if (!contentAndEnrichmentsElement) return;
     this.enchrichmentsManager = new EnrichmentsManager(contentAndEnrichmentsElement as HTMLElement);
+  }
+
+  setupPopups () {
+    if (!this.documentElement) return;
+
+    // if the document isn't using la-akoma-ntoso, then fiddle existing <a> elements to ensure that the external popups
+    // functionality finds them (it expects AKN-style a tags)
+    if (this.documentElement.tagName !== 'LA-AKOMA-NTOSO') {
+      for (const a of Array.from(this.documentElement.querySelectorAll('a[href^="/akn/"]'))) {
+        a.classList.add('akn-ref');
+        // @ts-ignore
+        a.setAttribute('data-href', a.getAttribute('href'));
+      }
+    }
+
+    const el = document.createElement('la-decorate-external-refs');
+    el.akomaNtoso = (this.documentElement as HTMLElement);
+    el.popups = true;
+    el.provider = '//' + window.location.host;
+    this.documentElement.appendChild(el);
   }
 }
 

--- a/peachjam/js/peachjam.ts
+++ b/peachjam/js/peachjam.ts
@@ -12,6 +12,7 @@ import {
   LaTableOfContents,
   LaTocItem,
   LaDecorateInternalRefs,
+  LaDecorateExternalRefs,
   LaDecorateTerms
 } from '@lawsafrica/law-widgets/dist/components';
 
@@ -19,6 +20,7 @@ customElements.define('la-akoma-ntoso', LaAkomaNtoso as any);
 customElements.define('la-gutter', LaGutter as any);
 customElements.define('la-gutter-item', LaGutterItem as any);
 customElements.define('la-decorate-internal-refs', LaDecorateInternalRefs as any);
+customElements.define('la-decorate-external-refs', LaDecorateExternalRefs as any);
 customElements.define('la-decorate-terms', LaDecorateTerms as any);
 customElements.define('la-table-of-contents-controller', LaTableOfContentsController as any);
 customElements.define('la-table-of-contents', LaTableOfContents as any);

--- a/peachjam/templates/peachjam/document_popup.html
+++ b/peachjam/templates/peachjam/document_popup.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+<div class="document-popup-content">
+  <div class="mb-2">
+    <div>
+      {% block title %}
+        <b>{{ document.title }}</b>
+        {% block title-badges %}
+          {% if document.metadata_json.repealed %}
+            <span class="badge bg-danger">{% trans 'repealed' %}</span>
+          {% endif %}
+        {% endblock %}
+      {% endblock %}
+    </div>
+    {% block citation %}
+      {% if document.citation %}
+        <div>
+          <i>{{ document.citation }}</i>
+        </div>
+      {% endif %}
+    {% endblock %}
+  </div>
+  {% block date %}<div>{{ document.date }}</div>{% endblock %}
+</div>

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -40,6 +40,7 @@ from peachjam.views import (
     DocumentListView,
     DocumentMediaView,
     DocumentNatureListView,
+    DocumentPopupView,
     DocumentSourcePDFView,
     DocumentSourceView,
     FirstLevelTaxonomyDetailView,
@@ -59,6 +60,9 @@ from peachjam.views import (
     TopLevelTaxonomyListView,
     UserProfileDetailView,
 )
+
+# cache duration for most cached pages
+CACHE_DURATION = 60 * 60 * 24
 
 urlpatterns = [
     path("", HomePageView.as_view(), name="home_page"),
@@ -125,17 +129,17 @@ urlpatterns = [
     # document detail views
     re_path(
         r"^(?P<frbr_uri>akn/.*)/source$",
-        cache_page(60 * 60 * 24)(DocumentSourceView.as_view()),
+        cache_page(CACHE_DURATION)(DocumentSourceView.as_view()),
         name="document_source",
     ),
     re_path(
         r"^(?P<frbr_uri>akn/.*)/source.pdf$",
-        cache_page(60 * 60 * 24)(DocumentSourcePDFView.as_view()),
+        cache_page(CACHE_DURATION)(DocumentSourcePDFView.as_view()),
         name="document_source_pdf",
     ),
     re_path(
         r"^(?P<frbr_uri>akn/.*)/media/(?P<filename>.+)$",
-        cache_page(60 * 60 * 24)(DocumentMediaView.as_view()),
+        cache_page(CACHE_DURATION)(DocumentMediaView.as_view()),
         name="document_media",
     ),
     re_path(
@@ -196,6 +200,11 @@ urlpatterns = [
         r"^doc/(?P<nature>[\w-]+)$",
         DocumentNatureListView.as_view(),
         name="document_nature_list",
+    ),
+    # law-widget support services
+    path(
+        "p/<str:partner>/e/popup/<path:frbr_uri>",
+        cache_page(CACHE_DURATION)(DocumentPopupView.as_view()),
     ),
 ]
 

--- a/peachjam/views/__init__.py
+++ b/peachjam/views/__init__.py
@@ -19,3 +19,4 @@ from .pocketlaw import *
 from .robots import *
 from .taxonomy import *
 from .terms_of_use import *
+from .widgets import *

--- a/peachjam/views/widgets.py
+++ b/peachjam/views/widgets.py
@@ -1,0 +1,22 @@
+from django.http import Http404
+from django.utils.translation import get_language
+from django.views.generic import DetailView
+
+from peachjam.helpers import add_slash
+from peachjam.models import CoreDocument
+
+
+class DocumentPopupView(DetailView):
+    """Shows a popup with basic details for a document."""
+
+    model = CoreDocument
+    context_object_name = "document"
+    template_name = "peachjam/document_popup.html"
+
+    def get_object(self, *args, **kwargs):
+        obj = self.model.objects.best_for_frbr_uri(
+            add_slash(self.kwargs.get("frbr_uri")), get_language()
+        )[0]
+        if not obj:
+            raise Http404()
+        return obj


### PR DESCRIPTION
Add wikipedia-style popups for citations in document body, using the `la-decorate-external-refs` widget from law-widgets.

1. for Akoma Ntoso, this works out the box
2. for PDF and HTML, we need to first add some attributes to the `<a>` tags so that the law-widgets picks them up

https://www.loom.com/share/021f935d5f6e4080b5a44d52aee3fc70