### PR TITLE
fix redirects

### DIFF
--- a/peachjam/tests/test_resolver.py
+++ b/peachjam/tests/test_resolver.py
@@ -18,8 +18,8 @@ class TestRedirectResolver(TestCase):
     def test_resolver_africanlii(self):
         resolver = RedirectResolver("africanlii")
         domains = [
-            "new.zambialii.org",
-            "new.ulii.org",
+            "zambialii.org",
+            "ulii.org",
             "lawlibrary.org.za",
             "lawlibrary.org.za",
             "new.tanzlii.org",
@@ -38,8 +38,8 @@ class TestRedirectResolver(TestCase):
         resolver = RedirectResolver("zanzibarlii")
 
         domains = [
-            "new.zambialii.org",
-            "new.ulii.org",
+            "zambialii.org",
+            "ulii.org",
             "lawlibrary.org.za",
             "lawlibrary.org.za",
             "new.tanzlii.org",
@@ -57,8 +57,8 @@ class TestRedirectResolver(TestCase):
         resolver = RedirectResolver("tanzlii")
 
         domains = [
-            "new.zambialii.org",
-            "new.ulii.org",
+            "zambialii.org",
+            "ulii.org",
             "lawlibrary.org.za",
             "lawlibrary.org.za",
             None,

--- a/peachjam/views/documents.py
+++ b/peachjam/views/documents.py
@@ -20,7 +20,7 @@ class RedirectResolver:
         },
         "ghalii": {
             "country_code": "gh",
-            "domain": "new.ghalii.org",
+            "domain": "ghalii.org",
         },
         "lawlibrary": {
             "country_code": "za",
@@ -28,7 +28,7 @@ class RedirectResolver:
         },
         "lesotholii": {
             "country_code": "ls",
-            "domain": "new.lesotholii.org",
+            "domain": "lesotholii.org",
         },
         "malawilii": {
             "country_code": "mw",
@@ -44,11 +44,11 @@ class RedirectResolver:
         },
         "seylii": {
             "country_code": "sc",
-            "domain": "new.seylii.org",
+            "domain": "seylii.org",
         },
         "sierralii": {
             "country_code": "sl",
-            "domain": "new.sierralii.org",
+            "domain": "sierralii.org",
         },
         "tanzlii": {
             "country_code": "tz",
@@ -56,15 +56,15 @@ class RedirectResolver:
         },
         "tcilii": {
             "country_code": "tc",
-            "domain": "new.tcilii.org",
+            "domain": "tcilii.org",
         },
         "ulii": {
             "country_code": "ug",
-            "domain": "new.ulii.org",
+            "domain": "ulii.org",
         },
         "zambialii": {
             "country_code": "zm",
-            "domain": "new.zambialii.org",
+            "domain": "zambialii.org",
         },
         "zanzibarlii": {
             "place_code": "tz-znz",

--- a/seylii/settings.py
+++ b/seylii/settings.py
@@ -12,6 +12,7 @@ JAZZMIN_SETTINGS["site_brand"] = "seylii.org"  # noqa
 COURT_CODE_MAPPINGS = {
     "constitutional-court": "SCCC",
     "court-of-appeal": "SCCA",
+    "court-appeal": "SCCA",
     "supreme-court": "SCSC",
 }
 LANGUAGES = [


### PR DESCRIPTION
* old seylii judgments use `court-appeal` not `court-of-appeal`: eg https://old2.seylii.org/sc/judgment/court-appeal/2023/8
* remove `new.` for sites that have been migrated
