### PR TITLE
Use gthread not gevent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y libreoffice poppler-utils
 
 # Production-only dependencies
-RUN pip install psycopg2==2.9.3 gevent==21.12.0 gunicorn==20.1.0
+RUN pip install psycopg2==2.9.3 gunicorn==20.1.0
 
 # node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn --worker-class gevent --workers 4 --worker-connections 15 peachjam.wsgi:application -t 600 --log-file -
+web: gunicorn --worker-class gthread --workers 2 --threads 8 peachjam.wsgi:application -t 600 --log-file -
 tasks: python manage.py process_tasks


### PR DESCRIPTION
* use gthread not gevent
* reduce workers to 2 and use 8 threads in each worker
* this will mean that long-running requests (eg. PDF conversion) don't block other requests

See:

* https://dev.to/lsena/gunicorn-worker-types-how-to-choose-the-right-one-4n2c 
* https://luis-sena.medium.com/gunicorn-vs-python-gil-221e673d692 