### PR TITLE
Increase ranker bulk update timeout

### DIFF
--- a/peachjam/graph/ranker.py
+++ b/peachjam/graph/ranker.py
@@ -117,5 +117,5 @@ class GraphRanker:
             SearchableDocument._index._get_connection(),
             actions,
             chunk_size=1000,
-            request_timeout=60,
+            request_timeout=60 * 60 * 30,
         )


### PR DESCRIPTION
- the ranker keeps timing out when doing the bulk update. This increases the time to 30 minutes which is hopefully enough time to update the index.