### PR TITLE
Fix datetime admin bug

### DIFF
--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -425,7 +425,7 @@ class CoreDocument(PolymorphicModel):
     def clean(self):
         super().clean()
 
-        if self.date > datetime.date.today():
+        if self.date and self.date > datetime.date.today():
             raise ValidationError(
                 {"date": _("You cannot set a future date for the document")}
             )


### PR DESCRIPTION
- Fixes a server error when a user saves a document without date but with work identification details present.

fixes #1369