### PR TITLE
Search improvements

### DIFF
--- a/peachjam/resources.py
+++ b/peachjam/resources.py
@@ -250,7 +250,6 @@ class BaseDocumentResource(resources.ModelResource):
 
     class Meta:
         exclude = (
-            "created_at",
             "updated_at",
             "source_file",
             "coredocument_ptr",

--- a/peachjam/resources.py
+++ b/peachjam/resources.py
@@ -303,7 +303,8 @@ class BaseDocumentResource(resources.ModelResource):
     def before_import_row(self, row, **kwargs):
         if kwargs.get("user"):
             row["created_by"] = kwargs["user"].id
-        logger.info(f"Importing row: {row}")
+        if not row.get("skip"):
+            logger.info(f"Importing row: {row}")
 
     def skip_row(self, instance, original, row, import_validation_errors=None):
         return row["skip"]

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -56,6 +56,8 @@ class SearchableDocument(Document):
     # Judgment
     matter_type = fields.KeywordField(attr="matter_type.name")
     case_number = fields.TextField()
+    # this case party names etc. and so the standard analyzer is better than a language-based one
+    case_name = fields.TextField(analyzer="standard")
     court = fields.KeywordField(attr="court.name")
     headnote_holding = fields.TextField()
     flynote = fields.TextField()

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -86,8 +86,9 @@ class NestedPageQueryBackend(BaseSearchQueryBackend):
                     must=[
                         SimpleQueryString(
                             query=search_term,
-                            default_operator="and",
+                            default_operator="OR",
                             quote_field_suffix=".exact",
+                            minimum_should_match="70%",
                             fields=["pages.body"],
                         )
                     ],
@@ -223,8 +224,11 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
     # allowed and default ordering
     ordering_fields = {"date": "date", "title": "title"}
     ordering = ("_score", "date")
-    # this means that ALL terms must appear in ANY of the searched fields
-    simple_query_string_options = {"default_operator": "AND"}
+    # this means that at least 70% of terms must appear in ANY of the searched fields
+    simple_query_string_options = {
+        "default_operator": "OR",
+        "minimum_should_match": "70%",
+    }
 
     filter_fields = {
         "authors": "authors",


### PR DESCRIPTION
* use minimum_should_match (see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html and https://github.com/laws-africa/peachjam/issues/1161)
* index `case_name` for citator searches
* import/export allows created_at