### PR TITLE
rds proxy doesn't allow -c args

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -187,7 +187,8 @@ db_app_name = "-".join(
     [slugify(PEACHJAM["APP_NAME"]), os.environ.get("DYNO", "django")]
 )
 for cfg in DATABASES.values():
-    cfg.setdefault("OPTIONS", {})["options"] = f"-c application_name={db_app_name}"
+    if "proxy" not in cfg["HOST"]:
+        cfg.setdefault("OPTIONS", {})["options"] = f"-c application_name={db_app_name}"
 
 
 # Password validation


### PR DESCRIPTION
This is a bit of a hack until we can turn this off completely