### PR TITLE
Use la-table-of-contents-controller for taxonomy tree admin

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from datetime import date
 
 from ckeditor.widgets import CKEditorWidget
@@ -532,6 +533,25 @@ class TaxonomyAdmin(TreeAdmin):
     form = movenodeform_factory(Taxonomy, TaxonomyForm)
     readonly_fields = ("slug",)
     inlines = [EntityProfileInline]
+    # prevent pagination
+    list_per_page = 1_000_000
+
+    def changelist_view(self, request, extra_context=None):
+        resp = super().changelist_view(request, extra_context)
+
+        def fixup(item):
+            item["title"] = item["data"]["name"]
+            item["href"] = reverse("admin:peachjam_taxonomy_change", args=[item["id"]])
+            for kid in item.get("children", []):
+                fixup(kid)
+
+        # grab the tree and turn it into something la-table-of-contents-controller understands
+        tree = self.model.dump_bulk()
+        for x in tree:
+            fixup(x)
+        resp.context_data["tree_json"] = json.dumps(tree)
+
+        return resp
 
 
 class CoreDocumentAdmin(DocumentAdmin):

--- a/peachjam/templates/admin/tree_change_list.html
+++ b/peachjam/templates/admin/tree_change_list.html
@@ -1,0 +1,11 @@
+{% extends 'admin/tree_change_list.html' %}
+{% load static i18n %}
+{% block result_list %}
+  <script defer src="{% static 'js/app-prod.js' %}"></script>
+  <la-table-of-contents-controller
+  items="{{ tree_json }}"
+  title-filter-placeholder="{% trans "Search" %}"
+  collapse-all-btn-text="{% trans "Collapse all" %}"
+  expand-all-btn-text="{% trans "Expand all" %}"
+  ></la-table-of-contents-controller>
+{% endblock %}


### PR DESCRIPTION
Replace the old taxonomy tree admin view with a tree-based view that shows the entire tree at once.

The only functionality this effectively hides is the drag-and-drop to re-order the entries.

![image](https://github.com/laws-africa/peachjam/assets/4178542/ed1764b8-403a-4243-8364-b2d2294b2b5a)

@actlikewill here's the simplest way to integrate la-table-of-contents-controller with the taxonomy tree.