### PR TITLE
Ensure super().get_base_queryset is used

### DIFF
--- a/africanlii/views/agp.py
+++ b/africanlii/views/agp.py
@@ -8,8 +8,7 @@ class AGPLegalInstrumentListView(FilteredDocumentListView):
     navbar_link = "legal_instruments"
 
     def get_base_queryset(self):
-        qs = super().get_base_queryset()
-        return qs.filter(frbr_uri_doctype="act").prefetch_related("work", "nature")
+        return super().get_base_queryset().filter(frbr_uri_doctype="act")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
@@ -22,9 +21,7 @@ class AGPSoftLawListView(DocumentListView):
     navbar_link = "soft_law"
 
     def get_base_queryset(self):
-        qs = super().get_base_queryset()
-        qs = qs.exclude(frbr_uri_doctype="doc").prefetch_related("work", "nature")
-        return qs
+        return super().get_base_queryset().exclude(frbr_uri_doctype="doc")
 
 
 class AGPReportsGuidesListView(DocumentListView):
@@ -32,6 +29,4 @@ class AGPReportsGuidesListView(DocumentListView):
     navbar_link = "reports_guides"
 
     def get_base_queryset(self):
-        qs = super().get_base_queryset()
-        qs = qs.filter(frbr_uri_doctype="doc").prefetch_related("work", "nature")
-        return qs
+        return super().get_base_queryset().filter(frbr_uri_doctype="doc")

--- a/peachjam/views/authors.py
+++ b/peachjam/views/authors.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 
-from peachjam.models import Author, CoreDocument
+from peachjam.models import Author
 from peachjam.views.generic_views import FilteredDocumentListView
 
 
@@ -10,9 +10,13 @@ class AuthorDetailView(FilteredDocumentListView):
     navbar_link = "author_detail"
 
     def get_base_queryset(self):
-        return CoreDocument.objects.prefetch_related("nature", "work").filter(
-            Q(genericdocument__author=self.author)
-            | Q(legalinstrument__author=self.author)
+        return (
+            super()
+            .get_base_queryset()
+            .filter(
+                Q(genericdocument__author=self.author)
+                | Q(legalinstrument__author=self.author)
+            )
         )
 
     def get_queryset(self):

--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -27,6 +27,7 @@ class DocumentListView(ListView):
     context_object_name = "documents"
     paginate_by = 50
     model = CoreDocument
+    queryset = CoreDocument.objects.prefetch_related("nature", "work")
 
     def get_base_queryset(self):
         qs = self.queryset if self.queryset is not None else self.model.objects

--- a/peachjam/views/place.py
+++ b/peachjam/views/place.py
@@ -23,8 +23,10 @@ class PlaceDetailView(FilteredDocumentListView):
         return super().get(request, code, *args, **kwargs)
 
     def get_base_queryset(self):
-        return self.model.objects.prefetch_related("work").filter(
-            jurisdiction=self.country, locality=self.locality
+        return (
+            super()
+            .get_base_queryset()
+            .filter(jurisdiction=self.country, locality=self.locality)
         )
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Otherwise we don't get the document language filtering behaviour

Before:

![image](https://github.com/laws-africa/peachjam/assets/4178542/90d8656e-ec5f-47f7-bf7d-956adb861cc0)
