### PR TITLE
Force input boxes on mobile to use 16px fonts

### DIFF
--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -133,7 +133,6 @@ footer {
   font-size: 22px;
 }
 
-
 @each $state, $value in $theme-colors {
   .alert-#{$state} {
     $alert-color: shift-color($value, $alert-color-scale);
@@ -150,4 +149,11 @@ footer {
 
 html[data-user-agent*='pocketlaw'] .pocketlaw-hidden {
   display: none;
+}
+
+// force font size on mobile to 16 px
+@include media-breakpoint-down(sm) {
+  input {
+    font-size: 16px !important;
+  }
 }


### PR DESCRIPTION
Otherwise, iphone zooms into the input box, which is a weird experience.

We wouldn't have this issue if our base font size was 1rem (usually 16px), but we reduce it because otherwise the site's font size is too large.

See https://makersaid.com/disable-safari-auto-zoom-on-form/