### PR TITLE
Bug fix for author import field

### DIFF
--- a/peachjam/resources.py
+++ b/peachjam/resources.py
@@ -379,10 +379,6 @@ class ManyToManyFieldWidget(ManyToManyWidget):
 
 
 class GenericDocumentResource(BaseDocumentResource):
-    author = fields.Field(
-        attribute="author",
-        widget=ForeignKeyWidget(Author, field="code__iexact"),
-    )
     nature = fields.Field(
         column_name="nature",
         attribute="nature",
@@ -391,7 +387,7 @@ class GenericDocumentResource(BaseDocumentResource):
     authors = fields.Field(
         column_name="authors",
         attribute="authors",
-        widget=ManyToManyFieldWidget(Author, separator="|", field="name"),
+        widget=ManyToManyFieldWidget(Author, separator="|", field="code__iexact"),
     )
 
     class Meta(BaseDocumentResource.Meta):


### PR DESCRIPTION
We were previously using the value in the authors column as the name of the author, instead of using it as the code. The resultant effect is that we're creating authors, instead of filtering them and then updating their document.