### PR TITLE
Better control of when to show jurisdiction filter

### DIFF
--- a/africanlii/settings.py
+++ b/africanlii/settings.py
@@ -8,7 +8,7 @@ JAZZMIN_SETTINGS["site_title"] = "Africanlii"  # noqa
 JAZZMIN_SETTINGS["site_header"] = "Africanlii"  # noqa
 JAZZMIN_SETTINGS["site_brand"] = "Agp.africanlli.org"  # noqa
 
-EXTRA_SEARCH_INDEXES = [
+PEACHJAM["EXTRA_SEARCH_INDEXES"] = [  # noqa
     "ghalii",
     "lawlibrary",
     "lesotholii",
@@ -24,6 +24,7 @@ EXTRA_SEARCH_INDEXES = [
     "zanzibarlii",
     "zimlii",
 ]
+PEACHJAM["SEARCH_JURISDICTION_FILTER"] = True  # noqa
 
 # The slugs of the taxonomy roots that are treated as federated indexes
 FEDERATED_DOC_INDEX_ROOTS = ["case-indexes"]

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -115,6 +115,8 @@ PEACHJAM = {
         "CITATOR_API", "https://api.laws.africa/citator/v1/extract-citations"
     ),
     "CITATOR_API_KEY": os.environ.get("CITATOR_API_KEY"),
+    "EXTRA_SEARCH_INDEXES": [],
+    "SEARCH_JURISDICTION_FILTER": False,
 }
 
 PEACHJAM["ES_INDEX"] = os.environ.get("ES_INDEX", slugify(PEACHJAM["APP_NAME"]))
@@ -257,8 +259,6 @@ ELASTICSEARCH_MAX_ANALYZED_OFFSET = os.environ.get(
 ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = (
     "peachjam_search.tasks.BackgroundTaskSearchProcessor"
 )
-
-EXTRA_SEARCH_INDEXES = []
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -261,7 +261,7 @@ def get_search_indexes(base_index):
         + [f"{base_index}_{lang}" for lang in ANALYZERS.keys()]
         + [
             f"{i}_{lang}"
-            for i in settings.EXTRA_SEARCH_INDEXES
+            for i in settings.PEACHJAM["EXTRA_SEARCH_INDEXES"]
             for lang in ANALYZERS.keys()
         ]
     )

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -196,7 +196,7 @@ class SearchView(TemplateView):
             "author": Author.model_label,
             "searchPlaceholder": search_placeholder_text,
         }
-        context["show_jurisdiction"] = bool(settings.EXTRA_SEARCH_INDEXES)
+        context["show_jurisdiction"] = settings.PEACHJAM["SEARCH_JURISDICTION_FILTER"]
         return context
 
 


### PR DESCRIPTION
Otherwise gazettes.africa doesn't show it correctly. Corresponding fix for Gazettes.Africa to follow shortly.