### PR TITLE
Redirect www to non-www

### DIFF
--- a/peachjam/middleware.py
+++ b/peachjam/middleware.py
@@ -1,0 +1,20 @@
+from django.shortcuts import redirect
+
+
+class RedirectWWWMiddleware:
+    """Redirect www to non-www permanently."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        host = request.META.get("HTTP_HOST")
+        if host and host.startswith("www."):
+            non_www = host[4:]
+            return redirect(
+                f"https://{non_www}{request.get_full_path()}", permanent=True
+            )
+
+        return response

--- a/peachjam/middleware.py
+++ b/peachjam/middleware.py
@@ -10,7 +10,7 @@ class RedirectWWWMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
 
-        host = request.META.get("HTTP_HOST")
+        host = request.get_host()
         if host and host.startswith("www."):
             non_www = host[4:]
             return redirect(

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "log_request_id.middleware.RequestIDMiddleware",
+    "peachjam.middleware.RedirectWWWMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
eg. www.lawlibrary.org.za redirects to lawlibrary.org.za, so that we don't have duplicate websites.