### PR TITLE
search expanded title (title and citation)

### DIFF
--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -246,6 +246,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
 
     search_fields = {
         "title": {"boost": 6},
+        "title_expanded": {"boost": 4},
         "authors": None,
         "citation": {"boost": 4},
         "judges": None,


### PR DESCRIPTION
Before this, searches that used by the title and the citation in the full search didn't match well. Now they do.

Before:

![image](https://github.com/laws-africa/peachjam/assets/4178542/f33c0a49-c5cb-4cad-bd9f-46bece0ce0d3)


After:

![Search - lawlibrary 2023-05-19 17-04-13](https://github.com/laws-africa/peachjam/assets/4178542/56a601f6-69ca-4c5c-975c-af11af5ee0d3)
