### PR TITLE
Fix for gazettes adapter to not delete gazettes unnecessarily

### DIFF
--- a/peachjam/adapters/adapters.py
+++ b/peachjam/adapters/adapters.py
@@ -338,7 +338,7 @@ class IndigoAdapter(Adapter):
     def get_content_html(self, document):
         if document["stub"]:
             return None
-        return self.client_get(document["url"] + ".html").text
+        return self.client_get(document["url"] + ".html?resolver=none").text
 
     def get_toc_json(self, url):
         def remove_subparagraph(d):

--- a/peachjam/adapters/gazettes.py
+++ b/peachjam/adapters/gazettes.py
@@ -36,7 +36,7 @@ class GazetteAdapter(Adapter):
             .using("gazettes_africa")
         )
         # start building queryset for deleted gazettes
-        deleted_qs = Gazette.objects.filter(jurisdiction=self.jurisdiction)
+        deleted_qs = Gazette.objects
 
         if "-" not in self.jurisdiction:
             # locality code not specified hence None e.g "ZA"
@@ -48,6 +48,7 @@ class GazetteAdapter(Adapter):
             )
         else:
             updated_qs = updated_qs.filter(jurisdiction=self.jurisdiction.split("-")[0])
+            deleted_qs = deleted_qs.filter(jurisdiction=self.jurisdiction.split("-")[0])
 
             # locality code present e.g. "ZA-gp"
             if self.jurisdiction.split("-")[1] != "*":

--- a/peachjam/adapters/gazettes.py
+++ b/peachjam/adapters/gazettes.py
@@ -43,6 +43,9 @@ class GazetteAdapter(Adapter):
             updated_qs = updated_qs.filter(
                 jurisdiction=self.jurisdiction, locality=None
             )
+            deleted_qs = deleted_qs.filter(
+                jurisdiction=self.jurisdiction, locality=None
+            )
         else:
             updated_qs = updated_qs.filter(jurisdiction=self.jurisdiction.split("-")[0])
 


### PR DESCRIPTION
This fixes an issue when there are gazettes in a locality. The deleted queryset was previously not limiting the locality to `None` when looking for gazettes to delete, and so gazettes in localities were being deleted incorrectly.

This also changes the Indigo adapter to specify `resolver=none` when fetching HTML. This means that links to legislation will use the local link and not go through `resolver.laws.africa` which is unecessary. This will fix extracted citations for HTML legislation, which were currently not working. eg https://lawlibrary.org.za/akn/za/act/2021/2/eng@2021-06-04 cites the Constitution but that's not included in the "Citations" tab.

The second fix will require all legislation on all LIIs to be updated.