### PR TITLE
Indigo adapter can handle multiple place codes; bg tasks

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -697,14 +697,17 @@ class IngestorAdmin(admin.ModelAdmin):
     list_display = ("name", "last_refreshed_at", "enabled")
 
     def refresh_all_content(self, request, queryset):
-        from peachjam.tasks import run_ingestors
+        from peachjam.tasks import run_ingestor
 
         queryset.update(last_refreshed_at=None)
-        # queue up the background ingestor update task
-        run_ingestors()
+        for ing in queryset:
+            # queue up the background ingestor update task
+            run_ingestor(ing.pk)
         self.message_user(request, _("Refreshing content in the background."))
 
-    refresh_all_content.short_description = gettext_lazy("Refresh all content")
+    refresh_all_content.short_description = gettext_lazy(
+        "Refresh content selected ingestors"
+    )
 
 
 class ArticleAttachmentInline(BaseAttachmentFileInline):

--- a/peachjam/tasks.py
+++ b/peachjam/tasks.py
@@ -82,15 +82,35 @@ def delete_document(ingestor_id, expression_frbr_uri):
 
 @background(queue="peachjam", remove_existing_tasks=True)
 def run_ingestors():
+    """Queues up background tasks to run ingestors."""
     from peachjam.models import Ingestor
 
-    log.info("Running ingestors...")
+    log.info("Setting up background tasks to run ingestors...")
 
     for ingestor in Ingestor.objects.all():
         if ingestor.enabled:
-            ingestor.check_for_updates()
+            run_ingestor(ingestor.pk)
 
-    log.info("Running ingestors done")
+    log.info("Done")
+
+
+@background(queue="peachjam", remove_existing_tasks=True)
+def run_ingestor(ingestor_id):
+    """Run an ingestor."""
+    from peachjam.models import Ingestor
+
+    log.info(f"Running ingestor {ingestor_id}...")
+
+    ingestor = Ingestor.objects.filter(pk=ingestor_id).first()
+    if not ingestor:
+        log.info(f"No ingestor with id {ingestor_id} exists, ignoring.")
+        return
+
+    if ingestor.enabled:
+        ingestor.check_for_updates()
+        log.info("Done")
+    else:
+        log.info("Ingestor not enabled, ignoring.")
 
 
 @background(queue="peachjam", remove_existing_tasks=True)


### PR DESCRIPTION
- indigo adapter can fetch for multiple place codes, simplifying cases where we need to fetch content for multiple places from the same API
- ingestors run as separate background tasks so that they fail and refresh independently

This will require existing ingestor adapters to be updated:

* ensure `api_url` is `https://api.laws.africa/v2`
* remove `url`
* ensure `places` is the correct list of place codes