### PR TITLE
redirect new.foo to foo; agp.africanlii.org to africanlii.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,14 @@ concurrency:
 
 jobs:
   deploy-agp:
-    name: Deploy to agp.africanlii.org
+    name: Deploy to africanlii.org
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: git push to agp.africanlii.org
+    - name: git push to africanlii.org
       uses: dokku/github-action@master
       with:
         ssh_private_key: ${{ secrets.SSH_DEPLOYMENT_KEY }}

--- a/eswatinilii/templates/peachjam/_footer.html
+++ b/eswatinilii/templates/peachjam/_footer.html
@@ -10,7 +10,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -32,7 +32,7 @@
            alt="Laws.Africa"/>
     </a>
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/ghalii/templates/peachjam/_footer.html
+++ b/ghalii/templates/peachjam/_footer.html
@@ -34,7 +34,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -46,7 +46,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>

--- a/lawlibrary/templates/peachjam/_footer.html
+++ b/lawlibrary/templates/peachjam/_footer.html
@@ -44,7 +44,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="http://www.jifa.uct.ac.za/" target="_blank" rel="noreferrer">JIFA</a>
@@ -73,7 +73,7 @@
            alt="Laws.Africa"/>
     </a>
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/lesotholii/templates/peachjam/_footer.html
+++ b/lesotholii/templates/peachjam/_footer.html
@@ -31,7 +31,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -43,7 +43,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>

--- a/liiweb/templates/peachjam/_footer.html
+++ b/liiweb/templates/peachjam/_footer.html
@@ -33,7 +33,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -106,7 +106,7 @@
            alt="Laws.Africa"/>
     </a>
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>

--- a/malawilii/templates/peachjam/_footer.html
+++ b/malawilii/templates/peachjam/_footer.html
@@ -10,7 +10,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://namati.org/network/organization/the-gender-and-justice-unit/"
@@ -46,7 +46,7 @@
            alt="Laws.Africa"/>
     </a>
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/namiblii/templates/peachjam/_footer.html
+++ b/namiblii/templates/peachjam/_footer.html
@@ -14,7 +14,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -26,7 +26,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "log_request_id.middleware.RequestIDMiddleware",
     "peachjam.middleware.RedirectWWWMiddleware",
+    "peachjam.middleware.RedirectNewMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -282,7 +282,8 @@ if not DEBUG:
         environment=PEACHJAM["SENTRY_ENVIRONMENT"],
         integrations=[DjangoIntegration(), sentry_logging],
         send_default_pii=True,
-        traces_sample_rate=0.5,  # sample 50% of requests for performance metrics
+        # sample x% of requests for performance metrics
+        traces_sample_rate=float(os.environ.get("SENTRY_SAMPLE_RATE", "0.25")),
     )
 
 DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}

--- a/peachjam/tests/test_resolver.py
+++ b/peachjam/tests/test_resolver.py
@@ -22,7 +22,7 @@ class TestRedirectResolver(TestCase):
             "ulii.org",
             "lawlibrary.org.za",
             "lawlibrary.org.za",
-            "new.tanzlii.org",
+            "tanzlii.org",
             "zanzibarlii.org",
             None,
         ]
@@ -42,9 +42,9 @@ class TestRedirectResolver(TestCase):
             "ulii.org",
             "lawlibrary.org.za",
             "lawlibrary.org.za",
-            "new.tanzlii.org",
+            "tanzlii.org",
             None,
-            "agp.africanlii.org",
+            "africanlii.org",
         ]
         results = zip(urls, domains)
         for result in results:
@@ -63,7 +63,7 @@ class TestRedirectResolver(TestCase):
             "lawlibrary.org.za",
             None,
             "zanzibarlii.org",
-            "agp.africanlii.org",
+            "africanlii.org",
         ]
         results = zip(urls, domains)
         for result in results:

--- a/peachjam/views/documents.py
+++ b/peachjam/views/documents.py
@@ -16,7 +16,7 @@ class RedirectResolver:
     RESOLVER_MAPPINGS = {
         "africanlii": {
             "country_code": "aa",
-            "domain": "agp.africanlii.org",
+            "domain": "africanlii.org",
         },
         "ghalii": {
             "country_code": "gh",
@@ -52,7 +52,7 @@ class RedirectResolver:
         },
         "tanzlii": {
             "country_code": "tz",
-            "domain": "new.tanzlii.org",
+            "domain": "tanzlii.org",
         },
         "tcilii": {
             "country_code": "tc",

--- a/seylii/templates/peachjam/_footer.html
+++ b/seylii/templates/peachjam/_footer.html
@@ -16,7 +16,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://www.judiciary.sc/" target="_blank" rel="noreferrer">Seychelles Judiciary</a>
@@ -34,7 +34,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/sierralii/templates/peachjam/_footer.html
+++ b/sierralii/templates/peachjam/_footer.html
@@ -31,7 +31,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -43,7 +43,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>

--- a/tanzlii/templates/peachjam/_footer.html
+++ b/tanzlii/templates/peachjam/_footer.html
@@ -41,7 +41,7 @@
     {% block second-content-column %}
       <h5>{% trans 'Our partners' %}</h5>
       <div>
-        <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+        <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
       </div>
       <div>
         <a href="https://www.judiciary.go.tz/web/"
@@ -55,7 +55,7 @@
     {% block footer-logos %}
       <div class="footer-logos">
         <a class="footer-logos__item"
-           href="https://agp.africanlii.org/"
+           href="https://africanlii.org/"
            target="_blank"
            rel="noreferrer">
           <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/tcilii/templates/peachjam/_footer.html
+++ b/tcilii/templates/peachjam/_footer.html
@@ -48,7 +48,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -98,7 +98,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/ulii/templates/peachjam/_footer.html
+++ b/ulii/templates/peachjam/_footer.html
@@ -45,7 +45,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -57,7 +57,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>

--- a/zambialii/templates/peachjam/_footer.html
+++ b/zambialii/templates/peachjam/_footer.html
@@ -46,7 +46,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -67,7 +67,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/zanzibarlii/templates/peachjam/_footer.html
+++ b/zanzibarlii/templates/peachjam/_footer.html
@@ -38,7 +38,7 @@
   {% block second-content-column %}
     <h5>{% trans 'Our partners' %}</h5>
     <div>
-      <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+      <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
     </div>
     <div>
       <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -47,7 +47,7 @@
   {% block footer-logos %}
     <div class="footer-logos">
       <a class="footer-logos__item"
-         href="https://agp.africanlii.org/"
+         href="https://africanlii.org/"
          target="_blank"
          rel="noreferrer">
         <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />

--- a/zimlii/templates/peachjam/_footer.html
+++ b/zimlii/templates/peachjam/_footer.html
@@ -35,7 +35,7 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://agp.africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
   </div>
   <div>
     <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
@@ -51,7 +51,7 @@
 {% block footer-logos %}
   <div class="footer-logos">
     <a class="footer-logos__item"
-       href="https://agp.africanlii.org/"
+       href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>


### PR DESCRIPTION
* also reduce sentry tracing sample rate to 25% of queries, we're going through our free tier too quickly