### PR TITLE
Fix API url, and ensure building absolute urls uses https

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -493,6 +493,8 @@ CKEDITOR_CONFIGS = {
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SESSION_COOKIE_SECURE = True
+# nginx sets this header to indicate if the upstream request was secure
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Caches
 if DEBUG:

--- a/peachjam_api/urls_public.py
+++ b/peachjam_api/urls_public.py
@@ -17,5 +17,5 @@ router.register(
 
 urlpatterns = [
     # public-facing API
-    path("v1/", include(router.urls)),
+    path("", include(router.urls)),
 ]


### PR DESCRIPTION
* Fixes the url from `.../api/v1/v1/gazettes` to `.../api/v1/gazettes`
* ensures `get_absolute_url` knows what header to look for to know the original request was secure
