### PR TITLE
additional logging

### DIFF
--- a/peachjam/resources.py
+++ b/peachjam/resources.py
@@ -93,9 +93,11 @@ class SourceFileWidget(CharWidget):
                             file.seek(0)
                             attempt += 1
                             try:
+                                logger.info(
+                                    f"converting file from {source_url} to html (attempt {attempt})"
+                                )
                                 soffice_convert(file, suffix, "html")
-                                if attempt > 1:
-                                    logger.info(f"soffice success on attempt {attempt}")
+                                logger.info(f"soffice success on attempt {attempt}")
                                 break
                             except SOfficeError as e:
                                 logger.warning(


### PR DESCRIPTION
We are seeing repeat attempts, but the current logging doesn't make sense, so I'm adding more.

We're seeing logs like this, which seems to imply it never succeeds??

```
2023-05-15 12:30:23 INFO resources 3c49b374e2b45ba2b9404302a7270b1d 9 140690579257088 Importing row: OrderedDict([('skip', ''), ('jurisdiction', 'SZ'), ('language', 'eng'), ('case_name', 'Hlatshwayo v Lukhele'), ('case_string_override', 'Civil Case 4551 of 2007'), ('matter_type', 'Civil Case'), ('case_number_numeric', '4551'), ('case_number_year', '2007'), ('court', 'SZHC'), ('source_url', 'https://media.eswatinilii.org/files/judgments/szhc/2008/22/2008-szhc-22.rtf'), ('headnote_holding', ''), ('serial_number_override', '22'), ('judges', ''), ('date', '2008-03-07'), ('created_by', 4)])
2023-05-15 12:30:49 INFO resources 3c49b374e2b45ba2b9404302a7270b1d 9 140690579257088 Importing row: OrderedDict([('skip', ''), ('jurisdiction', 'SZ'), ('language', 'eng'), ('case_name', 'Swazi National Assemblies of God v DSG Investments and Others '), ('case_string_override', '2472 of 2008'), ('matter_type', ''), ('case_number_numeric', '2472'), ('case_number_year', '2008'), ('court', 'SZHC'), ('source_url', 'https://media.eswatinilii.org/files/judgments/szhc/2008/38/2008-szhc-38.rtf|https://media.eswatinilii.org/files/judgments/szhc/2008/38/2008-szhc-38.pdf'), ('headnote_holding', ''), ('serial_number_override', '38'), ('judges', ''), ('date', '2008-10-03'), ('created_by', 4)])
2023-05-15 12:31:18 WARNING resources 3c49b374e2b45ba2b9404302a7270b1d 9 140690579257088 soffice error on attempt 1 of 3
Traceback (most recent call last):
  File "/app/peachjam/resources.py", line 108, in clean
    soffice_convert(file, suffix, "html")
  File "/usr/local/lib/python3.8/site-packages/docpipe/soffice.py", line 71, in soffice_convert
    raise SOfficeError("soffice was unable to extract content from the file")
docpipe.soffice.SOfficeError
2023-05-15 12:31:27 INFO resources 3c49b374e2b45ba2b9404302a7270b1d 9 140690579257088 Importing row: OrderedDict([('skip', ''), ('jurisdiction', 'SZ'), ('language', 'eng'), ('case_name', 'Greenhead v Dube and Another'), ('case_string_override', '2234 of 2007'), ('matter_type', ''), ('case_number_numeric', '2234'), ('case_number_year', '2007'), ('court', 'SZHC'), ('source_url', 'https://media.eswatinilii.org/files/judgments/szhc/2008/19/2008-szhc-19.rtf'), ('headnote_holding', ''), ('serial_number_override', '19'), ('judges', ''), ('date', '2008-02-15'), ('created_by', 4)])
2023-05-15 12:31:29 INFO resources 3c49b374e2b45ba2b9404302a7270b1d 9 140690579257088 Importing row: OrderedDict([('skip', ''), ('jurisdiction', 'SZ'), ('language', 'eng'), ('case_name', 'R v Gama '), ('case_string_override', '206 of 2002'), ('matter_type', ''), ('case_number_numeric', '206'), ('case_number_year', '2002'), ('court', 'SZHC'), ('source_url', 'https://media.eswatinilii.org/files/judgments/szhc/2008/63/2008-szhc-63.rtf|https://media.eswatinilii.org/files/judgments/szhc/2008/63/2008-szhc-63.pdf'), ('headnote_holding', ''), ('serial_number_override', '63'), ('judges', ''), ('date', '2008-06-30'), ('created_by', 4)])

```