### PR TITLE
Fix court registries list

### DIFF
--- a/peachjam/helpers.py
+++ b/peachjam/helpers.py
@@ -48,3 +48,9 @@ def pdfjs_to_text(fname):
 
         subprocess.run(cmd, check=True)
         return outf.read().decode("utf-8")
+
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from list."""
+    for i in range(n):
+        yield lst[i::n]

--- a/peachjam/templates/peachjam/_registries.html
+++ b/peachjam/templates/peachjam/_registries.html
@@ -7,14 +7,14 @@
         <ul class="list-unstyled">
           {% for r in group %}
             {% if r.code == registry.code %}
-              <li class="disabled">{{ r.name }}</li>
+              <li>{{ r.name }}</li>
             {% else %}
-              <li>
+              <li class="inactive">
                 <a href="{{ r.get_absolute_url }}">{{ r.name }}</a>
               </li>
             {% endif %}
-          </ul>
-        {% endfor %}
+          {% endfor %}
+        </ul>
       </div>
     {% endfor %}
   </div>

--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 
-from peachjam.helpers import lowercase_alphabet
+from peachjam.helpers import chunks, lowercase_alphabet
 from peachjam.models import Court, CourtRegistry, Judgment
 from peachjam.views.generic_views import FilteredDocumentListView
 
@@ -68,11 +68,7 @@ class CourtDetailView(FilteredDocumentListView):
             judgments__isnull=True
         )  # display registries with judgments only
 
-        registry_group = max([len(context["registries"]) // 2, 1])
-        context["registry_groups"] = (
-            context["registries"][:registry_group],
-            context["registries"][registry_group:],
-        )
+        context["registry_groups"] = list(chunks(context["registries"], 2))
 
         order_outcomes = list(
             {

--- a/peachjam/views/gazette.py
+++ b/peachjam/views/gazette.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.dates import MONTHS
 from django.views.generic import TemplateView
 
+from peachjam.helpers import chunks
 from peachjam.models import Gazette, Locality
 from peachjam.registry import registry
 from peachjam.views.generic_views import BaseDocumentDetailView, DocumentListView
@@ -61,11 +62,7 @@ class GazetteListView(TemplateView):
             )
             context["localities"] = Locality.objects.filter(pk__in=locality_ids)
 
-        loc_group = max([len(context["localities"]) // 2, 1])
-        context["locality_groups"] = (
-            context["localities"][:loc_group],
-            context["localities"][loc_group:],
-        )
+        context["locality_groups"] = list(chunks(context["localities"], 2))
 
         if not self.locality:
             # counts and years for gazettes at the top-level?


### PR DESCRIPTION
This PR:
- Fixes the court registry listing on the court detail and court registry detail pages.
- Adds a `chunks` helper method that splits a list into n-sized chunks.

https://www.loom.com/share/803b90b4377f48ca93f1d81b114b4c69?sid=4a8c2776-8816-4612-8c00-52f1f08fb75a