### PR TITLE
when loading changed provisions, ignore 404s

### DIFF
--- a/peachjam/context_processors.py
+++ b/peachjam/context_processors.py
@@ -11,7 +11,9 @@ def general(request):
         "DEBUG": settings.DEBUG,
         "APP_NAME": settings.PEACHJAM["APP_NAME"],
         "SUPPORT_EMAIL": settings.PEACHJAM["SUPPORT_EMAIL"],
-        "SENTRY_DSN_KEY": settings.PEACHJAM["SENTRY_DSN_KEY"],
-        "SENTRY_ENVIRONMENT": settings.PEACHJAM["SENTRY_ENVIRONMENT"],
+        "SENTRY_CONFIG": {
+            "dsn": settings.PEACHJAM["SENTRY_DSN_KEY"],
+            "environment": settings.PEACHJAM["SENTRY_ENVIRONMENT"],
+        },
         "PEACHJAM_SETTINGS": pj_settings(),
     }

--- a/peachjam/js/components/DocDiffs/index.ts
+++ b/peachjam/js/components/DocDiffs/index.ts
@@ -26,8 +26,6 @@ class DocDiffsManager {
     if (response.ok) {
       const { provisions = [] } = await response.json();
       this.decorateChangedProvisions(provisions);
-    } else {
-      throw new Error(response.statusText);
     }
   }
 

--- a/peachjam/js/peachjam.ts
+++ b/peachjam/js/peachjam.ts
@@ -33,6 +33,7 @@ class PeachJam {
   }
 
   setup () {
+    this.setupSentry();
     this.createComponents();
   }
 
@@ -62,6 +63,25 @@ class PeachJam {
         this.components.push(vueComp);
       }
     });
+  }
+
+  private setupSentry () {
+    const el = document.getElementById('sentry-config');
+    const config = el ? JSON.parse(el.innerHTML) : null;
+    // @ts-ignore
+    if (config && window.Sentry) {
+      // @ts-ignore
+      window.Sentry.init({
+        dsn: config.dsn,
+        environment: config.environment,
+        allowUrls: [
+          new RegExp(window.location.host.replace('.', '\\.') + '/static/')
+        ],
+        denyUrls: [
+          new RegExp(window.location.host.replace('.', '\\.') + '/static/lib/pdfjs/')
+        ]
+      });
+    }
   }
 }
 

--- a/peachjam/js/peachjam.ts
+++ b/peachjam/js/peachjam.ts
@@ -79,7 +79,21 @@ class PeachJam {
         ],
         denyUrls: [
           new RegExp(window.location.host.replace('.', '\\.') + '/static/lib/pdfjs/')
-        ]
+        ],
+        beforeSend (event: any) {
+          try {
+            const frames = event.exception.values[0].stacktrace.frames;
+            // if all frames are anonymous, don't send this event
+            // see https://github.com/getsentry/sentry-javascript/issues/3147
+            if (frames && frames.length > 0 && frames.all((f: any) => f.filename === '<anonymous>')) {
+              return null;
+            }
+          } catch (e) {
+            // ignore error, send event
+          }
+
+          return event;
+        }
       });
     }
   }

--- a/peachjam/js/utils/function.ts
+++ b/peachjam/js/utils/function.ts
@@ -3,6 +3,8 @@
 import { TOCItemType } from './types-and-interfaces';
 
 export function scrollToElement (elem: HTMLElement, callback: (element: HTMLElement) => void = () => false, offset: number = 0) {
+  if (window.IntersectionObserver === undefined) return;
+
   // Setup intersection observer
   const observer = new IntersectionObserver((entries, observer) => {
     entries.forEach(entry => {

--- a/peachjam/templates/peachjam/layouts/main.html
+++ b/peachjam/templates/peachjam/layouts/main.html
@@ -8,7 +8,6 @@
 {% endblock %}
 {% block head-js %}
   <script defer src="{% static 'bootstrap/dist/js/bootstrap.bundle.js' %}"></script>
-  <script defer src="{% static 'js/app-prod.js' %}"></script>
   <!-- Small script to add the current user agent to the root HTML element -->
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function () {
@@ -17,23 +16,11 @@
   </script>
   {% if not DEBUG %}
     <!-- sentry -->
-    <script src="https://browser.sentry-cdn.com/7.19.0/bundle.min.js"
-            integrity="sha384-ztBHD5Kyf+YJqkbZijnUhyS5dYdQDCEfB2QjYao1rVJ1qBpQn+WMbafstDcVTHnB"
-            crossorigin="anonymous"></script>
-    <script>
-    window.addEventListener('load', function() {
-      Sentry.init({
-        dsn: '{{ SENTRY_DSN_KEY }}',
-        environment: '{{ SENTRY_ENVIRONMENT }}',
-        allowUrls: [
-          new RegExp(window.location.host.replace(".", "\\.") + "/static/")
-        ],
-        denyUrls: [
-          new RegExp(window.location.host.replace(".", "\\.") + "/static/lib/pdfjs/")
-        ]
-      });
-    });
-    </script>
+    {{ SENTRY_CONFIG|json_script:"sentry-config" }}
+    <script src="https://browser.sentry-cdn.com/7.51.2/bundle.min.js"
+            integrity="sha384-TIc4wz4oU9UgbI5Cu7R/6jhJOszkPGImz+Ney9MXZ3MESAGeYJUOV+36KnTacIXP"
+            crossorigin="anonymous"
+            defer></script>
     {% if PEACHJAM_SETTINGS.google_analytics_id %}
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async
@@ -47,6 +34,8 @@
       </script>
     {% endif %}
   {% endif %}
+  <!-- must be last script to load -->
+  <script defer src="{% static 'js/app-prod.js' %}"></script>
 {% endblock %}
 {% block header %}
   {% include 'peachjam/_header.html' %}


### PR DESCRIPTION
* Fixes https://github.com/laws-africa/peachjam/issues/1199
* Fixes https://github.com/laws-africa/peachjam/issues/1201
* guard against fully-anonymous errors, which don't come from our code
* init sentry is typescript so we can configure it more easily