### PR TITLE
additional open office mime type

### DIFF
--- a/peachjam/pipelines.py
+++ b/peachjam/pipelines.py
@@ -5,6 +5,7 @@ from docpipe.soffice import DocToHtml
 from docpipe.xmlutils import unwrap_element
 
 DOC_MIMETYPES = [
+    "application/vnd.oasis.opendocument.text",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "application/msword",
     "application/rtf",


### PR DESCRIPTION
This fixes #1261 by allowing us to upload an OpenOffice (actually, libreoffice) document which has corrected footnote symbols.

![image](https://github.com/laws-africa/peachjam/assets/4178542/e5f4cc0c-d7fd-4ca6-bf80-ae9f8d000cb4)

![image](https://github.com/laws-africa/peachjam/assets/4178542/51be7627-a9ee-415a-8aa3-bf8f0766cc45)
