### PR TITLE
Reduce repitition; simplify metabase stats view

### DIFF
--- a/africanlii/templates/peachjam/_footer.html
+++ b/africanlii/templates/peachjam/_footer.html
@@ -2,9 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% block first-content-column %}
-  <div class="mb-3">
-    <strong>{% trans 'About AfricanLII' %}</strong>
-  </div>
+  <h5>{% trans 'About' %} {{ APP_NAME }}</h5>
   <p>
     {% blocktrans trimmed %}
       AfricanLII is an open-access research platform for African law jointly operated by the AfricanLII programme of
@@ -22,9 +20,11 @@
   <div>
     <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
   </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
+  {% if PEACHJAM_SETTINGS.metabase_dashboard_link %}
+    <div>
+      <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
+    </div>
+  {% endif %}
 {% endblock %}
 {% block second-content-column %}
   <div class="mb-2">

--- a/eswatinilii/templates/peachjam/_footer.html
+++ b/eswatinilii/templates/peachjam/_footer.html
@@ -6,12 +6,6 @@
       ESwatiniLII is a free access to law website by the Judiciary of eSwatini. eSwatiniLII exists to provide free access to the law for everyone, as a fundamental right of every citizen to know the law that governs them.
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/ghalii/templates/peachjam/_footer.html
+++ b/ghalii/templates/peachjam/_footer.html
@@ -30,12 +30,6 @@
       GhaLII's objectives include promotion of access to legal information from Ghana as a fundamental part of the rule of law.
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/lawlibrary/templates/peachjam/_footer.html
+++ b/lawlibrary/templates/peachjam/_footer.html
@@ -40,12 +40,6 @@
       <a href="http://www.falm.info/declaration/">Montreal Declaration on Free Access to Law.</a>
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/lesotholii/templates/peachjam/_footer.html
+++ b/lesotholii/templates/peachjam/_footer.html
@@ -27,12 +27,6 @@
   <p>
     The Lesotho Legal Information Institute (LesLII) was set up in 2012. LesLII's mission is to publish the laws of Lesotho for free access to everyone.  LesLII is supported by the Judiciary of Lesotho, the Law Office, the Law Society and other justice sector stakeholders. AfricanLII and Laws.Africa provide technical support to LesLII.
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/liiweb/templates/peachjam/_footer.html
+++ b/liiweb/templates/peachjam/_footer.html
@@ -17,8 +17,18 @@
   <hr/>
 {% endblock %}
 {% block first-content-column %}
-  <h5>{% trans 'About' %}</h5>
+  <h5>{% trans 'About' %} {{ APP_NAME }}</h5>
   {% block about %}{% endblock %}
+  {% block first-content-column-links %}
+    <div>
+      <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
+    </div>
+    {% if PEACHJAM_SETTINGS.metabase_dashboard_link %}
+      <div>
+        <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
+      </div>
+    {% endif %}
+  {% endblock %}
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/malawilii/templates/peachjam/_footer.html
+++ b/malawilii/templates/peachjam/_footer.html
@@ -6,12 +6,6 @@
       The Malawi Legal Information Institute (MalawiLII) was launched in 2009 as an online resource that provides free access to the laws of Malawi.
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/namiblii/templates/peachjam/_footer.html
+++ b/namiblii/templates/peachjam/_footer.html
@@ -10,12 +10,6 @@
   <p>
     NamibLII is the embodiment of this mandate making annotated statutes, judgments, and gazettes available in a user-friendly format.
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/peachjam/templates/peachjam/metabase_stats.html
+++ b/peachjam/templates/peachjam/metabase_stats.html
@@ -7,7 +7,10 @@
   <section class="py-5">
     <div class="container">
       <h1 class="mb-4">{{ APP_NAME }} {% trans 'Statistics' %}</h1>
-      <iframe src={{ metabase_embed }} style="display:block; width:100%; height:190vh;"></iframe>
+      <iframe src="{{ PEACHJAM_SETTINGS.metabase_dashboard_link }}"
+              style="display:block;
+                     width:100%;
+                     height:190vh"></iframe>
     </div>
   </section>
 {% endblock %}

--- a/peachjam/views/metabase_stats.py
+++ b/peachjam/views/metabase_stats.py
@@ -8,9 +8,6 @@ class MetabaseStatsView(TemplateView):
     template_name = "peachjam/metabase_stats.html"
 
     def get(self, request, *args, **kwargs):
-        if pj_settings().metabase_dashboard_link:
-            context = self.get_context_data(**kwargs)
-            context["metabase_embed"] = pj_settings().metabase_dashboard_link
-            return self.render_to_response(context)
-        else:
+        if not pj_settings().metabase_dashboard_link:
             raise Http404
+        return super().get(request, *args, **kwargs)

--- a/seylii/templates/peachjam/_footer.html
+++ b/seylii/templates/peachjam/_footer.html
@@ -12,12 +12,6 @@
       SeyLII was established in 2012 under the auspices of the Judiciary of Seychelles and with the support of AfricanLII. It became an independent registered association in 2015. SeyLII is a member of the international Free Access to Law Movement and subscribes to the principles of the <a href="http://www.fatlm.org/declaration/">Declaration on Free Access to Law.</a>
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/sierralii/templates/peachjam/_footer.html
+++ b/sierralii/templates/peachjam/_footer.html
@@ -27,12 +27,6 @@
   <p>
     SierraLII provides free, unrestricted access to the primary and secondary legal materials of Sierra Leone.  Free Access to Law supports the rule of law, access to justice and transparency.
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/tcilii/templates/peachjam/_footer.html
+++ b/tcilii/templates/peachjam/_footer.html
@@ -44,13 +44,6 @@
       Free access to legal information is a primary tenet of any sound justice system. We seek to serve the community in the TCI and beyond.
     {% endblocktrans %}
   </p>
-  <br/>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/ulii/templates/peachjam/_footer.html
+++ b/ulii/templates/peachjam/_footer.html
@@ -41,12 +41,6 @@
       ULII is also an end user interface for the Electronic Court Case Management Information System.
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/zambialii/templates/peachjam/_footer.html
+++ b/zambialii/templates/peachjam/_footer.html
@@ -42,12 +42,6 @@
       <a href="https://drive.google.com/file/d/1FRH3SqmlgeJAtTNPv0wemSGmltM5pwYy/view" target="_blank" rel="noreferrer">View the ZambiaLII Brochure</a>
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>

--- a/zimlii/templates/peachjam/_footer.html
+++ b/zimlii/templates/peachjam/_footer.html
@@ -31,12 +31,6 @@
     ZimLII is a member of the global Free Access to Law Movement and works closely with the African and international free access to law community to promote justice and rule of law by maximising access at no cost to public legal information.
     {% endblocktrans %}
   </p>
-  <div>
-    <a href="{% url 'terms_of_use' %}">{% trans 'Terms of Use' %}</a>
-  </div>
-  <div>
-    <a href="{% url 'metabase_stats' %}">{% trans 'Site Statistics' %}</a>
-  </div>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>


### PR DESCRIPTION
* reduce repetition in templates -- rather than copy-and-paste, adjust templates so that we can inherit functionality
* settings are already injected into the view, no need to duplicate
* don't add a link to the site if it's going to 404