### PR TITLE
check labels first; correct model to re-index; re-index related

### DIFF
--- a/peachjam/models/generic_document.py
+++ b/peachjam/models/generic_document.py
@@ -99,10 +99,14 @@ class Legislation(CoreDocument):
             code="repealed",
             defaults={"name": "Repealed", "code": "repealed", "level": "danger"},
         )
+
+        labels = list(self.labels.all())
+
         # apply label if repealed
         if self.repealed:
-            self.labels.add(label.pk)
-        else:
+            if label not in labels:
+                self.labels.add(label.pk)
+        elif label in labels:
             # not repealed, remove label
             self.labels.remove(label.pk)
 

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -319,11 +319,14 @@ class Judgment(CoreDocument):
             defaults={"name": "Reported", "code": "reported", "level": "success"},
         )
 
+        labels = list(self.labels.all())
+
         # if the judgment has alternative_names, apply the "reported" label
         if self.alternative_names.exists():
-            self.labels.add(label.pk)
+            if label not in labels:
+                self.labels.add(label.pk)
         # if the judgment no alternative_names, remove the "reported" label
-        else:
+        elif label in labels:
             self.labels.remove(label.pk)
 
         super().apply_labels()


### PR DESCRIPTION
* check labels before removing or adding -- otherwise this triggers an unnecessary search index update even if nothing has changed
* when a many-to-one model changes, the `instance` to `handle_save` is the document, but `sender` is, say, a `Bench` class or a `CoreDocument_labels` class. So this change correctly uses the document model class name that is queued up to be re-indexed, not the sender.
* handle deletion of related models as a background task (eg. when a label is removed from a document)