### PR TITLE
locality legislation view uses entity profiles from locality

### DIFF
--- a/lawlibrary/templates/liiweb/locality_legislation_list.html
+++ b/lawlibrary/templates/liiweb/locality_legislation_list.html
@@ -1,11 +1,13 @@
 {% extends 'liiweb/locality_legislation_list.html' %}
 {% block breadcrumbs %}
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item">
-        <a href="{{ breadcrumb_link }}">{{ locality_legislation_title }}</a>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page">{{ locality.name }}</li>
-    </ol>
-  </nav>
+  <div class="container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item">
+          <a href="{{ breadcrumb_link }}">{{ locality_legislation_title }}</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">{{ locality.name }}</li>
+      </ol>
+    </nav>
+  </div>
 {% endblock %}

--- a/liiweb/templates/liiweb/legislation_list.html
+++ b/liiweb/templates/liiweb/legislation_list.html
@@ -4,9 +4,14 @@
   {% trans 'Legislation' %}
 {% endblock %}
 {% block page-content %}
+  {% block breadcrumbs %}{% endblock %}
+  {% block entity-profile %}
+    {% if entity_profile %}
+      <div class="mt-3">{% include 'peachjam/_entity_profile.html' %}</div>
+    {% endif %}
+  {% endblock %}
   <section class="pb-5">
     <div class="container">
-      {% block breadcrumbs %}{% endblock %}
       {% block page-heading %}
         <h1 class="my-4">{% trans 'Legislation' %}</h1>
       {% endblock %}

--- a/liiweb/templates/liiweb/locality_legislation_list.html
+++ b/liiweb/templates/liiweb/locality_legislation_list.html
@@ -2,14 +2,16 @@
 {% load i18n %}
 {% block title %}{{ locality_legislation_title }}{% endblock %}
 {% block breadcrumbs %}
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item">
-        <a href="{% url 'locality_legislation' %}">{{ locality_legislation_title }}</a>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page">{{ locality.name }}</li>
-    </ol>
-  </nav>
+  <div class="container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item">
+          <a href="{% url 'locality_legislation' %}">{{ locality_legislation_title }}</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">{{ locality.name }}</li>
+      </ol>
+    </nav>
+  </div>
 {% endblock %}
 {% block page-heading %}
   <h1 class="my-4">{{ page_heading }}</h1>

--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -97,5 +97,7 @@ class LocalityLegislationListView(LegislationListView):
             locality=self.locality,
             locality_legislation_title="Provincial Legislation",
             page_heading=_("%(locality)s Legislation" % {"locality": self.locality}),
+            entity_profile=self.locality.entity_profile.first(),
+            entity_profile_title=self.locality.name,
             **kwargs,
         )

--- a/open_by_laws/templates/open_by_laws/municipal_by_laws_list.html
+++ b/open_by_laws/templates/open_by_laws/municipal_by_laws_list.html
@@ -4,14 +4,16 @@
   {% blocktrans with locality=locality.name %}{{ locality }} By-laws{% endblocktrans %}
 {% endblock %}
 {% block breadcrumbs %}
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item">
-        <a href="{% url 'home_page' %}">{% trans 'Municipalities' %}</a>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page">{{ locality }}</li>
-    </ol>
-  </nav>
+  <div class="container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item">
+          <a href="{% url 'home_page' %}">{% trans 'Municipalities' %}</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">{{ locality }}</li>
+      </ol>
+    </nav>
+  </div>
 {% endblock %}
 {% block page-heading %}
   <h1 class="my-4">{% blocktrans with locality=locality.name %}{{ locality }} By-laws{% endblocktrans %}</h1>

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -941,6 +941,7 @@ class LocalityAdmin(admin.ModelAdmin):
     list_display = ("name", "jurisdiction", "code")
     prepopulated_fields = {"code": ("name",)}
     search_fields = ("name", "code")
+    inlines = [EntityProfileInline]
 
 
 @admin.register(Judge)

--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -9,6 +9,7 @@ from cobalt.akn import StructuredDocument, datestring
 from cobalt.uri import FrbrUri
 from countries_plus.models import Country
 from django.conf import settings
+from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.files import File
@@ -87,6 +88,9 @@ class Locality(models.Model):
         Country, on_delete=models.PROTECT, verbose_name=_("jurisdiction")
     )
     code = models.CharField(_("code"), max_length=20, null=False)
+    entity_profile = GenericRelation(
+        "peachjam.EntityProfile", verbose_name=_("profile")
+    )
 
     class Meta:
         verbose_name = _("locality")

--- a/peachjam/models/taxonomies.py
+++ b/peachjam/models/taxonomies.py
@@ -1,15 +1,19 @@
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from treebeard.mp_tree import MP_Node
 
-from peachjam.models import CoreDocument, EntityProfile
+from peachjam.models import CoreDocument
 
 
 class Taxonomy(MP_Node):
     name = models.CharField(_("name"), max_length=255)
     slug = models.SlugField(_("slug"), max_length=255, unique=True)
     node_order_by = ["name"]
+    entity_profile = GenericRelation(
+        "peachjam.EntityProfile", verbose_name=_("profile")
+    )
 
     class Meta:
         verbose_name = _("taxonomies")
@@ -21,7 +25,7 @@ class Taxonomy(MP_Node):
     def get_entity_profile(self):
         """Get the entity profile for this taxonomy, starting with the current taxonomy and then
         looking up the tree until one is found."""
-        entity_profile = EntityProfile.objects.filter(object_id=self.pk).first()
+        entity_profile = self.entity_profile.first()
         if entity_profile:
             return entity_profile
         if self.is_root():


### PR DESCRIPTION
This enables us to have a richer experience on legislation views, similar to what we do on court and taxonomy detail views.

* lays the groundwork for #1461 to support profiles at the top-level legislation level (this only covers locality legislation)
* also fixes how we find entity profiles for taxonomy topics
* ref #1461

![image](https://github.com/laws-africa/peachjam/assets/4178542/f78a558c-81fa-463c-9763-8ce71460257b)
