### PR TITLE
Sharing URLs take current page portion into account

### DIFF
--- a/peachjam/js/components/DocumentContent/pdf-renderer.ts
+++ b/peachjam/js/components/DocumentContent/pdf-renderer.ts
@@ -3,6 +3,8 @@ import peachJam from '../../peachjam';
 // @ts-ignore
 import { markRange, rangeToTarget, targetToRange } from '../../dom';
 import { scrollToElement } from '../../utils/function';
+import DocumentContent from './index';
+import i18next from 'i18next';
 
 type GlobalWorkerOptionsType = {
   [key: string]: any,
@@ -25,16 +27,18 @@ class PdfRenderer {
   protected pdfContentMarks: any[] = [];
   protected progressBarElement: HTMLElement | null;
   protected previewPanelsContainer: Element | null;
+  protected manager: DocumentContent;
   public onPreviewPanelClick: () => void = () => {};
   public onPdfLoaded: () => void = () => {};
 
-  constructor (root: HTMLElement) {
+  constructor (root: HTMLElement, manager: DocumentContent) {
+    this.root = root;
+    this.manager = manager;
     this.pdfjsLib = pdfjsLib as iPdfLib;
     if (!this.pdfjsLib) {
       throw new Error('Failed to load pdf.js');
     }
     this.pdfjsLib.GlobalWorkerOptions.workerSrc = peachJam.config.pdfWorker;
-    this.root = root;
     this.pdfUrl = root.dataset.pdf;
     this.pdfContentWrapper = root.querySelector('.pdf-content');
     this.progressBarElement = root.querySelector('.progress-bar');
@@ -103,6 +107,9 @@ class PdfRenderer {
     this.activatePreviewPanel(e.currentTarget);
     if (!(e.currentTarget instanceof HTMLElement)) return;
     document.location.hash = `#page-${e.currentTarget.dataset.page}`;
+    // update the current portion for sharing purposes
+    const portion = i18next.t('Page {{page}}', { page: e.currentTarget.dataset.page });
+    this.manager.setSharedPortion(portion);
     this.scrollToPage(e.currentTarget.dataset.page);
   }
 

--- a/peachjam/js/components/DocumentContent/pdf-renderer.ts
+++ b/peachjam/js/components/DocumentContent/pdf-renderer.ts
@@ -108,7 +108,7 @@ class PdfRenderer {
     if (!(e.currentTarget instanceof HTMLElement)) return;
     document.location.hash = `#page-${e.currentTarget.dataset.page}`;
     // update the current portion for sharing purposes
-    const portion = i18next.t('Page {{page}}', { page: e.currentTarget.dataset.page });
+    const portion = i18next.t('Page') + ' ' + e.currentTarget.dataset.page;
     this.manager.setSharedPortion(portion);
     this.scrollToPage(e.currentTarget.dataset.page);
   }

--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -3,6 +3,7 @@
 <div class="document-content"
      data-component="DocumentContent"
      data-display-type="{{ display_type }}"
+     data-title="{{ document.title }}"
      {% if document.frbr_uri_subtype == 'book' %} data-toc-show-active-item-only{% endif %}>
   <!--
   contents of #navigation-content will be placed in [data-offcanvas-body] for tablet/mobile screensize

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -31,17 +31,17 @@
             </div>
             <div class="d-flex align-items-center">
               <a href="https://api.whatsapp.com/send?text={{ request.build_absolute_uri }}"
-                 class="btn btn-link"
+                 class="btn btn-link share-link"
                  target="_blank">
                 <i class="bi bi-whatsapp whatsapp-forecolor share-icon"></i>
               </a>
-              <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri }}"
-                 class="btn btn-link"
+              <a href="https://twitter.com/intent/tweet?text={{ request.build_absolute_uri }}"
+                 class="btn btn-link share-link"
                  target="_blank">
                 <i class="bi bi-twitter twitter-forecolor share-icon"></i>
               </a>
               <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}"
-                 class="btn btn-link"
+                 class="btn btn-link share-link"
                  target="_blank">
                 <i class="bi bi-facebook facebook-forecolor share-icon"></i>
               </a>


### PR DESCRIPTION
When sharing a PDF, we'll share "Title - Page 2 - URL#page-2"

When sharing a portion of an HTML document, we'll share "Title - Section 32 - URL#sec_32"

This is required for the law reader project to ensure that users can easily share the current portion/page of the document they are reading.

About 77% of shares through our share buttons are for whatsapp.