### PR TITLE
Fix for adding generic documents without proper dates

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -225,7 +225,7 @@ class DocumentForm(forms.ModelForm):
                     data["frbr_uri_date"] = parse_date(
                         DateSelectorWidget().value_from_datadict(data, None, "date")
                     ).strftime("%Y-%m-%d")
-                except ValueError:
+                except (ValueError, AttributeError):
                     pass
 
         super().__init__(data, *args, **kwargs)


### PR DESCRIPTION
- Fixes adding generic documents. 
- The error is thrown when the parse_date function returns None and we try to pull the date from it anyway.

fixes #1112