### PR TITLE
Pdf links

### DIFF
--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -252,6 +252,33 @@
     .pdfPresentationMode.pdfPresentationModeControls .textLayer span {
       cursor: default;
     }
+
+    .annotationLayer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      pointer-events: none;
+      transform-origin: 0 0;
+      z-index: 3;
+    }
+
+    .annotationLayer canvas {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
+
+    .annotationLayer section {
+      position: absolute;
+      text-align: initial;
+      pointer-events: auto;
+      box-sizing: border-box;
+      transform-origin: 0 0;
+    }
+
+    .annotationLayer .linkAnnotation {
+      cursor: pointer;
+    }
   }
 
   .pdf-content__page {


### PR DESCRIPTION
This is complex. I don't yet know how pdfjs handles internal links. In some cases it has references like "p37" for a page number (is that always consistent?). In other cases it's something more complex such as `01-Chapter%2001_Evidence%20Manual.indd:.20300:2432`. I don't know how the internal identifiers are made available to the code.

pdfjs has some of its implementation here: https://github.com/mozilla/pdf.js/blob/1b79b0cd210e38aab6e3420de5fe862a1c7f56c7/web/pdf_link_service.js#L183