### PR TITLE
Force default language for ZanzibarLII and TanzLII

### DIFF
--- a/peachjam/middleware.py
+++ b/peachjam/middleware.py
@@ -1,4 +1,5 @@
 from django.shortcuts import redirect
+from django.utils.deprecation import MiddlewareMixin
 
 
 class RedirectWWWMiddleware:
@@ -18,3 +19,19 @@ class RedirectWWWMiddleware:
             )
 
         return response
+
+
+class ForceDefaultLanguageMiddleware(MiddlewareMixin):
+    """
+    Ignore Accept-Language HTTP headers
+
+    This will force the I18N machinery to always choose settings.LANGUAGE_CODE
+    as the default initial language, unless another one is set via sessions or cookies.
+
+    Should be installed *before* any middleware that checks request.META['HTTP_ACCEPT_LANGUAGE'],
+    namely django.middleware.locale.LocaleMiddleware
+    """
+
+    def process_request(self, request):
+        if "HTTP_ACCEPT_LANGUAGE" in request.META:
+            del request.META["HTTP_ACCEPT_LANGUAGE"]

--- a/tanzlii/settings.py
+++ b/tanzlii/settings.py
@@ -10,6 +10,11 @@ JAZZMIN_SETTINGS["site_header"] = "TanzLII"  # noqa
 JAZZMIN_SETTINGS["site_brand"] = "tanzlii.org"  # noqa
 
 COURT_CODE_MAPPINGS = {"court-appeal-tanzania": "TZCA", "high-court-tanzania": "TZHC"}
+
+# Custom middleware to force the I18N machinery to always choose settings.LANGUAGE_CODE
+# as the default initial language, unless another one is set via sessions or cookies
+MIDDLEWARE = ["peachjam.middleware.ForceDefaultLanguageMiddleware"] + MIDDLEWARE  # noqa
+
 LANGUAGE_CODE = "sw"
 
 LANGUAGES = [

--- a/zanzibarlii/settings.py
+++ b/zanzibarlii/settings.py
@@ -4,6 +4,11 @@ from liiweb.settings import *  # noqa
 
 INSTALLED_APPS = ["zanzibarlii.apps.ZanzibarLIIConfig"] + INSTALLED_APPS  # noqa
 
+
+# Custom middleware to force the I18N machinery to always choose settings.LANGUAGE_CODE
+# as the default initial language, unless another one is set via sessions or cookies
+MIDDLEWARE = ["peachjam.middleware.ForceDefaultLanguageMiddleware"] + MIDDLEWARE  # noqa
+
 LANGUAGE_CODE = "sw"
 
 LANGUAGES = [


### PR DESCRIPTION
This PR adds a custom middleware that forces the default site language to be used, unless another one is set via sessions or cookies.

This has been applied for ZanzibarLII and TanzLII.

Resolves #1086 