### PR TITLE
specify lang attribute on document content 

### DIFF
--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -118,6 +118,7 @@
           data-document-element
           frbr-expression-uri="{{ document.expression_frbr_uri }}"
           class="flash-target"
+          lang="{{ document.language.iso }}"
           >
           <la-decorate-terms popup-definitions link-terms></la-decorate-terms>
           <la-decorate-internal-refs flag popups></la-decorate-internal-refs>
@@ -125,7 +126,11 @@
           </la-akoma-ntoso>
         {% endif %}
         {% if display_type == 'html' %}
-          <div class="content content__html" data-document-element>{{ document.content_html|safe }}</div>
+          <div class="content content__html"
+               lang="{{ document.language.iso }}"
+               data-document-element>
+            {{ document.content_html|safe }}
+          </div>
         {% endif %}
         {% if display_type == 'pdf' %}
           <div class="content" data-document-element>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -16,6 +16,13 @@
   {% if not document.allow_robots %}<meta name="robots" content="noindex" />{% endif %}
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:title" content="{{ document.title }}"/>
+  {% if language_versions|length > 1 %}
+    {% for version in language_versions %}
+      <link rel="alternate"
+            hreflang="{{ version.language.iso }}"
+            href="{{ request.scheme }}://{{ request.get_host }}{{ version.get_absolute_url }}"/>
+    {% endfor %}
+  {% endif %}
 {% endblock %}
 {% block page-content %}
   <div class="pb-5">
@@ -260,8 +267,9 @@
                                 {% for version in language_versions %}
                                   <li>
                                     <a class="dropdown-item {% if version.pk == document.pk %}active{% endif %}"
-                                       href="{{ request.scheme }}://{{ request.get_host }}{{ version.get_absolute_url }}"
-                                       hreflang="{{ version.language.iso }}">{% trans version.language.name %}</a>
+                                       rel="alternate"
+                                       hreflang="{{ version.language.iso }}"
+                                       href="{{ request.scheme }}://{{ request.get_host }}{{ version.get_absolute_url }}">{{ version.language.iso }}">{% trans version.language.name %}</a>
                                   </li>
                                 {% endfor %}
                               </ul>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -260,7 +260,8 @@
                                 {% for version in language_versions %}
                                   <li>
                                     <a class="dropdown-item {% if version.pk == document.pk %}active{% endif %}"
-                                       href="{{ version.get_absolute_url }}">{% trans version.language.name %}</a>
+                                       href="{{ request.scheme }}://{{ request.get_host }}{{ version.get_absolute_url }}"
+                                       hreflang="{{ version.language.iso }}">{% trans version.language.name %}</a>
                                   </li>
                                 {% endfor %}
                               </ul>


### PR DESCRIPTION
* specify lang attribute on document content 
* include hreflang for alternate language links (standard requires a full URL) (a tags)
* include `<link rel="alternate"` tags for language versions

![image](https://github.com/laws-africa/peachjam/assets/4178542/5cc1e863-538b-4e46-9c8b-d7833540dccc)


![image](https://github.com/laws-africa/peachjam/assets/4178542/7af2ca58-7511-41c7-80a3-3e9615e32bf6)

Closes #1159 
