### PR TITLE
updated out-of-date warning

### DIFF
--- a/africanlii/locale/en/LC_MESSAGES/django.po
+++ b/africanlii/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-24 15:05+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: apps.py:20
-msgid "Regional Body"
+msgid "Regional Body / Author"
 msgstr ""
 
 #: apps.py:21
-msgid "Regional Bodies"
+msgid "Regional Bodies / Authors"
 msgstr ""
 
 #: models/au.py:13 models/au.py:33
@@ -86,6 +86,11 @@ msgstr ""
 msgid "ratification countries"
 msgstr ""
 
+#: templates/africanlii/_lii_info.html:5
+#, python-format
+msgid "Visit %(lii_name)s for more legal information."
+msgstr ""
+
 #: templates/africanlii/_ratification_table.html:2
 msgid "Ratified documents"
 msgstr ""
@@ -95,15 +100,15 @@ msgid "Title"
 msgstr ""
 
 #: templates/africanlii/_ratification_table.html:7
-msgid "Ratification Date"
+msgid "Signature Date"
 msgstr ""
 
 #: templates/africanlii/_ratification_table.html:8
-msgid "Deposit Date"
+msgid "Ratification Date"
 msgstr ""
 
 #: templates/africanlii/_ratification_table.html:9
-msgid "Signature Date"
+msgid "Deposit Date"
 msgstr ""
 
 #: templates/africanlii/au_detail_page.html:4
@@ -146,9 +151,9 @@ msgstr ""
 msgid "African Union Institutions"
 msgstr ""
 
-#: templates/africanlii/au_detail_page.html:79
+#: templates/africanlii/au_detail_page.html:78
 #: templates/africanlii/member_state_detail.html:12
-#: templates/peachjam/home.html:106
+#: templates/peachjam/home.html:110
 msgid "Member States"
 msgstr ""
 
@@ -161,7 +166,7 @@ msgstr ""
 
 #: templates/africanlii/au_institution_detail.html:37
 #: templates/africanlii/au_organ_detail.html:37
-#: templates/africanlii/member_state_detail.html:37
+#: templates/africanlii/member_state_detail.html:38
 #: templates/africanlii/regional_economic_community_detail.html:38
 msgid "No documents found."
 msgstr ""
@@ -275,7 +280,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: templates/peachjam/_header.html:123
+#: templates/peachjam/_header.html:121
 msgid "Help"
 msgstr ""
 
@@ -369,7 +374,7 @@ msgstr ""
 msgid "Search %(APP_NAME)s"
 msgstr ""
 
-#: templates/peachjam/home.html:44 templates/peachjam/home.html:161
+#: templates/peachjam/home.html:44 templates/peachjam/home.html:165
 msgid "Search"
 msgstr ""
 
@@ -385,67 +390,63 @@ msgstr ""
 msgid "We digitise the law and policy of the African Governance Architecture and help Africans and the world connect with and understand the African Union agenda."
 msgstr ""
 
-#: templates/peachjam/home.html:96
-msgid "Regional Courts"
-msgstr ""
-
-#: templates/peachjam/home.html:111
+#: templates/peachjam/home.html:115
 msgid "Explore Member States"
 msgstr ""
 
-#: templates/peachjam/home.html:120
+#: templates/peachjam/home.html:124
 msgid "Recent Judgments"
 msgstr ""
 
-#: templates/peachjam/home.html:121
+#: templates/peachjam/home.html:125
 msgid "View more judgments"
 msgstr ""
 
-#: templates/peachjam/home.html:125
+#: templates/peachjam/home.html:129
 msgid "Recent Legal Instruments"
 msgstr ""
 
-#: templates/peachjam/home.html:126
+#: templates/peachjam/home.html:130
 msgid "View more legal instruments"
 msgstr ""
 
-#: templates/peachjam/home.html:132
+#: templates/peachjam/home.html:136
 msgid "Recent Soft Law"
 msgstr ""
 
-#: templates/peachjam/home.html:133
+#: templates/peachjam/home.html:137
 msgid "View more Soft Law"
 msgstr ""
 
-#: templates/peachjam/home.html:137
+#: templates/peachjam/home.html:141
 msgid "Recent Reports and Guides"
 msgstr ""
 
-#: templates/peachjam/home.html:138
+#: templates/peachjam/home.html:142
 msgid "View more Reports and Guides"
 msgstr ""
 
-#: templates/peachjam/home.html:146
+#: templates/peachjam/home.html:150
 msgid "Explore African national legal information"
 msgstr ""
 
-#: templates/peachjam/home.html:148
+#: templates/peachjam/home.html:152
 msgid "Explore African national legislation and court judgments from Legal Information Institutes across Africa."
 msgstr ""
 
-#: templates/peachjam/home.html:157 templates/peachjam/home.html:158
+#: templates/peachjam/home.html:161 templates/peachjam/home.html:162
 msgid "Search African legal information"
 msgstr ""
 
-#: templates/peachjam/home.html:184
+#: templates/peachjam/home.html:188
 msgid "Latest Commentary"
 msgstr ""
 
-#: templates/peachjam/home.html:187
+#: templates/peachjam/home.html:191
 msgid "View more commentary"
 msgstr ""
 
-#: templates/peachjam/home.html:193
+#: templates/peachjam/home.html:197
 msgid "Collections"
 msgstr ""
 

--- a/africanlii/locale/fr/LC_MESSAGES/django.po
+++ b/africanlii/locale/fr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-24 15:05+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-25 08:22\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
@@ -18,11 +18,15 @@ msgstr ""
 "X-Crowdin-File-ID: 101\n"
 
 #: apps.py:20
-msgid "Regional Body"
+#, fuzzy
+#| msgid "Regional Body"
+msgid "Regional Body / Author"
 msgstr "Corps régional"
 
 #: apps.py:21
-msgid "Regional Bodies"
+#, fuzzy
+#| msgid "Regional Bodies"
+msgid "Regional Bodies / Authors"
 msgstr "Organismes régionaux"
 
 #: models/au.py:13 models/au.py:33
@@ -85,6 +89,11 @@ msgstr "Pays de ratification"
 msgid "ratification countries"
 msgstr "Pays de ratification"
 
+#: templates/africanlii/_lii_info.html:5
+#, python-format
+msgid "Visit %(lii_name)s for more legal information."
+msgstr ""
+
 #: templates/africanlii/_ratification_table.html:2
 msgid "Ratified documents"
 msgstr "Documents ratifiés"
@@ -94,16 +103,16 @@ msgid "Title"
 msgstr "Titre"
 
 #: templates/africanlii/_ratification_table.html:7
+msgid "Signature Date"
+msgstr "Date de signature"
+
+#: templates/africanlii/_ratification_table.html:8
 msgid "Ratification Date"
 msgstr "Date de ratification"
 
-#: templates/africanlii/_ratification_table.html:8
+#: templates/africanlii/_ratification_table.html:9
 msgid "Deposit Date"
 msgstr "Date de dépôt"
-
-#: templates/africanlii/_ratification_table.html:9
-msgid "Signature Date"
-msgstr "Date de signature"
 
 #: templates/africanlii/au_detail_page.html:4
 #: templates/africanlii/au_detail_page.html:11
@@ -145,9 +154,9 @@ msgstr "Communautés économiques régionales"
 msgid "African Union Institutions"
 msgstr "Institutions de l'Union africaine"
 
-#: templates/africanlii/au_detail_page.html:79
+#: templates/africanlii/au_detail_page.html:78
 #: templates/africanlii/member_state_detail.html:12
-#: templates/peachjam/home.html:106
+#: templates/peachjam/home.html:110
 msgid "Member States"
 msgstr "États membres"
 
@@ -160,7 +169,7 @@ msgstr "Union africaine"
 
 #: templates/africanlii/au_institution_detail.html:37
 #: templates/africanlii/au_organ_detail.html:37
-#: templates/africanlii/member_state_detail.html:37
+#: templates/africanlii/member_state_detail.html:38
 #: templates/africanlii/regional_economic_community_detail.html:38
 msgid "No documents found."
 msgstr "Aucun document trouvé."
@@ -274,7 +283,7 @@ msgstr "Rapports et tutoriels"
 msgid "Articles"
 msgstr "Articles"
 
-#: templates/peachjam/_header.html:123
+#: templates/peachjam/_header.html:121
 msgid "Help"
 msgstr "Aide"
 
@@ -368,7 +377,7 @@ msgstr "Rechercher %(documents_count)s documents de l'Union africaine et informa
 msgid "Search %(APP_NAME)s"
 msgstr "Rechercher dans %(APP_NAME)s"
 
-#: templates/peachjam/home.html:44 templates/peachjam/home.html:161
+#: templates/peachjam/home.html:44 templates/peachjam/home.html:165
 msgid "Search"
 msgstr "Recherche"
 
@@ -384,67 +393,63 @@ msgstr "Explorez la loi et la politique de l'Union africaine"
 msgid "We digitise the law and policy of the African Governance Architecture and help Africans and the world connect with and understand the African Union agenda."
 msgstr "Nous numérisons la loi et la politique de l’Architecture de Gouvernance Africaine et aidons les Africains et le monde à relier et comprendre le programme de l’Union Africaine."
 
-#: templates/peachjam/home.html:96
-msgid "Regional Courts"
-msgstr "Cours régionaux"
-
-#: templates/peachjam/home.html:111
+#: templates/peachjam/home.html:115
 msgid "Explore Member States"
 msgstr "Explorer les États membres"
 
-#: templates/peachjam/home.html:120
+#: templates/peachjam/home.html:124
 msgid "Recent Judgments"
 msgstr "Jugements récents"
 
-#: templates/peachjam/home.html:121
+#: templates/peachjam/home.html:125
 msgid "View more judgments"
 msgstr "Voir plus de jugements"
 
-#: templates/peachjam/home.html:125
+#: templates/peachjam/home.html:129
 msgid "Recent Legal Instruments"
 msgstr "Derniers instruments juridiques"
 
-#: templates/peachjam/home.html:126
+#: templates/peachjam/home.html:130
 msgid "View more legal instruments"
 msgstr "Voir plus d'instruments juridiques"
 
-#: templates/peachjam/home.html:132
+#: templates/peachjam/home.html:136
 msgid "Recent Soft Law"
 msgstr "Récente norme non contraignantes"
 
-#: templates/peachjam/home.html:133
+#: templates/peachjam/home.html:137
 msgid "View more Soft Law"
 msgstr "Voir plus de droit non contraignant"
 
-#: templates/peachjam/home.html:137
+#: templates/peachjam/home.html:141
 msgid "Recent Reports and Guides"
 msgstr "Rapports et guides récents"
 
-#: templates/peachjam/home.html:138
+#: templates/peachjam/home.html:142
 msgid "View more Reports and Guides"
 msgstr "Afficher plus de rapports et de guides"
 
-#: templates/peachjam/home.html:146
+#: templates/peachjam/home.html:150
 msgid "Explore African national legal information"
 msgstr "Explorer les informations juridiques nationales africaines"
 
-#: templates/peachjam/home.html:148
+#: templates/peachjam/home.html:152
 msgid "Explore African national legislation and court judgments from Legal Information Institutes across Africa."
 msgstr "Explorez la législation nationale africaine et les jugements des tribunaux des instituts d'information juridique à travers l'Afrique."
 
-#: templates/peachjam/home.html:157 templates/peachjam/home.html:158
+#: templates/peachjam/home.html:161 templates/peachjam/home.html:162
 msgid "Search African legal information"
 msgstr "Rechercher des informations juridiques africaines"
 
-#: templates/peachjam/home.html:184
+#: templates/peachjam/home.html:188
 msgid "Latest Commentary"
 msgstr "Dernier commentaire"
 
-#: templates/peachjam/home.html:187
+#: templates/peachjam/home.html:191
 msgid "View more commentary"
 msgstr "Voir plus de commentaires"
 
-#: templates/peachjam/home.html:193
+#: templates/peachjam/home.html:197
 msgid "Collections"
 msgstr "Collections"
 
@@ -457,3 +462,5 @@ msgstr "Rapports et tutoriels"
 msgid "Search regional and national African legal information."
 msgstr "Rechercher des informations juridiques africaines régionales et nationales."
 
+#~ msgid "Regional Courts"
+#~ msgstr "Cours régionaux"

--- a/africanlii/locale/pt/LC_MESSAGES/django.po
+++ b/africanlii/locale/pt/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-24 15:05+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-25 08:22\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese\n"
@@ -18,11 +18,15 @@ msgstr ""
 "X-Crowdin-File-ID: 101\n"
 
 #: apps.py:20
-msgid "Regional Body"
+#, fuzzy
+#| msgid "Regional Body"
+msgid "Regional Body / Author"
 msgstr "Órgão Regional"
 
 #: apps.py:21
-msgid "Regional Bodies"
+#, fuzzy
+#| msgid "Regional Bodies"
+msgid "Regional Bodies / Authors"
 msgstr "Órgãos Regionais"
 
 #: models/au.py:13 models/au.py:33
@@ -85,6 +89,11 @@ msgstr "país de ratificação"
 msgid "ratification countries"
 msgstr "países ratificados"
 
+#: templates/africanlii/_lii_info.html:5
+#, python-format
+msgid "Visit %(lii_name)s for more legal information."
+msgstr ""
+
 #: templates/africanlii/_ratification_table.html:2
 msgid "Ratified documents"
 msgstr "Documentos ratificados"
@@ -94,16 +103,16 @@ msgid "Title"
 msgstr "Título"
 
 #: templates/africanlii/_ratification_table.html:7
+msgid "Signature Date"
+msgstr "Data da Assinatura"
+
+#: templates/africanlii/_ratification_table.html:8
 msgid "Ratification Date"
 msgstr "Data de ratificação"
 
-#: templates/africanlii/_ratification_table.html:8
+#: templates/africanlii/_ratification_table.html:9
 msgid "Deposit Date"
 msgstr "Data do Depósito"
-
-#: templates/africanlii/_ratification_table.html:9
-msgid "Signature Date"
-msgstr "Data da Assinatura"
 
 #: templates/africanlii/au_detail_page.html:4
 #: templates/africanlii/au_detail_page.html:11
@@ -145,9 +154,9 @@ msgstr "Comunidades Económicas Regionais"
 msgid "African Union Institutions"
 msgstr "Instituições da União Africana"
 
-#: templates/africanlii/au_detail_page.html:79
+#: templates/africanlii/au_detail_page.html:78
 #: templates/africanlii/member_state_detail.html:12
-#: templates/peachjam/home.html:106
+#: templates/peachjam/home.html:110
 msgid "Member States"
 msgstr "Estados Membros"
 
@@ -160,7 +169,7 @@ msgstr "União Africana"
 
 #: templates/africanlii/au_institution_detail.html:37
 #: templates/africanlii/au_organ_detail.html:37
-#: templates/africanlii/member_state_detail.html:37
+#: templates/africanlii/member_state_detail.html:38
 #: templates/africanlii/regional_economic_community_detail.html:38
 msgid "No documents found."
 msgstr "Nenhum documento encontrado."
@@ -274,7 +283,7 @@ msgstr "Relatórios e guias"
 msgid "Articles"
 msgstr "Artigos"
 
-#: templates/peachjam/_header.html:123
+#: templates/peachjam/_header.html:121
 msgid "Help"
 msgstr "Socorro"
 
@@ -368,7 +377,7 @@ msgstr "Pesquise %(documents_count)s documentos da União Africana e informaçõ
 msgid "Search %(APP_NAME)s"
 msgstr "Pesquisar %(APP_NAME)s"
 
-#: templates/peachjam/home.html:44 templates/peachjam/home.html:161
+#: templates/peachjam/home.html:44 templates/peachjam/home.html:165
 msgid "Search"
 msgstr "Pesquisa"
 
@@ -384,67 +393,63 @@ msgstr "Explore a lei e a política da União Africana"
 msgid "We digitise the law and policy of the African Governance Architecture and help Africans and the world connect with and understand the African Union agenda."
 msgstr "Digitalizamos a lei e a política da Arquitetura da Governação Africana e ajudamos os Africanos e o mundo a ligarem-se e a compreenderem a agenda da União Africana."
 
-#: templates/peachjam/home.html:96
-msgid "Regional Courts"
-msgstr "Tribunais Regionais"
-
-#: templates/peachjam/home.html:111
+#: templates/peachjam/home.html:115
 msgid "Explore Member States"
 msgstr "Explorar Estados Membros"
 
-#: templates/peachjam/home.html:120
+#: templates/peachjam/home.html:124
 msgid "Recent Judgments"
 msgstr "Julgamentos Recentes"
 
-#: templates/peachjam/home.html:121
+#: templates/peachjam/home.html:125
 msgid "View more judgments"
 msgstr "Ver mais julgamentos"
 
-#: templates/peachjam/home.html:125
+#: templates/peachjam/home.html:129
 msgid "Recent Legal Instruments"
 msgstr "Instrumentos Jurídicos Recentes"
 
-#: templates/peachjam/home.html:126
+#: templates/peachjam/home.html:130
 msgid "View more legal instruments"
 msgstr "Ver mais instrumentos jurídicos"
 
-#: templates/peachjam/home.html:132
+#: templates/peachjam/home.html:136
 msgid "Recent Soft Law"
 msgstr "Lei branda recente"
 
-#: templates/peachjam/home.html:133
+#: templates/peachjam/home.html:137
 msgid "View more Soft Law"
 msgstr "Veja mais Soft Law"
 
-#: templates/peachjam/home.html:137
+#: templates/peachjam/home.html:141
 msgid "Recent Reports and Guides"
 msgstr "Relatórios e guias recentes"
 
-#: templates/peachjam/home.html:138
+#: templates/peachjam/home.html:142
 msgid "View more Reports and Guides"
 msgstr "Veja mais relatórios e guias"
 
-#: templates/peachjam/home.html:146
+#: templates/peachjam/home.html:150
 msgid "Explore African national legal information"
 msgstr "Explore as informações jurídicas nacionais africanas"
 
-#: templates/peachjam/home.html:148
+#: templates/peachjam/home.html:152
 msgid "Explore African national legislation and court judgments from Legal Information Institutes across Africa."
 msgstr "Explore a legislação nacional africana e as decisões judiciais dos Institutos de Informação Jurídica em toda a África."
 
-#: templates/peachjam/home.html:157 templates/peachjam/home.html:158
+#: templates/peachjam/home.html:161 templates/peachjam/home.html:162
 msgid "Search African legal information"
 msgstr "Pesquisar informações legais africanas"
 
-#: templates/peachjam/home.html:184
+#: templates/peachjam/home.html:188
 msgid "Latest Commentary"
 msgstr "Comentário mais recente"
 
-#: templates/peachjam/home.html:187
+#: templates/peachjam/home.html:191
 msgid "View more commentary"
 msgstr "Ver mais comentários"
 
-#: templates/peachjam/home.html:193
+#: templates/peachjam/home.html:197
 msgid "Collections"
 msgstr "Coleções"
 
@@ -457,3 +462,5 @@ msgstr "Relatórios e guias"
 msgid "Search regional and national African legal information."
 msgstr "Pesquise informações legais africanas regionais e nacionais."
 
+#~ msgid "Regional Courts"
+#~ msgstr "Tribunais Regionais"

--- a/africanlii/locale/sw/LC_MESSAGES/django.po
+++ b/africanlii/locale/sw/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-24 15:05+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-25 08:22\n"
 "Last-Translator: \n"
 "Language-Team: Swahili\n"
@@ -18,11 +18,15 @@ msgstr ""
 "X-Crowdin-File-ID: 101\n"
 
 #: apps.py:20
-msgid "Regional Body"
+#, fuzzy
+#| msgid "Regional Body"
+msgid "Regional Body / Author"
 msgstr "Bodi ya Kanda"
 
 #: apps.py:21
-msgid "Regional Bodies"
+#, fuzzy
+#| msgid "Regional Bodies"
+msgid "Regional Bodies / Authors"
 msgstr "Vyombo vya kanda"
 
 #: models/au.py:13 models/au.py:33
@@ -85,6 +89,11 @@ msgstr "nchi iliyoridhia"
 msgid "ratification countries"
 msgstr "nchi zilizoridhia"
 
+#: templates/africanlii/_lii_info.html:5
+#, python-format
+msgid "Visit %(lii_name)s for more legal information."
+msgstr ""
+
 #: templates/africanlii/_ratification_table.html:2
 msgid "Ratified documents"
 msgstr "Hati zilizoidhinishwa"
@@ -94,16 +103,16 @@ msgid "Title"
 msgstr "Mada"
 
 #: templates/africanlii/_ratification_table.html:7
+msgid "Signature Date"
+msgstr "Tarehe ya Saini"
+
+#: templates/africanlii/_ratification_table.html:8
 msgid "Ratification Date"
 msgstr "Tarehe ya Kuridhiwa"
 
-#: templates/africanlii/_ratification_table.html:8
+#: templates/africanlii/_ratification_table.html:9
 msgid "Deposit Date"
 msgstr "Tarehe ya Kuweka"
-
-#: templates/africanlii/_ratification_table.html:9
-msgid "Signature Date"
-msgstr "Tarehe ya Saini"
 
 #: templates/africanlii/au_detail_page.html:4
 #: templates/africanlii/au_detail_page.html:11
@@ -145,9 +154,9 @@ msgstr "Jumuiya za Kiuchumi za Kanda"
 msgid "African Union Institutions"
 msgstr "Taasisi za Umoja wa Afrika"
 
-#: templates/africanlii/au_detail_page.html:79
+#: templates/africanlii/au_detail_page.html:78
 #: templates/africanlii/member_state_detail.html:12
-#: templates/peachjam/home.html:106
+#: templates/peachjam/home.html:110
 msgid "Member States"
 msgstr "Nchi Wanachama"
 
@@ -160,7 +169,7 @@ msgstr "Umoja wa Afrika"
 
 #: templates/africanlii/au_institution_detail.html:37
 #: templates/africanlii/au_organ_detail.html:37
-#: templates/africanlii/member_state_detail.html:37
+#: templates/africanlii/member_state_detail.html:38
 #: templates/africanlii/regional_economic_community_detail.html:38
 msgid "No documents found."
 msgstr "Hakuna nyaraka zilizopatikana."
@@ -274,7 +283,7 @@ msgstr "Ripoti na Miongozo"
 msgid "Articles"
 msgstr "Makala"
 
-#: templates/peachjam/_header.html:123
+#: templates/peachjam/_header.html:121
 msgid "Help"
 msgstr "Msaada"
 
@@ -368,7 +377,7 @@ msgstr "Tafuta hati %(documents_count)s za Umoja wa Afrika na taarifa za kisheri
 msgid "Search %(APP_NAME)s"
 msgstr "Tafuta %(APP_NAME)s"
 
-#: templates/peachjam/home.html:44 templates/peachjam/home.html:161
+#: templates/peachjam/home.html:44 templates/peachjam/home.html:165
 msgid "Search"
 msgstr "Tafuta"
 
@@ -384,67 +393,63 @@ msgstr "Chunguza sheria na sera ya Umoja wa Afrika"
 msgid "We digitise the law and policy of the African Governance Architecture and help Africans and the world connect with and understand the African Union agenda."
 msgstr "Tunaweka kidigiti sheria na sera ya Muundo wa Utawala wa Afrika na kuwasaidia Waafrika na ulimwengu kuungana na kuelewa ajenda ya Umoja wa Afrika."
 
-#: templates/peachjam/home.html:96
-msgid "Regional Courts"
-msgstr "Mahakama za Kanda"
-
-#: templates/peachjam/home.html:111
+#: templates/peachjam/home.html:115
 msgid "Explore Member States"
 msgstr "Gundua Nchi Wanachama"
 
-#: templates/peachjam/home.html:120
+#: templates/peachjam/home.html:124
 msgid "Recent Judgments"
 msgstr "Hukumu za Hivi Karibuni"
 
-#: templates/peachjam/home.html:121
+#: templates/peachjam/home.html:125
 msgid "View more judgments"
 msgstr "Tazama hukumu zaidi"
 
-#: templates/peachjam/home.html:125
+#: templates/peachjam/home.html:129
 msgid "Recent Legal Instruments"
 msgstr "Hati za Kisheria za Hivi Karibuni"
 
-#: templates/peachjam/home.html:126
+#: templates/peachjam/home.html:130
 msgid "View more legal instruments"
 msgstr "Tazama hati zaidi za kisheria"
 
-#: templates/peachjam/home.html:132
+#: templates/peachjam/home.html:136
 msgid "Recent Soft Law"
 msgstr "Sheria Zisizofunga za Hivi Karibuni"
 
-#: templates/peachjam/home.html:133
+#: templates/peachjam/home.html:137
 msgid "View more Soft Law"
 msgstr "Tazama zaidi Sheria Zisizofunga"
 
-#: templates/peachjam/home.html:137
+#: templates/peachjam/home.html:141
 msgid "Recent Reports and Guides"
 msgstr "Ripoti na Miongozo ya Hivi Karibuni"
 
-#: templates/peachjam/home.html:138
+#: templates/peachjam/home.html:142
 msgid "View more Reports and Guides"
 msgstr "Tazama Ripoti na Miongozo zaidi"
 
-#: templates/peachjam/home.html:146
+#: templates/peachjam/home.html:150
 msgid "Explore African national legal information"
 msgstr "Gundua taarifa za kisheria za kitaifa za Kiafrika"
 
-#: templates/peachjam/home.html:148
+#: templates/peachjam/home.html:152
 msgid "Explore African national legislation and court judgments from Legal Information Institutes across Africa."
 msgstr "Gundua sheria za kitaifa za Kiafrika na hukumu za mahakama kutoka Taasisi za Habari za Kisheria kote barani Afrika."
 
-#: templates/peachjam/home.html:157 templates/peachjam/home.html:158
+#: templates/peachjam/home.html:161 templates/peachjam/home.html:162
 msgid "Search African legal information"
 msgstr "Tafuta habari za kisheria za Kiafrika"
 
-#: templates/peachjam/home.html:184
+#: templates/peachjam/home.html:188
 msgid "Latest Commentary"
 msgstr "Maoni ya Hivi Karibuni"
 
-#: templates/peachjam/home.html:187
+#: templates/peachjam/home.html:191
 msgid "View more commentary"
 msgstr "Tazama maoni zaidi"
 
-#: templates/peachjam/home.html:193
+#: templates/peachjam/home.html:197
 msgid "Collections"
 msgstr "Makusanyo"
 
@@ -457,3 +462,5 @@ msgstr "Ripoti na Miongozo"
 msgid "Search regional and national African legal information."
 msgstr "Tafuta taarifa za kisheria za kikanda na kitaifa za Afrika."
 
+#~ msgid "Regional Courts"
+#~ msgstr "Mahakama za Kanda"

--- a/liiweb/locale/en/LC_MESSAGES/django.po
+++ b/liiweb/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,73 +22,83 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: templates/liiweb/home.html:25 templates/liiweb/home.html:26
+#: templates/liiweb/home.html:35 templates/liiweb/home.html:36
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr ""
 
-#: templates/liiweb/home.html:32
+#: templates/liiweb/home.html:42
 msgid "Search"
 msgstr ""
 
-#: templates/liiweb/home.html:35
+#: templates/liiweb/home.html:44
 msgid "Advanced search"
 msgstr ""
 
-#: templates/liiweb/home.html:62
+#: templates/liiweb/home.html:67
 msgid "Recent Judgments"
 msgstr ""
 
-#: templates/liiweb/home.html:63
+#: templates/liiweb/home.html:68
 msgid "View more judgments"
 msgstr ""
 
-#: templates/liiweb/home.html:67
+#: templates/liiweb/home.html:72
 msgid "Recent Legislation"
 msgstr ""
 
-#: templates/liiweb/home.html:68
+#: templates/liiweb/home.html:73
 msgid "View more legislation"
 msgstr ""
 
-#: templates/liiweb/home.html:89
-msgid "Twitter"
-msgstr ""
-
-#: templates/liiweb/home.html:102
+#: templates/liiweb/home.html:100
 msgid "Facebook"
 msgstr ""
 
-#: templates/liiweb/home.html:117
-msgid "Tweets by AfricanLII"
-msgstr ""
-
-#: templates/liiweb/home.html:150
+#: templates/liiweb/home.html:135
 msgid "Courts"
 msgstr ""
 
-#: templates/liiweb/home.html:154
+#: templates/liiweb/home.html:139
 msgid "Collections"
 msgstr ""
 
+#: templates/liiweb/home.html:152
+#, python-format
+msgid "Use %(APP_NAME)s when you're offline"
+msgstr ""
+
+#: templates/liiweb/home.html:154
+#, python-format
+msgid "Pocket Law is an offline copy of the caselaw, legislation and other legal materials from %(APP_NAME)s."
+msgstr ""
+
+#: templates/liiweb/home.html:166
+msgid "Latest Articles"
+msgstr ""
+
+#: templates/liiweb/home.html:168
+msgid "View more articles"
+msgstr ""
+
 #: templates/liiweb/legislation_list.html:4
-#: templates/liiweb/legislation_list.html:11 templates/peachjam/_header.html:17
+#: templates/liiweb/legislation_list.html:16 templates/peachjam/_header.html:17
 msgid "Legislation"
 msgstr ""
 
-#: templates/liiweb/legislation_list.html:18
+#: templates/liiweb/legislation_list.html:23
 msgid "Current legislation"
 msgstr ""
 
-#: templates/liiweb/legislation_list.html:24
+#: templates/liiweb/legislation_list.html:29
 msgid "Repealed legislation"
 msgstr ""
 
-#: templates/liiweb/legislation_list.html:36
+#: templates/liiweb/legislation_list.html:41
 msgid "All legislation"
 msgstr ""
 
-#: templates/liiweb/legislation_list.html:42
+#: templates/liiweb/legislation_list.html:47
 msgid "You are viewing repealed legislation which is no longer in force."
 msgstr ""
 
@@ -96,26 +106,36 @@ msgstr ""
 msgid "Pocket Law"
 msgstr ""
 
-#: templates/peachjam/_footer.html:4
-msgid "Subscribe"
-msgstr ""
-
-#: templates/peachjam/_footer.html:9
-msgid "Subscribe to our newsletter for updates and news."
-msgstr ""
-
-#: templates/peachjam/_footer.html:20 templates/peachjam/_header.html:23
+#: templates/peachjam/_footer.html:4 templates/peachjam/_header.html:23
 msgid "About"
 msgstr ""
 
+#: templates/peachjam/_footer.html:12
+#, python-format
+msgid "Use %(APP_NAME)s offline with <a href=\"%(pocket_law_url)s\">Pocket Law</a>."
+msgstr ""
+
+#: templates/peachjam/_footer.html:20
+msgid "Site Statistics"
+msgstr ""
+
 #: templates/peachjam/_footer.html:24
+msgid "Terms of Use"
+msgstr ""
+
+#: templates/peachjam/_footer.html:29
 msgid "Our partners"
 msgstr ""
 
-#: templates/peachjam/_footer.html:33
+#: templates/peachjam/_footer.html:38
 msgid "Other African Legal Information Institutions"
 msgstr ""
 
 #: templates/peachjam/_header.html:11
 msgid "Judgments"
+msgstr ""
+
+#: views/legislation.py:99
+#, python-format
+msgid "%(locality)s Legislation"
 msgstr ""

--- a/liiweb/locale/fr/LC_MESSAGES/django.po
+++ b/liiweb/locale/fr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 10:30+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
@@ -21,73 +21,85 @@ msgstr ""
 msgid "Home"
 msgstr "Accueil"
 
-#: templates/liiweb/home.html:25 templates/liiweb/home.html:26
+#: templates/liiweb/home.html:35 templates/liiweb/home.html:36
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr "Rechercher dans %(APP_NAME)s"
 
-#: templates/liiweb/home.html:32
+#: templates/liiweb/home.html:42
 msgid "Search"
 msgstr "Recherche"
 
-#: templates/liiweb/home.html:35
+#: templates/liiweb/home.html:44
 msgid "Advanced search"
 msgstr "Recherche avancée"
 
-#: templates/liiweb/home.html:62
+#: templates/liiweb/home.html:67
 msgid "Recent Judgments"
 msgstr "Jugements récents"
 
-#: templates/liiweb/home.html:63
+#: templates/liiweb/home.html:68
 msgid "View more judgments"
 msgstr "Voir plus de jugements"
 
-#: templates/liiweb/home.html:67
+#: templates/liiweb/home.html:72
 msgid "Recent Legislation"
 msgstr "Législation récente"
 
-#: templates/liiweb/home.html:68
+#: templates/liiweb/home.html:73
 msgid "View more legislation"
 msgstr "Voir plus de législation"
 
-#: templates/liiweb/home.html:89
-msgid "Twitter"
-msgstr "Twitter"
-
-#: templates/liiweb/home.html:102
+#: templates/liiweb/home.html:100
 msgid "Facebook"
 msgstr "Facebook"
 
-#: templates/liiweb/home.html:117
-msgid "Tweets by AfricanLII"
-msgstr "Tweets par AfricanLII"
-
-#: templates/liiweb/home.html:150
+#: templates/liiweb/home.html:135
 msgid "Courts"
 msgstr "Cours"
 
-#: templates/liiweb/home.html:154
+#: templates/liiweb/home.html:139
 msgid "Collections"
 msgstr "Collections"
 
+#: templates/liiweb/home.html:152
+#, python-format
+msgid "Use %(APP_NAME)s when you're offline"
+msgstr ""
+
+#: templates/liiweb/home.html:154
+#, python-format
+msgid "Pocket Law is an offline copy of the caselaw, legislation and other legal materials from %(APP_NAME)s."
+msgstr ""
+
+#: templates/liiweb/home.html:166
+msgid "Latest Articles"
+msgstr ""
+
+#: templates/liiweb/home.html:168
+#, fuzzy
+#| msgid "View more legislation"
+msgid "View more articles"
+msgstr "Voir plus de législation"
+
 #: templates/liiweb/legislation_list.html:4
-#: templates/liiweb/legislation_list.html:11 templates/peachjam/_header.html:17
+#: templates/liiweb/legislation_list.html:16 templates/peachjam/_header.html:17
 msgid "Legislation"
 msgstr "Législation"
 
-#: templates/liiweb/legislation_list.html:18
+#: templates/liiweb/legislation_list.html:23
 msgid "Current legislation"
 msgstr "Législation en vigueur"
 
-#: templates/liiweb/legislation_list.html:24
+#: templates/liiweb/legislation_list.html:29
 msgid "Repealed legislation"
 msgstr "Législation abrogée"
 
-#: templates/liiweb/legislation_list.html:36
+#: templates/liiweb/legislation_list.html:41
 msgid "All legislation"
 msgstr "Toutes les lois"
 
-#: templates/liiweb/legislation_list.html:42
+#: templates/liiweb/legislation_list.html:47
 msgid "You are viewing repealed legislation which is no longer in force."
 msgstr "Vous consultez une législation abrogée qui n'est plus en vigueur."
 
@@ -95,23 +107,28 @@ msgstr "Vous consultez une législation abrogée qui n'est plus en vigueur."
 msgid "Pocket Law"
 msgstr "Loi de poche"
 
-#: templates/peachjam/_footer.html:4
-msgid "Subscribe"
-msgstr "S'abonner"
-
-#: templates/peachjam/_footer.html:9
-msgid "Subscribe to our newsletter for updates and news."
-msgstr "Abonnez-vous à notre newsletter pour les mises à jour et les nouvelles."
-
-#: templates/peachjam/_footer.html:20 templates/peachjam/_header.html:23
+#: templates/peachjam/_footer.html:4 templates/peachjam/_header.html:23
 msgid "About"
 msgstr "À propos"
 
+#: templates/peachjam/_footer.html:12
+#, python-format
+msgid "Use %(APP_NAME)s offline with <a href=\"%(pocket_law_url)s\">Pocket Law</a>."
+msgstr ""
+
+#: templates/peachjam/_footer.html:20
+msgid "Site Statistics"
+msgstr ""
+
 #: templates/peachjam/_footer.html:24
+msgid "Terms of Use"
+msgstr ""
+
+#: templates/peachjam/_footer.html:29
 msgid "Our partners"
 msgstr "Nos partenaires"
 
-#: templates/peachjam/_footer.html:33
+#: templates/peachjam/_footer.html:38
 msgid "Other African Legal Information Institutions"
 msgstr "Autres Institutions Africaines d'information Juridique"
 
@@ -119,3 +136,20 @@ msgstr "Autres Institutions Africaines d'information Juridique"
 msgid "Judgments"
 msgstr "Jugements"
 
+#: views/legislation.py:99
+#, fuzzy, python-format
+#| msgid "Recent Legislation"
+msgid "%(locality)s Legislation"
+msgstr "Législation récente"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+
+#~ msgid "Tweets by AfricanLII"
+#~ msgstr "Tweets par AfricanLII"
+
+#~ msgid "Subscribe"
+#~ msgstr "S'abonner"
+
+#~ msgid "Subscribe to our newsletter for updates and news."
+#~ msgstr "Abonnez-vous à notre newsletter pour les mises à jour et les nouvelles."

--- a/liiweb/locale/pt/LC_MESSAGES/django.po
+++ b/liiweb/locale/pt/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 10:30+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese\n"
@@ -21,73 +21,85 @@ msgstr ""
 msgid "Home"
 msgstr "Página inicial"
 
-#: templates/liiweb/home.html:25 templates/liiweb/home.html:26
+#: templates/liiweb/home.html:35 templates/liiweb/home.html:36
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr "Pesquisar %(APP_NAME)s"
 
-#: templates/liiweb/home.html:32
+#: templates/liiweb/home.html:42
 msgid "Search"
 msgstr "Pesquisa"
 
-#: templates/liiweb/home.html:35
+#: templates/liiweb/home.html:44
 msgid "Advanced search"
 msgstr "Pesquisa avançada"
 
-#: templates/liiweb/home.html:62
+#: templates/liiweb/home.html:67
 msgid "Recent Judgments"
 msgstr "Julgamentos Recentes"
 
-#: templates/liiweb/home.html:63
+#: templates/liiweb/home.html:68
 msgid "View more judgments"
 msgstr "Ver mais julgamentos"
 
-#: templates/liiweb/home.html:67
+#: templates/liiweb/home.html:72
 msgid "Recent Legislation"
 msgstr "Legislação recente"
 
-#: templates/liiweb/home.html:68
+#: templates/liiweb/home.html:73
 msgid "View more legislation"
 msgstr "Ver mais legislação"
 
-#: templates/liiweb/home.html:89
-msgid "Twitter"
-msgstr "Twitter"
-
-#: templates/liiweb/home.html:102
+#: templates/liiweb/home.html:100
 msgid "Facebook"
 msgstr "Facebook"
 
-#: templates/liiweb/home.html:117
-msgid "Tweets by AfricanLII"
-msgstr "Tweets de AfricanLII"
-
-#: templates/liiweb/home.html:150
+#: templates/liiweb/home.html:135
 msgid "Courts"
 msgstr "Tribunais"
 
-#: templates/liiweb/home.html:154
+#: templates/liiweb/home.html:139
 msgid "Collections"
 msgstr "Coleções"
 
+#: templates/liiweb/home.html:152
+#, python-format
+msgid "Use %(APP_NAME)s when you're offline"
+msgstr ""
+
+#: templates/liiweb/home.html:154
+#, python-format
+msgid "Pocket Law is an offline copy of the caselaw, legislation and other legal materials from %(APP_NAME)s."
+msgstr ""
+
+#: templates/liiweb/home.html:166
+msgid "Latest Articles"
+msgstr ""
+
+#: templates/liiweb/home.html:168
+#, fuzzy
+#| msgid "View more legislation"
+msgid "View more articles"
+msgstr "Ver mais legislação"
+
 #: templates/liiweb/legislation_list.html:4
-#: templates/liiweb/legislation_list.html:11 templates/peachjam/_header.html:17
+#: templates/liiweb/legislation_list.html:16 templates/peachjam/_header.html:17
 msgid "Legislation"
 msgstr "Legislação"
 
-#: templates/liiweb/legislation_list.html:18
+#: templates/liiweb/legislation_list.html:23
 msgid "Current legislation"
 msgstr "Legislação atual"
 
-#: templates/liiweb/legislation_list.html:24
+#: templates/liiweb/legislation_list.html:29
 msgid "Repealed legislation"
 msgstr "Legislação repetida"
 
-#: templates/liiweb/legislation_list.html:36
+#: templates/liiweb/legislation_list.html:41
 msgid "All legislation"
 msgstr "Toda a legislação"
 
-#: templates/liiweb/legislation_list.html:42
+#: templates/liiweb/legislation_list.html:47
 msgid "You are viewing repealed legislation which is no longer in force."
 msgstr "Estão a ver legislação revogada, que já não está em vigor."
 
@@ -95,23 +107,28 @@ msgstr "Estão a ver legislação revogada, que já não está em vigor."
 msgid "Pocket Law"
 msgstr "Lei de Bolso"
 
-#: templates/peachjam/_footer.html:4
-msgid "Subscribe"
-msgstr "Inscrever-se"
-
-#: templates/peachjam/_footer.html:9
-msgid "Subscribe to our newsletter for updates and news."
-msgstr "Assine nossa newsletter para atualizações e notícias."
-
-#: templates/peachjam/_footer.html:20 templates/peachjam/_header.html:23
+#: templates/peachjam/_footer.html:4 templates/peachjam/_header.html:23
 msgid "About"
 msgstr "Sobre"
 
+#: templates/peachjam/_footer.html:12
+#, python-format
+msgid "Use %(APP_NAME)s offline with <a href=\"%(pocket_law_url)s\">Pocket Law</a>."
+msgstr ""
+
+#: templates/peachjam/_footer.html:20
+msgid "Site Statistics"
+msgstr ""
+
 #: templates/peachjam/_footer.html:24
+msgid "Terms of Use"
+msgstr ""
+
+#: templates/peachjam/_footer.html:29
 msgid "Our partners"
 msgstr "Nossos parceiros"
 
-#: templates/peachjam/_footer.html:33
+#: templates/peachjam/_footer.html:38
 msgid "Other African Legal Information Institutions"
 msgstr "Outras Instituições Jurídicas Africanas"
 
@@ -119,3 +136,20 @@ msgstr "Outras Instituições Jurídicas Africanas"
 msgid "Judgments"
 msgstr "Julgamentos"
 
+#: views/legislation.py:99
+#, fuzzy, python-format
+#| msgid "Recent Legislation"
+msgid "%(locality)s Legislation"
+msgstr "Legislação recente"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+
+#~ msgid "Tweets by AfricanLII"
+#~ msgstr "Tweets de AfricanLII"
+
+#~ msgid "Subscribe"
+#~ msgstr "Inscrever-se"
+
+#~ msgid "Subscribe to our newsletter for updates and news."
+#~ msgstr "Assine nossa newsletter para atualizações e notícias."

--- a/liiweb/locale/sw/LC_MESSAGES/django.po
+++ b/liiweb/locale/sw/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 10:30+0200\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Swahili\n"
@@ -21,73 +21,85 @@ msgstr ""
 msgid "Home"
 msgstr "Nyumbani"
 
-#: templates/liiweb/home.html:25 templates/liiweb/home.html:26
+#: templates/liiweb/home.html:35 templates/liiweb/home.html:36
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr "Tafuta %(APP_NAME)s"
 
-#: templates/liiweb/home.html:32
+#: templates/liiweb/home.html:42
 msgid "Search"
 msgstr "Tafuta"
 
-#: templates/liiweb/home.html:35
+#: templates/liiweb/home.html:44
 msgid "Advanced search"
 msgstr "Utafutaji wa kina"
 
-#: templates/liiweb/home.html:62
+#: templates/liiweb/home.html:67
 msgid "Recent Judgments"
 msgstr "Hukumu za Hivi Karibuni"
 
-#: templates/liiweb/home.html:63
+#: templates/liiweb/home.html:68
 msgid "View more judgments"
 msgstr "Tazama hukumu zaidi"
 
-#: templates/liiweb/home.html:67
+#: templates/liiweb/home.html:72
 msgid "Recent Legislation"
 msgstr "Sheria ya Hivi Karibuni"
 
-#: templates/liiweb/home.html:68
+#: templates/liiweb/home.html:73
 msgid "View more legislation"
 msgstr "Tazama sheria zaidi"
 
-#: templates/liiweb/home.html:89
-msgid "Twitter"
-msgstr "Twitter"
-
-#: templates/liiweb/home.html:102
+#: templates/liiweb/home.html:100
 msgid "Facebook"
 msgstr "Facebook"
 
-#: templates/liiweb/home.html:117
-msgid "Tweets by AfricanLII"
-msgstr "Tweets na AfricanLII"
-
-#: templates/liiweb/home.html:150
+#: templates/liiweb/home.html:135
 msgid "Courts"
 msgstr "Mahakama"
 
-#: templates/liiweb/home.html:154
+#: templates/liiweb/home.html:139
 msgid "Collections"
 msgstr "Makusanyo"
 
+#: templates/liiweb/home.html:152
+#, python-format
+msgid "Use %(APP_NAME)s when you're offline"
+msgstr ""
+
+#: templates/liiweb/home.html:154
+#, python-format
+msgid "Pocket Law is an offline copy of the caselaw, legislation and other legal materials from %(APP_NAME)s."
+msgstr ""
+
+#: templates/liiweb/home.html:166
+msgid "Latest Articles"
+msgstr ""
+
+#: templates/liiweb/home.html:168
+#, fuzzy
+#| msgid "View more legislation"
+msgid "View more articles"
+msgstr "Tazama sheria zaidi"
+
 #: templates/liiweb/legislation_list.html:4
-#: templates/liiweb/legislation_list.html:11 templates/peachjam/_header.html:17
+#: templates/liiweb/legislation_list.html:16 templates/peachjam/_header.html:17
 msgid "Legislation"
 msgstr "Sheria"
 
-#: templates/liiweb/legislation_list.html:18
+#: templates/liiweb/legislation_list.html:23
 msgid "Current legislation"
 msgstr "Sheria za sasa"
 
-#: templates/liiweb/legislation_list.html:24
+#: templates/liiweb/legislation_list.html:29
 msgid "Repealed legislation"
 msgstr "Sheria iliyofutwa"
 
-#: templates/liiweb/legislation_list.html:36
+#: templates/liiweb/legislation_list.html:41
 msgid "All legislation"
 msgstr "Sheria zote"
 
-#: templates/liiweb/legislation_list.html:42
+#: templates/liiweb/legislation_list.html:47
 msgid "You are viewing repealed legislation which is no longer in force."
 msgstr "Unatazama sheria iliyobatilishwa ambayo haitumiki tena."
 
@@ -95,23 +107,28 @@ msgstr "Unatazama sheria iliyobatilishwa ambayo haitumiki tena."
 msgid "Pocket Law"
 msgstr "Sheria zisizo mtandaoni"
 
-#: templates/peachjam/_footer.html:4
-msgid "Subscribe"
-msgstr "Jiandikishe"
-
-#: templates/peachjam/_footer.html:9
-msgid "Subscribe to our newsletter for updates and news."
-msgstr "Jiandikishe kwenye jarida letu kwa usasishaji na habari."
-
-#: templates/peachjam/_footer.html:20 templates/peachjam/_header.html:23
+#: templates/peachjam/_footer.html:4 templates/peachjam/_header.html:23
 msgid "About"
 msgstr "Kuhusu"
 
+#: templates/peachjam/_footer.html:12
+#, python-format
+msgid "Use %(APP_NAME)s offline with <a href=\"%(pocket_law_url)s\">Pocket Law</a>."
+msgstr ""
+
+#: templates/peachjam/_footer.html:20
+msgid "Site Statistics"
+msgstr ""
+
 #: templates/peachjam/_footer.html:24
+msgid "Terms of Use"
+msgstr ""
+
+#: templates/peachjam/_footer.html:29
 msgid "Our partners"
 msgstr "Washirika wetu"
 
-#: templates/peachjam/_footer.html:33
+#: templates/peachjam/_footer.html:38
 msgid "Other African Legal Information Institutions"
 msgstr "Taasisi Nyingine za Taarifa za Kisheria za Afrika"
 
@@ -119,3 +136,20 @@ msgstr "Taasisi Nyingine za Taarifa za Kisheria za Afrika"
 msgid "Judgments"
 msgstr "Hukumu"
 
+#: views/legislation.py:99
+#, fuzzy, python-format
+#| msgid "Recent Legislation"
+msgid "%(locality)s Legislation"
+msgstr "Sheria ya Hivi Karibuni"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+
+#~ msgid "Tweets by AfricanLII"
+#~ msgstr "Tweets na AfricanLII"
+
+#~ msgid "Subscribe"
+#~ msgstr "Jiandikishe"
+
+#~ msgid "Subscribe to our newsletter for updates and news."
+#~ msgstr "Jiandikishe kwenye jarida letu kwa usasishaji na habari."

--- a/peachjam/locale/en/LC_MESSAGES/django.po
+++ b/peachjam/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-13 09:08+0200\n"
+"POT-Creation-Date: 2023-08-30 10:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,105 +18,132 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:291
+#: admin.py:120
+msgid "Import"
+msgstr ""
+
+#: admin.py:363
 msgid "Key details"
 msgstr ""
 
-#: admin.py:304
+#: admin.py:376
 msgid "Additional details"
 msgstr ""
 
-#: admin.py:317
+#: admin.py:389
 msgid "Work identification"
 msgstr ""
 
-#: admin.py:330
+#: admin.py:402
 msgid "Content"
 msgstr ""
 
-#: admin.py:338
+#: admin.py:410
 msgid "Advanced"
 msgstr ""
 
-#: admin.py:493 models/judgment.py:319
+#: admin.py:650 models/judgment.py:370
 msgid "case number"
 msgstr ""
 
-#: admin.py:494 models/judgment.py:320
+#: admin.py:651 models/judgment.py:371
 msgid "case numbers"
 msgstr ""
 
-#: admin.py:586
+#: admin.py:665 models/judgment.py:36 models/judgment.py:158
+msgid "judge"
+msgstr ""
+
+#: admin.py:666 models/judgment.py:37 models/judgment.py:179
+msgid "judges"
+msgstr ""
+
+#: admin.py:766
 msgid "Refreshing content in the background."
 msgstr ""
 
-#: admin.py:588
-msgid "Refresh all content"
+#: admin.py:769
+msgid "Refresh content selected ingestors"
 msgstr ""
 
-#: models/article.py:20 models/core_document_model.py:241
+#: admin.py:817
+msgid "Articles published."
+msgstr ""
+
+#: admin.py:819
+msgid "Publish selected articles"
+msgstr ""
+
+#: admin.py:823
+msgid "Articles unpublished."
+msgstr ""
+
+#: admin.py:825
+msgid "Unpublish selected articles"
+msgstr ""
+
+#: models/article.py:21 models/core_document_model.py:326
 msgid "date"
 msgstr ""
 
-#: models/article.py:21 models/core_document_model.py:78
-#: models/core_document_model.py:240 models/core_document_model.py:661
+#: models/article.py:22 models/core_document_model.py:161
+#: models/core_document_model.py:325
 msgid "title"
 msgstr ""
 
-#: models/article.py:22
+#: models/article.py:23
 msgid "body"
 msgstr ""
 
-#: models/article.py:27 models/author.py:20 models/generic_document.py:20
-#: models/generic_document.py:48
+#: models/article.py:28 models/author.py:21
 msgid "author"
 msgstr ""
 
-#: models/article.py:30 models/core_document_model.py:573
+#: models/article.py:31 models/core_document_model.py:738
 msgid "image"
 msgstr ""
 
-#: models/article.py:32
+#: models/article.py:33
 msgid "summary"
 msgstr ""
 
-#: models/article.py:33 models/relationships.py:7 models/taxonomies.py:11
+#: models/article.py:34 models/relationships.py:7 models/taxonomies.py:12
 msgid "slug"
 msgstr ""
 
-#: models/article.py:34
+#: models/article.py:35
 msgid "published"
 msgstr ""
 
-#: models/article.py:35
+#: models/article.py:37
 msgid "topics"
 msgstr ""
 
-#: models/article.py:38
+#: models/article.py:41
 msgid "article"
 msgstr ""
 
-#: models/article.py:39
+#: models/article.py:42
 msgid "articles"
 msgstr ""
 
-#: models/article.py:64
+#: models/article.py:75
 msgid "user"
 msgstr ""
 
-#: models/article.py:67
+#: models/article.py:78
 msgid "photo"
 msgstr ""
 
-#: models/article.py:69
+#: models/article.py:80
 msgid "profile description"
 msgstr ""
 
-#: models/article.py:72
+#: models/article.py:83
 msgid "user profile"
 msgstr ""
 
-#: models/article.py:73
+#: models/article.py:84
 msgid "user profiles"
 msgstr ""
 
@@ -124,285 +151,335 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: models/author.py:9 models/core_document_model.py:41
-#: models/core_document_model.py:55 models/core_document_model.py:624
-#: models/ingestors.py:14 models/ingestors.py:33 models/judgment.py:14
-#: models/judgment.py:28 models/judgment.py:41 models/judgment.py:55
-#: models/judgment.py:69 models/judgment.py:86 models/judgment.py:120
-#: models/relationships.py:6 models/taxonomies.py:10
+#: models/author.py:8
+msgid "Authors"
+msgstr ""
+
+#: models/author.py:10 models/core_document_model.py:44
+#: models/core_document_model.py:72 models/core_document_model.py:86
+#: models/core_document_model.py:810 models/ingestors.py:14
+#: models/ingestors.py:33 models/judgment.py:15 models/judgment.py:30
+#: models/judgment.py:45 models/judgment.py:60 models/judgment.py:74
+#: models/judgment.py:91 models/judgment.py:125 models/relationships.py:6
+#: models/taxonomies.py:11
 msgid "name"
 msgstr ""
 
-#: models/author.py:10 models/core_document_model.py:43
-#: models/core_document_model.py:59 models/judgment.py:87
-#: models/judgment.py:121
+#: models/author.py:11 models/core_document_model.py:46
+#: models/core_document_model.py:74 models/core_document_model.py:90
+#: models/judgment.py:92 models/judgment.py:126
 msgid "code"
 msgstr ""
 
-#: models/author.py:13 models/judgment.py:96 models/profile.py:35
-#: models/profile.py:36
+#: models/author.py:14 models/core_document_model.py:92 models/judgment.py:101
+#: models/profile.py:35 models/profile.py:36 models/taxonomies.py:15
 msgid "profile"
 msgstr ""
 
-#: models/author.py:21
+#: models/author.py:22 models/generic_document.py:19
+#: models/generic_document.py:45
 msgid "authors"
 msgstr ""
 
-#: models/citations.py:10 models/core_document_model.py:568
-#: models/core_document_model.py:594 models/core_document_model.py:640
-#: models/core_document_model.py:659 models/core_document_model.py:680
-#: models/judgment.py:314 models/taxonomies.py:32
+#: models/citations.py:16 models/core_document_model.py:733
+#: models/core_document_model.py:759 models/core_document_model.py:826
+#: models/core_document_model.py:855 models/core_document_model.py:881
+#: models/judgment.py:365 models/taxonomies.py:46
 msgid "document"
 msgstr ""
 
-#: models/citations.py:12
+#: models/citations.py:18
 msgid "text"
 msgstr ""
 
-#: models/citations.py:13
+#: models/citations.py:19
 msgid "url"
 msgstr ""
 
-#: models/citations.py:15
+#: models/citations.py:21
 msgid "target id"
 msgstr ""
 
-#: models/citations.py:17
+#: models/citations.py:23
 msgid "target selectors"
 msgstr ""
 
-#: models/citations.py:20
+#: models/citations.py:26
 msgid "citation link"
 msgstr ""
 
-#: models/citations.py:21
+#: models/citations.py:27
 msgid "citation links"
 msgstr ""
 
-#: models/citations.py:56
+#: models/citations.py:62
 msgid "citing work"
 msgstr ""
 
-#: models/citations.py:63
+#: models/citations.py:69
 msgid "target work"
 msgstr ""
 
-#: models/core_document_model.py:44 models/core_document_model.py:626
-#: models/judgment.py:16 models/judgment.py:29 models/judgment.py:42
-#: models/judgment.py:57 models/judgment.py:70
-msgid "description"
+#: models/citations.py:90
+msgid "processing date"
 msgstr ""
 
-#: models/core_document_model.py:47
-msgid "document nature"
+#: models/citations.py:93
+msgid "citation processing"
 msgstr ""
 
 #: models/core_document_model.py:48
+msgid "level"
+msgstr ""
+
+#: models/core_document_model.py:62
+msgid "label"
+msgstr ""
+
+#: models/core_document_model.py:63 models/core_document_model.py:433
+msgid "labels"
+msgstr ""
+
+#: models/core_document_model.py:75 models/core_document_model.py:812
+#: models/judgment.py:17 models/judgment.py:32 models/judgment.py:47
+#: models/judgment.py:62 models/judgment.py:75
+msgid "description"
+msgstr ""
+
+#: models/core_document_model.py:78
+msgid "document nature"
+msgstr ""
+
+#: models/core_document_model.py:79
 msgid "document natures"
 msgstr ""
 
-#: models/core_document_model.py:57 models/core_document_model.py:261
+#: models/core_document_model.py:88 models/core_document_model.py:346
 msgid "jurisdiction"
 msgstr ""
 
-#: models/core_document_model.py:62 models/core_document_model.py:268
+#: models/core_document_model.py:96 models/core_document_model.py:353
 msgid "locality"
 msgstr ""
 
-#: models/core_document_model.py:63
+#: models/core_document_model.py:97
 msgid "localities"
 msgstr ""
 
-#: models/core_document_model.py:76
+#: models/core_document_model.py:110
 msgid "FRBR URI"
 msgstr ""
 
-#: models/core_document_model.py:84
-msgid "languages"
+#: models/core_document_model.py:114
+msgid "FRBR URI country"
 msgstr ""
 
-#: models/core_document_model.py:87
-msgid "ranking"
+#: models/core_document_model.py:120
+msgid "FRBR URI locality"
 msgstr ""
 
-#: models/core_document_model.py:90 models/core_document_model.py:230
-msgid "work"
+#: models/core_document_model.py:126
+msgid "FRBR URI place"
 msgstr ""
 
-#: models/core_document_model.py:91
-msgid "works"
-msgstr ""
-
-#: models/core_document_model.py:233
-msgid "document type"
-msgstr ""
-
-#: models/core_document_model.py:243 models/core_document_model.py:597
-msgid "source URL"
-msgstr ""
-
-#: models/core_document_model.py:245
-msgid "citation"
-msgstr ""
-
-#: models/core_document_model.py:246
-msgid "content HTML"
-msgstr ""
-
-#: models/core_document_model.py:247
-msgid "content HTML is AKN"
-msgstr ""
-
-#: models/core_document_model.py:248
-msgid "TOC JSON"
-msgstr ""
-
-#: models/core_document_model.py:254
-msgid "language"
-msgstr ""
-
-#: models/core_document_model.py:275 models/core_document_model.py:643
-msgid "nature"
-msgstr ""
-
-#: models/core_document_model.py:279
-msgid "work FRBR URI"
-msgstr ""
-
-#: models/core_document_model.py:284
+#: models/core_document_model.py:132 models/core_document_model.py:369
 msgid "FRBR URI doctype"
 msgstr ""
 
-#: models/core_document_model.py:291
+#: models/core_document_model.py:138 models/core_document_model.py:376
 msgid "FRBR URI subtype"
 msgstr ""
 
-#: models/core_document_model.py:296
-msgid "Document subtype. Lowercase letters, numbers _ and - only."
-msgstr ""
-
-#: models/core_document_model.py:299
+#: models/core_document_model.py:144 models/core_document_model.py:384
 msgid "FRBR URI actor"
 msgstr ""
 
-#: models/core_document_model.py:304
-msgid "Originating actor. Lowercase letters, numbers _ and - only."
-msgstr ""
-
-#: models/core_document_model.py:307
+#: models/core_document_model.py:150 models/core_document_model.py:392
 msgid "FRBR URI date"
 msgstr ""
 
-#: models/core_document_model.py:312
-msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
-msgstr ""
-
-#: models/core_document_model.py:315
+#: models/core_document_model.py:156 models/core_document_model.py:400
 msgid "FRBR URI number"
 msgstr ""
 
-#: models/core_document_model.py:321
-msgid "Unique number or short title identifying this work. Lowercase letters, numbers _ and - only."
+#: models/core_document_model.py:167
+msgid "languages"
 msgstr ""
 
-#: models/core_document_model.py:326
-msgid "expression FRBR URI"
+#: models/core_document_model.py:170
+msgid "ranking"
+msgstr ""
+
+#: models/core_document_model.py:173 models/core_document_model.py:315
+msgid "work"
+msgstr ""
+
+#: models/core_document_model.py:174
+msgid "works"
+msgstr ""
+
+#: models/core_document_model.py:318
+msgid "document type"
+msgstr ""
+
+#: models/core_document_model.py:328 models/core_document_model.py:762
+msgid "source URL"
 msgstr ""
 
 #: models/core_document_model.py:330
-msgid "created at"
+msgid "citation"
 msgstr ""
 
 #: models/core_document_model.py:331
-msgid "updated at"
+msgid "content HTML"
 msgstr ""
 
-#: models/core_document_model.py:336
-msgid "created by"
+#: models/core_document_model.py:332
+msgid "content HTML is AKN"
+msgstr ""
+
+#: models/core_document_model.py:333
+msgid "TOC JSON"
 msgstr ""
 
 #: models/core_document_model.py:339
+msgid "language"
+msgstr ""
+
+#: models/core_document_model.py:360 models/core_document_model.py:829
+msgid "nature"
+msgstr ""
+
+#: models/core_document_model.py:364
+msgid "work FRBR URI"
+msgstr ""
+
+#: models/core_document_model.py:381
+msgid "Document subtype. Lowercase letters, numbers _ and - only."
+msgstr ""
+
+#: models/core_document_model.py:389
+msgid "Originating actor. Lowercase letters, numbers _ and - only."
+msgstr ""
+
+#: models/core_document_model.py:397
+msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
+msgstr ""
+
+#: models/core_document_model.py:406
+msgid "Unique number or short title identifying this work. Lowercase letters, numbers _ and - only."
+msgstr ""
+
+#: models/core_document_model.py:411
+msgid "expression FRBR URI"
+msgstr ""
+
+#: models/core_document_model.py:415
+msgid "created at"
+msgstr ""
+
+#: models/core_document_model.py:416
+msgid "updated at"
+msgstr ""
+
+#: models/core_document_model.py:422
+msgid "created by"
+msgstr ""
+
+#: models/core_document_model.py:425
 msgid "allow robots"
 msgstr ""
 
-#: models/core_document_model.py:342
+#: models/core_document_model.py:428
 msgid "Allow this document to be indexed by search engine robots."
 msgstr ""
 
-#: models/core_document_model.py:368
-msgid "Invalid Date"
-msgstr ""
-
-#: models/core_document_model.py:371
+#: models/core_document_model.py:469
 msgid "You cannot set a future date for the document"
 msgstr ""
 
-#: models/core_document_model.py:377
+#: models/core_document_model.py:477
 #, python-format
 msgid "Invalid FRBR URI: %(uri)s"
 msgstr ""
 
-#: models/core_document_model.py:540
+#: models/core_document_model.py:488
+msgid "Document with this Expression FRBR URI already exists!"
+msgstr ""
+
+#: models/core_document_model.py:705
 msgid "filename"
 msgstr ""
 
-#: models/core_document_model.py:541
+#: models/core_document_model.py:706
 msgid "mimetype"
 msgstr ""
 
-#: models/core_document_model.py:542
+#: models/core_document_model.py:707
 msgid "size"
 msgstr ""
 
-#: models/core_document_model.py:543 models/core_document_model.py:570
+#: models/core_document_model.py:708 models/core_document_model.py:735
 msgid "file"
 msgstr ""
 
-#: models/core_document_model.py:574
+#: models/core_document_model.py:739
 msgid "images"
 msgstr ""
 
-#: models/core_document_model.py:601
+#: models/core_document_model.py:766
+msgid "file as pdf"
+msgstr ""
+
+#: models/core_document_model.py:774
 msgid "source file"
 msgstr ""
 
-#: models/core_document_model.py:602
+#: models/core_document_model.py:775
 msgid "source files"
 msgstr ""
 
-#: models/core_document_model.py:629
+#: models/core_document_model.py:815
 msgid "attached file nature"
 msgstr ""
 
-#: models/core_document_model.py:630
+#: models/core_document_model.py:816
 msgid "attached file natures"
 msgstr ""
 
-#: models/core_document_model.py:647
+#: models/core_document_model.py:833
 msgid "attached file"
 msgstr ""
 
-#: models/core_document_model.py:648
+#: models/core_document_model.py:834
 msgid "attached files"
 msgstr ""
 
-#: models/core_document_model.py:664
+#: models/core_document_model.py:858
+msgid "Law report citation/Alternative known name"
+msgstr ""
+
+#: models/core_document_model.py:865
 msgid "alternative name"
 msgstr ""
 
-#: models/core_document_model.py:665
+#: models/core_document_model.py:866
 msgid "alternative names"
 msgstr ""
 
-#: models/core_document_model.py:685
+#: models/core_document_model.py:886
 msgid "document text"
 msgstr ""
 
-#: models/core_document_model.py:689
+#: models/core_document_model.py:890
+msgid "document XML"
+msgstr ""
+
+#: models/core_document_model.py:894
 msgid "document content"
 msgstr ""
 
-#: models/core_document_model.py:690
+#: models/core_document_model.py:895
 msgid "document contents"
 msgstr ""
 
@@ -414,35 +491,35 @@ msgstr ""
 msgid "gazettes"
 msgstr ""
 
-#: models/generic_document.py:26
+#: models/generic_document.py:25
 msgid "generic document"
 msgstr ""
 
-#: models/generic_document.py:27
+#: models/generic_document.py:26
 msgid "generic documents"
 msgstr ""
 
-#: models/generic_document.py:54
+#: models/generic_document.py:51
 msgid "legal instrument"
 msgstr ""
 
-#: models/generic_document.py:55
+#: models/generic_document.py:52
 msgid "legal instruments"
 msgstr ""
 
-#: models/generic_document.py:77
+#: models/generic_document.py:74
 msgid "metadata JSON"
 msgstr ""
 
-#: models/generic_document.py:78 templates/peachjam/document_popup.html:9
+#: models/generic_document.py:75 templates/peachjam/document_popup.html:9
 msgid "repealed"
 msgstr ""
 
-#: models/generic_document.py:80
+#: models/generic_document.py:77
 msgid "parent work"
 msgstr ""
 
-#: models/generic_document.py:86 models/generic_document.py:87
+#: models/generic_document.py:83 models/generic_document.py:84
 msgid "legislation"
 msgstr ""
 
@@ -474,135 +551,123 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: models/judgment.py:20
+#: models/judgment.py:21
 msgid "attorney"
 msgstr ""
 
-#: models/judgment.py:21 models/judgment.py:149
+#: models/judgment.py:22 models/judgment.py:182
 msgid "attorneys"
 msgstr ""
 
-#: models/judgment.py:33
-msgid "judge"
-msgstr ""
-
-#: models/judgment.py:34 models/judgment.py:147
-msgid "judges"
-msgstr ""
-
-#: models/judgment.py:46
+#: models/judgment.py:51
 msgid "order outcome"
 msgstr ""
 
-#: models/judgment.py:47
+#: models/judgment.py:52
 msgid "order outcomes"
 msgstr ""
 
-#: models/judgment.py:61 models/judgment.py:307
+#: models/judgment.py:66 models/judgment.py:358
 msgid "matter type"
 msgstr ""
 
-#: models/judgment.py:62
+#: models/judgment.py:67
 msgid "matter types"
 msgstr ""
 
-#: models/judgment.py:71 models/judgment.py:98
+#: models/judgment.py:76 models/judgment.py:103
 msgid "order"
 msgstr ""
 
-#: models/judgment.py:78 models/judgment.py:93
+#: models/judgment.py:83 models/judgment.py:98
 msgid "court class"
 msgstr ""
 
-#: models/judgment.py:79
+#: models/judgment.py:84
 msgid "court classes"
 msgstr ""
 
-#: models/judgment.py:105 models/judgment.py:118 models/judgment.py:138
+#: models/judgment.py:110 models/judgment.py:123 models/judgment.py:169
 msgid "court"
 msgstr ""
 
-#: models/judgment.py:106
+#: models/judgment.py:111
 msgid "courts"
 msgstr ""
 
-#: models/judgment.py:124
+#: models/judgment.py:129
 msgid "court registry"
 msgstr ""
 
-#: models/judgment.py:125
+#: models/judgment.py:130
 msgid "court registries"
 msgstr ""
 
-#: models/judgment.py:158
-msgid "headnote holding"
-msgstr ""
-
-#: models/judgment.py:160
-msgid "additional citations"
-msgstr ""
-
-#: models/judgment.py:162
-msgid "flynote"
-msgstr ""
-
-#: models/judgment.py:164
-msgid "case name"
-msgstr ""
-
-#: models/judgment.py:166
-msgid "Party names for use in title"
-msgstr ""
-
-#: models/judgment.py:172
-msgid "serial number"
-msgstr ""
-
-#: models/judgment.py:174
-msgid "Serial number for MNC, unique for a year and an author."
-msgstr ""
-
-#: models/judgment.py:177
-msgid "serial number override"
-msgstr ""
-
-#: models/judgment.py:180
-msgid "Specific MNC serial number assigned by the court."
-msgstr ""
-
-#: models/judgment.py:184
-msgid "MNC"
-msgstr ""
-
-#: models/judgment.py:186
-msgid "Media neutral citation"
-msgstr ""
-
-#: models/judgment.py:201
+#: models/judgment.py:156 models/judgment.py:231
 msgid "judgment"
 msgstr ""
 
+#: models/judgment.py:191
+msgid "case summary"
+msgstr ""
+
+#: models/judgment.py:192
+msgid "flynote"
+msgstr ""
+
+#: models/judgment.py:194
+msgid "case name"
+msgstr ""
+
+#: models/judgment.py:196
+msgid "Party names for use in title"
+msgstr ""
+
 #: models/judgment.py:202
+msgid "serial number"
+msgstr ""
+
+#: models/judgment.py:204
+msgid "Serial number for MNC, unique for a year and an author."
+msgstr ""
+
+#: models/judgment.py:207
+msgid "serial number override"
+msgstr ""
+
+#: models/judgment.py:210
+msgid "Specific MNC serial number assigned by the court."
+msgstr ""
+
+#: models/judgment.py:214
+msgid "MNC"
+msgstr ""
+
+#: models/judgment.py:216
+msgid "Media neutral citation"
+msgstr ""
+
+#: models/judgment.py:232
 msgid "judgments"
 msgstr ""
 
-#: models/judgment.py:293
-msgid "string override"
+#: models/judgment.py:344
+msgid "Full case number as printed on judgment"
 msgstr ""
 
-#: models/judgment.py:297
+#: models/judgment.py:348
 msgid "Override for full case number string"
 msgstr ""
 
-#: models/judgment.py:299
+#: models/judgment.py:350
 msgid "string"
 msgstr ""
 
-#: models/judgment.py:300 templates/peachjam/_timeline_events.html:32
+#: models/judgment.py:351 templates/peachjam/_timeline_events.html:35
 msgid "number"
 msgstr ""
 
-#: models/judgment.py:301
+#: models/judgment.py:352
 msgid "year"
 msgstr ""
 
@@ -671,55 +736,95 @@ msgstr ""
 msgid "document languages"
 msgstr ""
 
-#: models/settings.py:40
+#: models/settings.py:41
+msgid "default document jurisdiction"
+msgstr ""
+
+#: models/settings.py:47
 msgid "document jurisdictions"
 msgstr ""
 
-#: models/settings.py:43
+#: models/settings.py:50
 msgid "subsidiary legislation label"
 msgstr ""
 
-#: models/settings.py:48
+#: models/settings.py:55
 msgid "google analytics id"
 msgstr ""
 
-#: models/settings.py:51
+#: models/settings.py:59
+msgid "Enter one or more Google Analytics IDs separated by spaces."
+msgstr ""
+
+#: models/settings.py:62
 msgid "pagerank boost value"
 msgstr ""
 
-#: models/settings.py:55
+#: models/settings.py:65
+msgid "allowed login domains"
+msgstr ""
+
+#: models/settings.py:69
+msgid "metabase dashboard link"
+msgstr ""
+
+#: models/settings.py:73
+msgid "mailchimp form url"
+msgstr ""
+
+#: models/settings.py:76
+msgid "twitter link"
+msgstr ""
+
+#: models/settings.py:79
+msgid "facebook link"
+msgstr ""
+
+#: models/settings.py:82
+msgid "re-extract citations"
+msgstr ""
+
+#: models/settings.py:85
+msgid "Pocket Law repo"
+msgstr ""
+
+#: models/settings.py:88
+msgid "help link"
+msgstr ""
+
+#: models/settings.py:95
 msgid "site settings"
 msgstr ""
 
-#: models/taxonomies.py:15 models/taxonomies.py:16
+#: models/taxonomies.py:19 models/taxonomies.py:20
 msgid "taxonomies"
 msgstr ""
 
-#: models/taxonomies.py:35
+#: models/taxonomies.py:49
 msgid "topic"
 msgstr ""
 
-#: models/taxonomies.py:40
+#: models/taxonomies.py:54
 msgid "document topic"
 msgstr ""
 
-#: models/taxonomies.py:41
+#: models/taxonomies.py:55
 msgid "document topics"
 msgstr ""
 
-#: settings.py:210
+#: settings.py:235
 msgid "English"
 msgstr ""
 
-#: settings.py:211
+#: settings.py:236
 msgid "French"
 msgstr ""
 
-#: settings.py:212
+#: settings.py:237
 msgid "Portuguese"
 msgstr ""
 
-#: settings.py:213
+#: settings.py:238
 msgid "Swahili"
 msgstr ""
 
@@ -838,6 +943,10 @@ msgstr ""
 msgid "Your password has been reset."
 msgstr ""
 
+#: templates/admin/change_form.html:7 templates/admin/change_list.html:10
+msgid "Help"
+msgstr ""
+
 #: templates/admin/login.html:20
 msgid "Please correct the error below."
 msgstr ""
@@ -855,6 +964,19 @@ msgstr ""
 msgid "Forgotten your password or username?"
 msgstr ""
 
+#: templates/admin/tree_change_list.html:7
+#: templates/peachjam/_document_content.html:48
+msgid "Search"
+msgstr ""
+
+#: templates/admin/tree_change_list.html:8
+msgid "Collapse all"
+msgstr ""
+
+#: templates/admin/tree_change_list.html:9
+msgid "Expand all"
+msgstr ""
+
 #: templates/peachjam/_child_documents.html:2
 msgid "Subsidiary legislation"
 msgstr ""
@@ -869,62 +991,68 @@ msgstr ""
 msgid "Numbered title"
 msgstr ""
 
-#: templates/peachjam/_citations.html:6
+#: templates/peachjam/_citations.html:7
 msgid "Cited documents"
 msgstr ""
 
-#: templates/peachjam/_citations.html:18
+#: templates/peachjam/_citations.html:13
 msgid "Documents citing this one"
 msgstr ""
 
-#: templates/peachjam/_court_list.html:14
-#: templates/peachjam/_court_list.html:20
+#: templates/peachjam/_citations_list.html:27
+msgid "Show/Hide all"
+msgstr ""
+
+#: templates/peachjam/_court_list.html:16
+#: templates/peachjam/_court_list.html:22
 msgid "No courts found."
 msgstr ""
 
-#: templates/peachjam/_document_content.html:24
+#: templates/peachjam/_document_content.html:25
 msgid "Table of contents"
 msgstr ""
 
-#: templates/peachjam/_document_content.html:36
+#: templates/peachjam/_document_content.html:37
 msgid "Pages"
 msgstr ""
 
-#: templates/peachjam/_document_content.html:47
-msgid "Search"
-msgstr ""
-
-#: templates/peachjam/_document_content.html:134
+#: templates/peachjam/_document_content.html:136
 msgid "Loading PDF..."
 msgstr ""
 
-#: templates/peachjam/_document_content.html:144
+#: templates/peachjam/_document_content.html:146
 #, python-format
 msgid "This document is %(filesize)s. Do you want to load it?"
 msgstr ""
 
-#: templates/peachjam/_document_content.html:148
+#: templates/peachjam/_document_content.html:150
 msgid "Load document"
 msgstr ""
 
-#: templates/peachjam/_document_content.html:157
+#: templates/peachjam/_document_content.html:159
 msgid "To the top"
 msgstr ""
 
-#: templates/peachjam/_document_count.html:4
+#: templates/peachjam/_document_count.html:3
 #, python-format
 msgid "%(doc_count)s document"
 msgid_plural "%(doc_count)s documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/peachjam/_document_table.html:10
-#: templates/peachjam/_judgment_table.html:8
-#: templates/peachjam/layouts/document_detail.html:214
+#: templates/peachjam/_document_table.html:8
+#: templates/peachjam/_ratifications.html:17
+msgid "Country"
+msgstr ""
+
+#: templates/peachjam/_document_table.html:13
+#: templates/peachjam/_judgment_table.html:7
+#: templates/peachjam/layouts/document_detail.html:232
 msgid "Date"
 msgstr ""
 
-#: templates/peachjam/_document_table.html:28
+#: templates/peachjam/_document_table.html:33
+#: templates/peachjam/layouts/document_detail.html:268
 msgid "Multiple languages available"
 msgstr ""
 
@@ -936,22 +1064,30 @@ msgstr ""
 msgid "Visit website"
 msgstr ""
 
-#: templates/peachjam/_header.html:32 templates/peachjam/_header.html:33
+#: templates/peachjam/_header.html:33 templates/peachjam/_header.html:34
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr ""
 
-#: templates/peachjam/_header.html:55
+#: templates/peachjam/_header.html:57
 msgid "Admin"
 msgstr ""
 
-#: templates/peachjam/_header.html:56
+#: templates/peachjam/_header.html:58
 msgid "Logout"
 msgstr ""
 
-#: templates/peachjam/_judgment_table.html:7
-#: templates/peachjam/layouts/document_detail.html:196
-msgid "Judges"
+#: templates/peachjam/_mailchimp_form.html:4
+msgid "Subscribe"
+msgstr ""
+
+#: templates/peachjam/_mailchimp_form.html:11
+msgid "Subscribe to our newsletter for updates and news."
+msgstr ""
+
+#: templates/peachjam/_months_list.html:7
+#: templates/peachjam/_months_list.html:24
+msgid "All months"
 msgstr ""
 
 #: templates/peachjam/_pagination.html:6
@@ -970,43 +1106,47 @@ msgstr ""
 msgid "Last updated"
 msgstr ""
 
-#: templates/peachjam/_ratifications.html:17
-msgid "Country"
-msgstr ""
-
 #: templates/peachjam/_ratifications.html:18
-msgid "Ratification Date"
-msgstr ""
-
-#: templates/peachjam/_ratifications.html:19
-msgid "Deposit Date"
-msgstr ""
-
-#: templates/peachjam/_ratifications.html:20
 msgid "Signature Date"
 msgstr ""
 
+#: templates/peachjam/_ratifications.html:19
+msgid "Ratification Date"
+msgstr ""
+
+#: templates/peachjam/_ratifications.html:20
+msgid "Deposit Date"
+msgstr ""
+
 #: templates/peachjam/_recent_document_list.html:14
-#: templates/peachjam/court_detail.html:35
-#: templates/peachjam/layouts/document_list.html:59
+#: templates/peachjam/court_detail.html:42
+#: templates/peachjam/layouts/document_list.html:60
 msgid "No documents found."
 msgstr ""
 
-#: templates/peachjam/_related_documents.html:2
-#: templates/peachjam/layouts/document_detail.html:84
-#: templates/peachjam/layouts/document_detail.html:328
+#: templates/peachjam/_registries.html:3
+msgid "Registries"
+msgstr ""
+
+#: templates/peachjam/_related_documents.html:4
+#: templates/peachjam/layouts/document_detail.html:93
+#: templates/peachjam/layouts/document_detail.html:357
 msgid "Related documents"
 msgstr ""
 
-#: templates/peachjam/_taxonomies.html:2
-#: templates/peachjam/first_level_taxonomy_detail.html:9
-#: templates/peachjam/taxonomy_detail.html:13
-#: templates/peachjam/top_level_taxonomy_list.html:8
+#: templates/peachjam/_social_media.html:2
+msgid "Follow us on social media"
+msgstr ""
+
+#: templates/peachjam/_taxonomies.html:4
+#: templates/peachjam/taxonomy_detail.html:10
+#: templates/peachjam/taxonomy_first_level_detail.html:10
+#: templates/peachjam/taxonomy_list.html:8
 msgid "Taxonomies"
 msgstr ""
 
 #: templates/peachjam/_taxonomy_list.html:23
-#: templates/peachjam/first_level_taxonomy_detail.html:25
+#: templates/peachjam/taxonomy_first_level_detail.html:28
 msgid "No taxonomies found"
 msgstr ""
 
@@ -1250,43 +1390,43 @@ msgstr ""
 msgid "Date of notice: 14 November 2022"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:2
+#: templates/peachjam/_timeline_events.html:4
 msgid "History of this document"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:11
+#: templates/peachjam/_timeline_events.html:14
 msgid "this version"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:15
+#: templates/peachjam/_timeline_events.html:18
 msgid "amendment not yet applied"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:24
+#: templates/peachjam/_timeline_events.html:27
 msgid "Amended by"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:27
+#: templates/peachjam/_timeline_events.html:30
 msgid "Assented to"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:29
+#: templates/peachjam/_timeline_events.html:32
 msgid "Commences"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:31
+#: templates/peachjam/_timeline_events.html:34
 msgid "Published in"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:34
+#: templates/peachjam/_timeline_events.html:37
 msgid "Repealed by"
 msgstr ""
 
-#: templates/peachjam/_timeline_events.html:42
+#: templates/peachjam/_timeline_events.html:45
 msgid "Read this version"
 msgstr ""
 
-#: templates/peachjam/_years_list.html:9 templates/peachjam/_years_list.html:25
+#: templates/peachjam/_years_list.html:7 templates/peachjam/_years_list.html:24
 msgid "All years"
 msgstr ""
 
@@ -1296,20 +1436,30 @@ msgstr ""
 
 #: templates/peachjam/article_detail.html:9
 #: templates/peachjam/article_list.html:4
+#: templates/peachjam/article_list.html:12
+#: templates/peachjam/article_list.html:17
 #: templates/peachjam/user_profile.html:21
 msgid "Articles"
 msgstr ""
 
-#: templates/peachjam/article_detail.html:56
+#: templates/peachjam/article_detail.html:44
+#: templates/peachjam/layouts/document_detail.html:313
+#: templates/peachjam/layouts/document_detail.html:318
+#: templates/peachjam/layouts/document_detail.html:324
+#: templates/peachjam/layouts/document_detail.html:337
+msgid "Download"
+msgstr ""
+
+#: templates/peachjam/article_detail.html:64
 msgid "About the author"
 msgstr ""
 
-#: templates/peachjam/article_detail.html:61
+#: templates/peachjam/article_detail.html:69
 #, python-format
 msgid "Recent articles by %(username)s"
 msgstr ""
 
-#: templates/peachjam/article_list.html:9
+#: templates/peachjam/article_list.html:23
 msgid "Latest Articles"
 msgstr ""
 
@@ -1323,6 +1473,7 @@ msgid "Books"
 msgstr ""
 
 #: templates/peachjam/court_detail.html:9
+#: templates/peachjam/court_registry_detail.html:9
 #: templates/peachjam/judgment_list.html:4
 #: templates/peachjam/judgment_list.html:9
 msgid "Judgments"
@@ -1338,8 +1489,8 @@ msgstr ""
 msgid "Gazettes"
 msgstr ""
 
-#: templates/peachjam/gazette_list.html:34
-#: templates/peachjam/gazette_list.html:59
+#: templates/peachjam/gazette_list.html:35
+#: templates/peachjam/gazette_list.html:60
 #, python-format
 msgid "%(num_gazettes)s gazette"
 msgid_plural "%(num_gazettes)s gazettes"
@@ -1365,17 +1516,17 @@ msgid "Media Neutral Citation"
 msgstr ""
 
 #: templates/peachjam/judgment_detail.html:13
-#: templates/peachjam/layouts/document_detail.html:155
+#: templates/peachjam/layouts/document_detail.html:165
 msgid "Copy to clipboard"
 msgstr ""
 
 #: templates/peachjam/judgment_detail.html:16
-#: templates/peachjam/layouts/document_detail.html:158
+#: templates/peachjam/layouts/document_detail.html:168
 msgid "Copied!"
 msgstr ""
 
 #: templates/peachjam/judgment_detail.html:17
-#: templates/peachjam/layouts/document_detail.html:159
+#: templates/peachjam/layouts/document_detail.html:169
 msgid "Copy"
 msgstr ""
 
@@ -1384,86 +1535,95 @@ msgid "Hearing date"
 msgstr ""
 
 #: templates/peachjam/judgment_detail.html:31
-msgid "Court Registry"
+msgid "Court"
 msgstr ""
 
 #: templates/peachjam/judgment_detail.html:39
+msgid "Court Registry"
+msgstr ""
+
+#: templates/peachjam/judgment_detail.html:47
 msgid "Order"
 msgstr ""
 
-#: templates/peachjam/judgment_detail.html:48
+#: templates/peachjam/judgment_detail.html:56
 msgid "Case number"
 msgstr ""
 
-#: templates/peachjam/judgment_detail.html:61
+#: templates/peachjam/judgment_detail.html:69
 msgid "Attorneys"
+msgstr ""
+
+#: templates/peachjam/judgment_detail.html:83
+msgid "Flynote"
+msgstr ""
+
+#: templates/peachjam/judgment_detail.html:93
+msgid "Case summary"
 msgstr ""
 
 #: templates/peachjam/judgment_list.html:15
 msgid "Recent judgments"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:59
+#: templates/peachjam/layouts/document_detail.html:66
 msgid "Document detail"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:71
+#: templates/peachjam/layouts/document_detail.html:79
 msgid "History"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:98
+#: templates/peachjam/layouts/document_detail.html:108
 msgid "Citations"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:112
+#: templates/peachjam/layouts/document_detail.html:122
 msgid "Ratifications"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:136
+#: templates/peachjam/layouts/document_detail.html:146
 msgid "Jurisdiction"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:149
+#: templates/peachjam/layouts/document_detail.html:159
 msgid "Citation"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:168
+#: templates/peachjam/layouts/document_detail.html:179
+msgid "Law report citations"
+msgstr ""
+
+#: templates/peachjam/layouts/document_detail.html:183
 msgid "Alternative names"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:187
-msgid "Court"
+#: templates/peachjam/layouts/document_detail.html:213
+msgid "Judges"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:210
+#: templates/peachjam/layouts/document_detail.html:228
 msgid "Judgment date"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:246
+#: templates/peachjam/layouts/document_detail.html:264
 msgid "Language"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:277
+#: templates/peachjam/layouts/document_detail.html:304
 msgid "Type"
 msgstr ""
 
-#: templates/peachjam/layouts/document_detail.html:286
-#: templates/peachjam/layouts/document_detail.html:291
-#: templates/peachjam/layouts/document_detail.html:297
-#: templates/peachjam/layouts/document_detail.html:310
-msgid "Download"
-msgstr ""
-
-#: templates/peachjam/layouts/document_detail.html:332
+#: templates/peachjam/layouts/document_detail.html:362
 #, python-format
 msgid "%(n_relationships)s related documents"
 msgstr ""
 
-#: templates/peachjam/layouts/document_list.html:30
+#: templates/peachjam/layouts/document_list.html:27
 msgid "Documents"
 msgstr ""
 
-#: templates/peachjam/layouts/document_list.html:42
+#: templates/peachjam/layouts/document_list.html:43
 msgid "Filters"
 msgstr ""
 
@@ -1481,6 +1641,18 @@ msgstr ""
 msgid "Legislation"
 msgstr ""
 
+#: templates/peachjam/metabase_stats.html:4
+msgid "Site Statistics"
+msgstr ""
+
+#: templates/peachjam/metabase_stats.html:9
+msgid "Statistics"
+msgstr ""
+
+#: templates/peachjam/taxonomy_list.html:4
+msgid "Taxonomy"
+msgstr ""
+
 #: templates/peachjam/terms_of_use.html:4
 #: templates/peachjam/terms_of_use.html:29
 msgid "Terms of Use"
@@ -1492,29 +1664,36 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: templates/peachjam/top_level_taxonomy_list.html:4
-msgid "Taxonomy"
-msgstr ""
-
-#: views/legislation.py:280
-msgid "This is the version of this Act as it was when it was repealed."
-msgstr ""
-
-#: views/legislation.py:281
-msgid "This is the latest version of this Act."
-msgstr ""
-
-#: views/legislation.py:283
+#: views/legislation.py:51
 #, python-format
-msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+msgid "This %(friendly_type)s was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 msgstr ""
 
-#: views/legislation.py:286
+#: views/legislation.py:59
 #, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This %(friendly_type)s has not yet commenced and is not yet law."
 msgstr ""
 
-#: views/legislation.py:290
+#: views/legislation.py:90
 #, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+msgid "This is the version of this %(friendly_type)s as it was when it was repealed."
+msgstr ""
+
+#: views/legislation.py:103
+#, python-format
+msgid "This is the latest version of this %(friendly_type)s."
+msgstr ""
+
+#: views/legislation.py:117
+#, python-format
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgstr ""
+
+#: views/legislation.py:122
+#, python-format
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+msgstr ""
+
+#: views/legislation.py:162
+msgid "There are outstanding amendments that have not yet been applied. See the History tab for more information."
 msgstr ""

--- a/peachjam/locale/fr/LC_MESSAGES/django.po
+++ b/peachjam/locale/fr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-13 09:08+0200\n"
+"POT-Creation-Date: 2023-08-30 10:47+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
@@ -17,105 +17,136 @@ msgstr ""
 "X-Crowdin-File: /main/peachjam/locale/en/LC_MESSAGES/django.po\n"
 "X-Crowdin-File-ID: 99\n"
 
-#: admin.py:291
+#: admin.py:120
+msgid "Import"
+msgstr ""
+
+#: admin.py:363
 msgid "Key details"
 msgstr "Détails essentiels"
 
-#: admin.py:304
+#: admin.py:376
 msgid "Additional details"
 msgstr "Détails supplémentaires"
 
-#: admin.py:317
+#: admin.py:389
 msgid "Work identification"
 msgstr "Identification de travail"
 
-#: admin.py:330
+#: admin.py:402
 msgid "Content"
 msgstr "Contenus"
 
-#: admin.py:338
+#: admin.py:410
 msgid "Advanced"
 msgstr "Avancé"
 
-#: admin.py:493 models/judgment.py:319
+#: admin.py:650 models/judgment.py:370
 msgid "case number"
 msgstr "numéro de dossier"
 
-#: admin.py:494 models/judgment.py:320
+#: admin.py:651 models/judgment.py:371
 msgid "case numbers"
 msgstr "numéros de dossier"
 
-#: admin.py:586
+#: admin.py:665 models/judgment.py:36 models/judgment.py:158
+msgid "judge"
+msgstr "juge"
+
+#: admin.py:666 models/judgment.py:37 models/judgment.py:179
+msgid "judges"
+msgstr "juges"
+
+#: admin.py:766
 msgid "Refreshing content in the background."
 msgstr "Actualisation du contenu en arrière-plan."
 
-#: admin.py:588
-msgid "Refresh all content"
-msgstr "Actualiser tout le contenu"
+#: admin.py:769
+msgid "Refresh content selected ingestors"
+msgstr ""
 
-#: models/article.py:20 models/core_document_model.py:241
+#: admin.py:817
+#, fuzzy
+#| msgid "published"
+msgid "Articles published."
+msgstr "publié"
+
+#: admin.py:819
+msgid "Publish selected articles"
+msgstr ""
+
+#: admin.py:823
+#, fuzzy
+#| msgid "published"
+msgid "Articles unpublished."
+msgstr "publié"
+
+#: admin.py:825
+msgid "Unpublish selected articles"
+msgstr ""
+
+#: models/article.py:21 models/core_document_model.py:326
 msgid "date"
 msgstr "date"
 
-#: models/article.py:21 models/core_document_model.py:78
-#: models/core_document_model.py:240 models/core_document_model.py:661
+#: models/article.py:22 models/core_document_model.py:161
+#: models/core_document_model.py:325
 msgid "title"
 msgstr "titre"
 
-#: models/article.py:22
+#: models/article.py:23
 msgid "body"
 msgstr "corps"
 
-#: models/article.py:27 models/author.py:20 models/generic_document.py:20
-#: models/generic_document.py:48
+#: models/article.py:28 models/author.py:21
 msgid "author"
 msgstr "auteur"
 
-#: models/article.py:30 models/core_document_model.py:573
+#: models/article.py:31 models/core_document_model.py:738
 msgid "image"
 msgstr "image"
 
-#: models/article.py:32
+#: models/article.py:33
 msgid "summary"
 msgstr "résumé"
 
-#: models/article.py:33 models/relationships.py:7 models/taxonomies.py:11
+#: models/article.py:34 models/relationships.py:7 models/taxonomies.py:12
 msgid "slug"
 msgstr "slug"
 
-#: models/article.py:34
+#: models/article.py:35
 msgid "published"
 msgstr "publié"
 
-#: models/article.py:35
+#: models/article.py:37
 msgid "topics"
 msgstr "sujets"
 
-#: models/article.py:38
+#: models/article.py:41
 msgid "article"
 msgstr "article"
 
-#: models/article.py:39
+#: models/article.py:42
 msgid "articles"
 msgstr "articles"
 
-#: models/article.py:64
+#: models/article.py:75
 msgid "user"
 msgstr "utilisateur"
 
-#: models/article.py:67
+#: models/article.py:78
 msgid "photo"
 msgstr "photo"
 
-#: models/article.py:69
+#: models/article.py:80
 msgid "profile description"
 msgstr "description du profil"
 
-#: models/article.py:72
+#: models/article.py:83
 msgid "user profile"
 msgstr "profil de l'utilisateur"
 
-#: models/article.py:73
+#: models/article.py:84
 msgid "user profiles"
 msgstr "profils des utilisateurs"
 
@@ -123,285 +154,349 @@ msgstr "profils des utilisateurs"
 msgid "Author"
 msgstr "Auteur"
 
-#: models/author.py:9 models/core_document_model.py:41
-#: models/core_document_model.py:55 models/core_document_model.py:624
-#: models/ingestors.py:14 models/ingestors.py:33 models/judgment.py:14
-#: models/judgment.py:28 models/judgment.py:41 models/judgment.py:55
-#: models/judgment.py:69 models/judgment.py:86 models/judgment.py:120
-#: models/relationships.py:6 models/taxonomies.py:10
+#: models/author.py:8
+#, fuzzy
+#| msgid "Author"
+msgid "Authors"
+msgstr "Auteur"
+
+#: models/author.py:10 models/core_document_model.py:44
+#: models/core_document_model.py:72 models/core_document_model.py:86
+#: models/core_document_model.py:810 models/ingestors.py:14
+#: models/ingestors.py:33 models/judgment.py:15 models/judgment.py:30
+#: models/judgment.py:45 models/judgment.py:60 models/judgment.py:74
+#: models/judgment.py:91 models/judgment.py:125 models/relationships.py:6
+#: models/taxonomies.py:11
 msgid "name"
 msgstr "nom"
 
-#: models/author.py:10 models/core_document_model.py:43
-#: models/core_document_model.py:59 models/judgment.py:87
-#: models/judgment.py:121
+#: models/author.py:11 models/core_document_model.py:46
+#: models/core_document_model.py:74 models/core_document_model.py:90
+#: models/judgment.py:92 models/judgment.py:126
 msgid "code"
 msgstr "code"
 
-#: models/author.py:13 models/judgment.py:96 models/profile.py:35
-#: models/profile.py:36
+#: models/author.py:14 models/core_document_model.py:92 models/judgment.py:101
+#: models/profile.py:35 models/profile.py:36 models/taxonomies.py:15
 msgid "profile"
 msgstr "profil"
 
-#: models/author.py:21
+#: models/author.py:22 models/generic_document.py:19
+#: models/generic_document.py:45
 msgid "authors"
 msgstr "auteurs"
 
-#: models/citations.py:10 models/core_document_model.py:568
-#: models/core_document_model.py:594 models/core_document_model.py:640
-#: models/core_document_model.py:659 models/core_document_model.py:680
-#: models/judgment.py:314 models/taxonomies.py:32
+#: models/citations.py:16 models/core_document_model.py:733
+#: models/core_document_model.py:759 models/core_document_model.py:826
+#: models/core_document_model.py:855 models/core_document_model.py:881
+#: models/judgment.py:365 models/taxonomies.py:46
 msgid "document"
 msgstr "document"
 
-#: models/citations.py:12
+#: models/citations.py:18
 msgid "text"
 msgstr "texte"
 
-#: models/citations.py:13
+#: models/citations.py:19
 msgid "url"
 msgstr "url"
 
-#: models/citations.py:15
+#: models/citations.py:21
 msgid "target id"
 msgstr "identifiant cible"
 
-#: models/citations.py:17
+#: models/citations.py:23
 msgid "target selectors"
 msgstr "sélecteurs de cible"
 
-#: models/citations.py:20
+#: models/citations.py:26
 msgid "citation link"
 msgstr "lien de citation"
 
-#: models/citations.py:21
+#: models/citations.py:27
 msgid "citation links"
 msgstr "liens de citation"
 
-#: models/citations.py:56
+#: models/citations.py:62
 msgid "citing work"
 msgstr "Citant un travail"
 
-#: models/citations.py:63
+#: models/citations.py:69
 msgid "target work"
 msgstr "Travail ciblé"
 
-#: models/core_document_model.py:44 models/core_document_model.py:626
-#: models/judgment.py:16 models/judgment.py:29 models/judgment.py:42
-#: models/judgment.py:57 models/judgment.py:70
+#: models/citations.py:90
+#, fuzzy
+#| msgid "Hearing date"
+msgid "processing date"
+msgstr "Date de l'audience"
+
+#: models/citations.py:93
+#, fuzzy
+#| msgid "citation link"
+msgid "citation processing"
+msgstr "lien de citation"
+
+#: models/core_document_model.py:48
+msgid "level"
+msgstr ""
+
+#: models/core_document_model.py:62
+msgid "label"
+msgstr ""
+
+#: models/core_document_model.py:63 models/core_document_model.py:433
+msgid "labels"
+msgstr ""
+
+#: models/core_document_model.py:75 models/core_document_model.py:812
+#: models/judgment.py:17 models/judgment.py:32 models/judgment.py:47
+#: models/judgment.py:62 models/judgment.py:75
 msgid "description"
 msgstr "description"
 
-#: models/core_document_model.py:47
+#: models/core_document_model.py:78
 msgid "document nature"
 msgstr "nature du document"
 
-#: models/core_document_model.py:48
+#: models/core_document_model.py:79
 msgid "document natures"
 msgstr "types de document"
 
-#: models/core_document_model.py:57 models/core_document_model.py:261
+#: models/core_document_model.py:88 models/core_document_model.py:346
 msgid "jurisdiction"
 msgstr "juridiction"
 
-#: models/core_document_model.py:62 models/core_document_model.py:268
+#: models/core_document_model.py:96 models/core_document_model.py:353
 msgid "locality"
 msgstr "localité"
 
-#: models/core_document_model.py:63
+#: models/core_document_model.py:97
 msgid "localities"
 msgstr "localités"
 
-#: models/core_document_model.py:76
+#: models/core_document_model.py:110
 msgid "FRBR URI"
 msgstr "FRBR URI"
 
-#: models/core_document_model.py:84
-msgid "languages"
-msgstr "langues"
+#: models/core_document_model.py:114
+#, fuzzy
+#| msgid "FRBR URI actor"
+msgid "FRBR URI country"
+msgstr "acteur de FRBR URI"
 
-#: models/core_document_model.py:87
-msgid "ranking"
-msgstr "classement"
+#: models/core_document_model.py:120
+#, fuzzy
+#| msgid "FRBR URI doctype"
+msgid "FRBR URI locality"
+msgstr "doctype de FRBR URI"
 
-#: models/core_document_model.py:90 models/core_document_model.py:230
-msgid "work"
-msgstr "travail"
+#: models/core_document_model.py:126
+#, fuzzy
+#| msgid "FRBR URI date"
+msgid "FRBR URI place"
+msgstr "date de FRBR URI"
 
-#: models/core_document_model.py:91
-msgid "works"
-msgstr "travaux"
-
-#: models/core_document_model.py:233
-msgid "document type"
-msgstr "type de document"
-
-#: models/core_document_model.py:243 models/core_document_model.py:597
-msgid "source URL"
-msgstr "URL source"
-
-#: models/core_document_model.py:245
-msgid "citation"
-msgstr "référence"
-
-#: models/core_document_model.py:246
-msgid "content HTML"
-msgstr "contenu HTML"
-
-#: models/core_document_model.py:247
-msgid "content HTML is AKN"
-msgstr "le contenu HTML est AKN"
-
-#: models/core_document_model.py:248
-msgid "TOC JSON"
-msgstr "JSON TOC"
-
-#: models/core_document_model.py:254
-msgid "language"
-msgstr "langue"
-
-#: models/core_document_model.py:275 models/core_document_model.py:643
-msgid "nature"
-msgstr "nature"
-
-#: models/core_document_model.py:279
-msgid "work FRBR URI"
-msgstr "travail FRBR URI"
-
-#: models/core_document_model.py:284
+#: models/core_document_model.py:132 models/core_document_model.py:369
 msgid "FRBR URI doctype"
 msgstr "doctype de FRBR URI"
 
-#: models/core_document_model.py:291
+#: models/core_document_model.py:138 models/core_document_model.py:376
 msgid "FRBR URI subtype"
 msgstr "subtype de FRBR URI"
 
-#: models/core_document_model.py:296
-msgid "Document subtype. Lowercase letters, numbers _ and - only."
-msgstr "Sous-type de document. Lettres minuscules, chiffres _ et - seulement."
-
-#: models/core_document_model.py:299
+#: models/core_document_model.py:144 models/core_document_model.py:384
 msgid "FRBR URI actor"
 msgstr "acteur de FRBR URI"
 
-#: models/core_document_model.py:304
-msgid "Originating actor. Lowercase letters, numbers _ and - only."
-msgstr "Acteur originaire. Lettres minuscules, chiffres _ et - seulement."
-
-#: models/core_document_model.py:307
+#: models/core_document_model.py:150 models/core_document_model.py:392
 msgid "FRBR URI date"
 msgstr "date de FRBR URI"
 
-#: models/core_document_model.py:312
-msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
-msgstr "AAAA, AAAA-MM, ou AAAA-MM-JJ"
-
-#: models/core_document_model.py:315
+#: models/core_document_model.py:156 models/core_document_model.py:400
 msgid "FRBR URI number"
 msgstr "numéro de FRBR URI"
 
-#: models/core_document_model.py:321
+#: models/core_document_model.py:167
+msgid "languages"
+msgstr "langues"
+
+#: models/core_document_model.py:170
+msgid "ranking"
+msgstr "classement"
+
+#: models/core_document_model.py:173 models/core_document_model.py:315
+msgid "work"
+msgstr "travail"
+
+#: models/core_document_model.py:174
+msgid "works"
+msgstr "travaux"
+
+#: models/core_document_model.py:318
+msgid "document type"
+msgstr "type de document"
+
+#: models/core_document_model.py:328 models/core_document_model.py:762
+msgid "source URL"
+msgstr "URL source"
+
+#: models/core_document_model.py:330
+msgid "citation"
+msgstr "référence"
+
+#: models/core_document_model.py:331
+msgid "content HTML"
+msgstr "contenu HTML"
+
+#: models/core_document_model.py:332
+msgid "content HTML is AKN"
+msgstr "le contenu HTML est AKN"
+
+#: models/core_document_model.py:333
+msgid "TOC JSON"
+msgstr "JSON TOC"
+
+#: models/core_document_model.py:339
+msgid "language"
+msgstr "langue"
+
+#: models/core_document_model.py:360 models/core_document_model.py:829
+msgid "nature"
+msgstr "nature"
+
+#: models/core_document_model.py:364
+msgid "work FRBR URI"
+msgstr "travail FRBR URI"
+
+#: models/core_document_model.py:381
+msgid "Document subtype. Lowercase letters, numbers _ and - only."
+msgstr "Sous-type de document. Lettres minuscules, chiffres _ et - seulement."
+
+#: models/core_document_model.py:389
+msgid "Originating actor. Lowercase letters, numbers _ and - only."
+msgstr "Acteur originaire. Lettres minuscules, chiffres _ et - seulement."
+
+#: models/core_document_model.py:397
+msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
+msgstr "AAAA, AAAA-MM, ou AAAA-MM-JJ"
+
+#: models/core_document_model.py:406
 msgid "Unique number or short title identifying this work. Lowercase letters, numbers _ and - only."
 msgstr "Nombre unique ou titre court identifiant ce travail. Lettres minuscules, chiffres _ et - seulement."
 
-#: models/core_document_model.py:326
+#: models/core_document_model.py:411
 msgid "expression FRBR URI"
 msgstr "expression FRBR URI"
 
-#: models/core_document_model.py:330
+#: models/core_document_model.py:415
 msgid "created at"
 msgstr "créé le"
 
-#: models/core_document_model.py:331
+#: models/core_document_model.py:416
 msgid "updated at"
 msgstr "mis à jour le"
 
-#: models/core_document_model.py:336
+#: models/core_document_model.py:422
 msgid "created by"
 msgstr "créer par"
 
-#: models/core_document_model.py:339
+#: models/core_document_model.py:425
 msgid "allow robots"
 msgstr "Autoriser les robots"
 
-#: models/core_document_model.py:342
+#: models/core_document_model.py:428
 msgid "Allow this document to be indexed by search engine robots."
 msgstr "Autoriser l'indexation de ce document par les robots des moteurs de recherche."
 
-#: models/core_document_model.py:368
-msgid "Invalid Date"
-msgstr "Date non valide"
-
-#: models/core_document_model.py:371
+#: models/core_document_model.py:469
 msgid "You cannot set a future date for the document"
 msgstr "Vous ne pouvez pas définir une date ultérieure pour le document"
 
-#: models/core_document_model.py:377
+#: models/core_document_model.py:477
 #, python-format
 msgid "Invalid FRBR URI: %(uri)s"
 msgstr "Invalid FRBR URI: %(uri)s"
 
-#: models/core_document_model.py:540
+#: models/core_document_model.py:488
+msgid "Document with this Expression FRBR URI already exists!"
+msgstr ""
+
+#: models/core_document_model.py:705
 msgid "filename"
 msgstr "nom de fichier"
 
-#: models/core_document_model.py:541
+#: models/core_document_model.py:706
 msgid "mimetype"
 msgstr "mimetype"
 
-#: models/core_document_model.py:542
+#: models/core_document_model.py:707
 msgid "size"
 msgstr "taille"
 
-#: models/core_document_model.py:543 models/core_document_model.py:570
+#: models/core_document_model.py:708 models/core_document_model.py:735
 msgid "file"
 msgstr "fichier"
 
-#: models/core_document_model.py:574
+#: models/core_document_model.py:739
 msgid "images"
 msgstr "images"
 
-#: models/core_document_model.py:601
+#: models/core_document_model.py:766
+msgid "file as pdf"
+msgstr ""
+
+#: models/core_document_model.py:774
 msgid "source file"
 msgstr "fichier source"
 
-#: models/core_document_model.py:602
+#: models/core_document_model.py:775
 msgid "source files"
 msgstr "fichiers sources"
 
-#: models/core_document_model.py:629
+#: models/core_document_model.py:815
 msgid "attached file nature"
 msgstr "type de pièce joint"
 
-#: models/core_document_model.py:630
+#: models/core_document_model.py:816
 msgid "attached file natures"
 msgstr "types de fichier joint"
 
-#: models/core_document_model.py:647
+#: models/core_document_model.py:833
 msgid "attached file"
 msgstr "fichier joint"
 
-#: models/core_document_model.py:648
+#: models/core_document_model.py:834
 msgid "attached files"
 msgstr "pièces jointes"
 
-#: models/core_document_model.py:664
+#: models/core_document_model.py:858
+msgid "Law report citation/Alternative known name"
+msgstr ""
+
+#: models/core_document_model.py:865
 msgid "alternative name"
 msgstr "nom alternatif"
 
-#: models/core_document_model.py:665
+#: models/core_document_model.py:866
 msgid "alternative names"
 msgstr "noms alternatifs"
 
-#: models/core_document_model.py:685
+#: models/core_document_model.py:886
 msgid "document text"
 msgstr "Texte du document"
 
-#: models/core_document_model.py:689
+#: models/core_document_model.py:890
+#, fuzzy
+#| msgid "document"
+msgid "document XML"
+msgstr "document"
+
+#: models/core_document_model.py:894
 msgid "document content"
 msgstr "Contenu du document"
 
-#: models/core_document_model.py:690
+#: models/core_document_model.py:895
 msgid "document contents"
 msgstr "Contenu du document"
 
@@ -413,35 +508,35 @@ msgstr "Journal Officiel"
 msgid "gazettes"
 msgstr "journal officiel"
 
-#: models/generic_document.py:26
+#: models/generic_document.py:25
 msgid "generic document"
 msgstr "document générique"
 
-#: models/generic_document.py:27
+#: models/generic_document.py:26
 msgid "generic documents"
 msgstr "documents génériques"
 
-#: models/generic_document.py:54
+#: models/generic_document.py:51
 msgid "legal instrument"
 msgstr "acte juridique"
 
-#: models/generic_document.py:55
+#: models/generic_document.py:52
 msgid "legal instruments"
 msgstr "actes juridiques"
 
-#: models/generic_document.py:77
+#: models/generic_document.py:74
 msgid "metadata JSON"
 msgstr "métadonnées JSON"
 
-#: models/generic_document.py:78 templates/peachjam/document_popup.html:9
+#: models/generic_document.py:75 templates/peachjam/document_popup.html:9
 msgid "repealed"
 msgstr "abrogé"
 
-#: models/generic_document.py:80
+#: models/generic_document.py:77
 msgid "parent work"
 msgstr "œuvre supérieur"
 
-#: models/generic_document.py:86 models/generic_document.py:87
+#: models/generic_document.py:83 models/generic_document.py:84
 msgid "legislation"
 msgstr "législation"
 
@@ -473,135 +568,125 @@ msgstr "dernière mise à jour le"
 msgid "enabled"
 msgstr "activé"
 
-#: models/judgment.py:20
+#: models/judgment.py:21
 msgid "attorney"
 msgstr "avocat"
 
-#: models/judgment.py:21 models/judgment.py:149
+#: models/judgment.py:22 models/judgment.py:182
 msgid "attorneys"
 msgstr "Avocats"
 
-#: models/judgment.py:33
-msgid "judge"
-msgstr "juge"
-
-#: models/judgment.py:34 models/judgment.py:147
-msgid "judges"
-msgstr "juges"
-
-#: models/judgment.py:46
+#: models/judgment.py:51
 msgid "order outcome"
 msgstr "Résultat de la commande"
 
-#: models/judgment.py:47
+#: models/judgment.py:52
 msgid "order outcomes"
 msgstr "Résultats de la commande"
 
-#: models/judgment.py:61 models/judgment.py:307
+#: models/judgment.py:66 models/judgment.py:358
 msgid "matter type"
 msgstr "type de matière"
 
-#: models/judgment.py:62
+#: models/judgment.py:67
 msgid "matter types"
 msgstr "types de matière"
 
-#: models/judgment.py:71 models/judgment.py:98
+#: models/judgment.py:76 models/judgment.py:103
 msgid "order"
 msgstr "Commande"
 
-#: models/judgment.py:78 models/judgment.py:93
+#: models/judgment.py:83 models/judgment.py:98
 msgid "court class"
 msgstr "cours de cour"
 
-#: models/judgment.py:79
+#: models/judgment.py:84
 msgid "court classes"
 msgstr "cours de cour"
 
-#: models/judgment.py:105 models/judgment.py:118 models/judgment.py:138
+#: models/judgment.py:110 models/judgment.py:123 models/judgment.py:169
 msgid "court"
 msgstr "cour"
 
-#: models/judgment.py:106
+#: models/judgment.py:111
 msgid "courts"
 msgstr "cours"
 
-#: models/judgment.py:124
+#: models/judgment.py:129
 msgid "court registry"
 msgstr "Greffe de la cour"
 
-#: models/judgment.py:125
+#: models/judgment.py:130
 msgid "court registries"
 msgstr "Registres judiciaires"
 
-#: models/judgment.py:158
-msgid "headnote holding"
-msgstr "résumé détaillé"
-
-#: models/judgment.py:160
-msgid "additional citations"
-msgstr "références supplémentaires"
-
-#: models/judgment.py:162
-msgid "flynote"
-msgstr "mot-clé"
-
-#: models/judgment.py:164
-msgid "case name"
-msgstr "nom de l'affaire"
-
-#: models/judgment.py:166
-msgid "Party names for use in title"
-msgstr "Noms des parties à utiliser dans le titre"
-
-#: models/judgment.py:172
-msgid "serial number"
-msgstr "numéro de série"
-
-#: models/judgment.py:174
-msgid "Serial number for MNC, unique for a year and an author."
-msgstr "Numéro de série pour CNM, unique pour une année et un auteur."
-
-#: models/judgment.py:177
-msgid "serial number override"
-msgstr "remplacement du numéro de série"
-
-#: models/judgment.py:180
-msgid "Specific MNC serial number assigned by the court."
-msgstr "Numéro de série CNM spécifique attribué par le tribunal."
-
-#: models/judgment.py:184
-msgid "MNC"
-msgstr "CNM"
-
-#: models/judgment.py:186
-msgid "Media neutral citation"
-msgstr "Citation neutre des médias"
-
-#: models/judgment.py:201
+#: models/judgment.py:156 models/judgment.py:231
 msgid "judgment"
 msgstr "jugement"
 
+#: models/judgment.py:191
+#, fuzzy
+#| msgid "summary"
+msgid "case summary"
+msgstr "résumé"
+
+#: models/judgment.py:192
+msgid "flynote"
+msgstr "mot-clé"
+
+#: models/judgment.py:194
+msgid "case name"
+msgstr "nom de l'affaire"
+
+#: models/judgment.py:196
+msgid "Party names for use in title"
+msgstr "Noms des parties à utiliser dans le titre"
+
 #: models/judgment.py:202
+msgid "serial number"
+msgstr "numéro de série"
+
+#: models/judgment.py:204
+msgid "Serial number for MNC, unique for a year and an author."
+msgstr "Numéro de série pour CNM, unique pour une année et un auteur."
+
+#: models/judgment.py:207
+msgid "serial number override"
+msgstr "remplacement du numéro de série"
+
+#: models/judgment.py:210
+msgid "Specific MNC serial number assigned by the court."
+msgstr "Numéro de série CNM spécifique attribué par le tribunal."
+
+#: models/judgment.py:214
+msgid "MNC"
+msgstr "CNM"
+
+#: models/judgment.py:216
+msgid "Media neutral citation"
+msgstr "Citation neutre des médias"
+
+#: models/judgment.py:232
 msgid "judgments"
 msgstr "jugements"
 
-#: models/judgment.py:293
-msgid "string override"
-msgstr "remplacement de chaîne de caractères"
+#: models/judgment.py:344
+msgid "Full case number as printed on judgment"
+msgstr ""
 
-#: models/judgment.py:297
+#: models/judgment.py:348
 msgid "Override for full case number string"
 msgstr "Remplacer pour la chaîne de numéro de cas complet"
 
-#: models/judgment.py:299
+#: models/judgment.py:350
 msgid "string"
 msgstr "chaîne de caractères"
 
-#: models/judgment.py:300 templates/peachjam/_timeline_events.html:32
+#: models/judgment.py:351 templates/peachjam/_timeline_events.html:35
 msgid "number"
 msgstr "nombre"
 
-#: models/judgment.py:301
+#: models/judgment.py:352
 msgid "year"
 msgstr "année"
 
@@ -670,55 +755,101 @@ msgstr "langue du document par défaut"
 msgid "document languages"
 msgstr "langues du document"
 
-#: models/settings.py:40
+#: models/settings.py:41
+#, fuzzy
+#| msgid "document jurisdictions"
+msgid "default document jurisdiction"
+msgstr "juridictions du document"
+
+#: models/settings.py:47
 msgid "document jurisdictions"
 msgstr "juridictions du document"
 
-#: models/settings.py:43
+#: models/settings.py:50
 msgid "subsidiary legislation label"
 msgstr "Étiquette législative subsidiaire"
 
-#: models/settings.py:48
+#: models/settings.py:55
 msgid "google analytics id"
 msgstr "Identifiant google analytiques"
 
-#: models/settings.py:51
+#: models/settings.py:59
+msgid "Enter one or more Google Analytics IDs separated by spaces."
+msgstr ""
+
+#: models/settings.py:62
 msgid "pagerank boost value"
 msgstr "valeur d'augmentation du PageRank"
 
-#: models/settings.py:55
+#: models/settings.py:65
+msgid "allowed login domains"
+msgstr ""
+
+#: models/settings.py:69
+msgid "metabase dashboard link"
+msgstr ""
+
+#: models/settings.py:73
+msgid "mailchimp form url"
+msgstr ""
+
+#: models/settings.py:76
+#, fuzzy
+#| msgid "citation link"
+msgid "twitter link"
+msgstr "lien de citation"
+
+#: models/settings.py:79
+msgid "facebook link"
+msgstr ""
+
+#: models/settings.py:82
+#, fuzzy
+#| msgid "Media neutral citation"
+msgid "re-extract citations"
+msgstr "Citation neutre des médias"
+
+#: models/settings.py:85
+msgid "Pocket Law repo"
+msgstr ""
+
+#: models/settings.py:88
+msgid "help link"
+msgstr ""
+
+#: models/settings.py:95
 msgid "site settings"
 msgstr "paramètres du site"
 
-#: models/taxonomies.py:15 models/taxonomies.py:16
+#: models/taxonomies.py:19 models/taxonomies.py:20
 msgid "taxonomies"
 msgstr "taxonomies"
 
-#: models/taxonomies.py:35
+#: models/taxonomies.py:49
 msgid "topic"
 msgstr "sujet"
 
-#: models/taxonomies.py:40
+#: models/taxonomies.py:54
 msgid "document topic"
 msgstr "sujet du document"
 
-#: models/taxonomies.py:41
+#: models/taxonomies.py:55
 msgid "document topics"
 msgstr "sujets du document"
 
-#: settings.py:210
+#: settings.py:235
 msgid "English"
 msgstr "Anglais"
 
-#: settings.py:211
+#: settings.py:236
 msgid "French"
 msgstr "Français"
 
-#: settings.py:212
+#: settings.py:237
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: settings.py:213
+#: settings.py:238
 msgid "Swahili"
 msgstr "Swahili"
 
@@ -775,10 +906,12 @@ msgstr "Mot de passe oublié ?"
 
 #: templates/account/login.html:76
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            Log in with %(provider.name)s\n"
 "          "
-msgstr "\n"
+msgstr ""
+"\n"
 "            Connectez-vous à %(provider.name)s\n"
 "          "
 
@@ -838,6 +971,10 @@ msgstr "Changer le mot de passe"
 msgid "Your password has been reset."
 msgstr "Votre mot de passe a été réinitialisé."
 
+#: templates/admin/change_form.html:7 templates/admin/change_list.html:10
+msgid "Help"
+msgstr ""
+
 #: templates/admin/login.html:20
 msgid "Please correct the error below."
 msgstr "Veuillez corriger l'erreur ci-dessous."
@@ -855,6 +992,19 @@ msgstr "Vous êtes authentifié en tant que %(username)s, mais vous n'êtes pas 
 msgid "Forgotten your password or username?"
 msgstr "Vous avez oublié votre mot de passe ou votre nom d'utilisateur ?"
 
+#: templates/admin/tree_change_list.html:7
+#: templates/peachjam/_document_content.html:48
+msgid "Search"
+msgstr "Recherche"
+
+#: templates/admin/tree_change_list.html:8
+msgid "Collapse all"
+msgstr ""
+
+#: templates/admin/tree_change_list.html:9
+msgid "Expand all"
+msgstr ""
+
 #: templates/peachjam/_child_documents.html:2
 msgid "Subsidiary legislation"
 msgstr "Législation subsidiaire"
@@ -869,62 +1019,68 @@ msgstr "Titre"
 msgid "Numbered title"
 msgstr "Titre numéroté"
 
-#: templates/peachjam/_citations.html:6
+#: templates/peachjam/_citations.html:7
 msgid "Cited documents"
 msgstr "Documents cités"
 
-#: templates/peachjam/_citations.html:18
+#: templates/peachjam/_citations.html:13
 msgid "Documents citing this one"
 msgstr "Documents citant celui-ci"
 
-#: templates/peachjam/_court_list.html:14
-#: templates/peachjam/_court_list.html:20
+#: templates/peachjam/_citations_list.html:27
+msgid "Show/Hide all"
+msgstr ""
+
+#: templates/peachjam/_court_list.html:16
+#: templates/peachjam/_court_list.html:22
 msgid "No courts found."
 msgstr "Aucun tribunal trouvé."
 
-#: templates/peachjam/_document_content.html:24
+#: templates/peachjam/_document_content.html:25
 msgid "Table of contents"
 msgstr "Table des matières"
 
-#: templates/peachjam/_document_content.html:36
+#: templates/peachjam/_document_content.html:37
 msgid "Pages"
 msgstr "Pages"
 
-#: templates/peachjam/_document_content.html:47
-msgid "Search"
-msgstr "Recherche"
-
-#: templates/peachjam/_document_content.html:134
+#: templates/peachjam/_document_content.html:136
 msgid "Loading PDF..."
 msgstr "Chargement du PDF..."
 
-#: templates/peachjam/_document_content.html:144
+#: templates/peachjam/_document_content.html:146
 #, python-format
 msgid "This document is %(filesize)s. Do you want to load it?"
 msgstr "Ce document est %(filesize)s. Voulez-vous le charger ?"
 
-#: templates/peachjam/_document_content.html:148
+#: templates/peachjam/_document_content.html:150
 msgid "Load document"
 msgstr "Charger le document"
 
-#: templates/peachjam/_document_content.html:157
+#: templates/peachjam/_document_content.html:159
 msgid "To the top"
 msgstr "En haut"
 
-#: templates/peachjam/_document_count.html:4
+#: templates/peachjam/_document_count.html:3
 #, python-format
 msgid "%(doc_count)s document"
 msgid_plural "%(doc_count)s documents"
 msgstr[0] "%(doc_count)s Document"
 msgstr[1] "%(doc_count)s Documents"
 
-#: templates/peachjam/_document_table.html:10
-#: templates/peachjam/_judgment_table.html:8
-#: templates/peachjam/layouts/document_detail.html:214
+#: templates/peachjam/_document_table.html:8
+#: templates/peachjam/_ratifications.html:17
+msgid "Country"
+msgstr "Pays"
+
+#: templates/peachjam/_document_table.html:13
+#: templates/peachjam/_judgment_table.html:7
+#: templates/peachjam/layouts/document_detail.html:232
 msgid "Date"
 msgstr "Date"
 
-#: templates/peachjam/_document_table.html:28
+#: templates/peachjam/_document_table.html:33
+#: templates/peachjam/layouts/document_detail.html:268
 msgid "Multiple languages available"
 msgstr "Plusieurs langues disponibles"
 
@@ -936,23 +1092,31 @@ msgstr "Adresse postale"
 msgid "Visit website"
 msgstr "Visiter le site internet"
 
-#: templates/peachjam/_header.html:32 templates/peachjam/_header.html:33
+#: templates/peachjam/_header.html:33 templates/peachjam/_header.html:34
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr "Rechercher dans %(APP_NAME)s"
 
-#: templates/peachjam/_header.html:55
+#: templates/peachjam/_header.html:57
 msgid "Admin"
 msgstr "Administrateur"
 
-#: templates/peachjam/_header.html:56
+#: templates/peachjam/_header.html:58
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: templates/peachjam/_judgment_table.html:7
-#: templates/peachjam/layouts/document_detail.html:196
-msgid "Judges"
-msgstr "Juges"
+#: templates/peachjam/_mailchimp_form.html:4
+msgid "Subscribe"
+msgstr ""
+
+#: templates/peachjam/_mailchimp_form.html:11
+msgid "Subscribe to our newsletter for updates and news."
+msgstr ""
+
+#: templates/peachjam/_months_list.html:7
+#: templates/peachjam/_months_list.html:24
+msgid "All months"
+msgstr ""
 
 #: templates/peachjam/_pagination.html:6
 msgid "Previous"
@@ -970,43 +1134,49 @@ msgstr "Source"
 msgid "Last updated"
 msgstr "Dernière mise à jour"
 
-#: templates/peachjam/_ratifications.html:17
-msgid "Country"
-msgstr "Pays"
-
 #: templates/peachjam/_ratifications.html:18
-msgid "Ratification Date"
-msgstr "Date de ratification"
-
-#: templates/peachjam/_ratifications.html:19
-msgid "Deposit Date"
-msgstr "Date de dépôt"
-
-#: templates/peachjam/_ratifications.html:20
 msgid "Signature Date"
 msgstr "Date de signature"
 
+#: templates/peachjam/_ratifications.html:19
+msgid "Ratification Date"
+msgstr "Date de ratification"
+
+#: templates/peachjam/_ratifications.html:20
+msgid "Deposit Date"
+msgstr "Date de dépôt"
+
 #: templates/peachjam/_recent_document_list.html:14
-#: templates/peachjam/court_detail.html:35
-#: templates/peachjam/layouts/document_list.html:59
+#: templates/peachjam/court_detail.html:42
+#: templates/peachjam/layouts/document_list.html:60
 msgid "No documents found."
 msgstr "Aucun document trouvé."
 
-#: templates/peachjam/_related_documents.html:2
-#: templates/peachjam/layouts/document_detail.html:84
-#: templates/peachjam/layouts/document_detail.html:328
+#: templates/peachjam/_registries.html:3
+#, fuzzy
+#| msgid "court registries"
+msgid "Registries"
+msgstr "Registres judiciaires"
+
+#: templates/peachjam/_related_documents.html:4
+#: templates/peachjam/layouts/document_detail.html:93
+#: templates/peachjam/layouts/document_detail.html:357
 msgid "Related documents"
 msgstr "Documents connexes"
 
-#: templates/peachjam/_taxonomies.html:2
-#: templates/peachjam/first_level_taxonomy_detail.html:9
-#: templates/peachjam/taxonomy_detail.html:13
-#: templates/peachjam/top_level_taxonomy_list.html:8
+#: templates/peachjam/_social_media.html:2
+msgid "Follow us on social media"
+msgstr ""
+
+#: templates/peachjam/_taxonomies.html:4
+#: templates/peachjam/taxonomy_detail.html:10
+#: templates/peachjam/taxonomy_first_level_detail.html:10
+#: templates/peachjam/taxonomy_list.html:8
 msgid "Taxonomies"
 msgstr "Taxonomies"
 
 #: templates/peachjam/_taxonomy_list.html:23
-#: templates/peachjam/first_level_taxonomy_detail.html:25
+#: templates/peachjam/taxonomy_first_level_detail.html:28
 msgid "No taxonomies found"
 msgstr "Aucune taxonomie trouvée"
 
@@ -1250,43 +1420,43 @@ msgstr "Si vous avez des commentaires ou des suggestions au sujet de cette polit
 msgid "Date of notice: 14 November 2022"
 msgstr "Date de la notification: 14 novembre 2022"
 
-#: templates/peachjam/_timeline_events.html:2
+#: templates/peachjam/_timeline_events.html:4
 msgid "History of this document"
 msgstr "Historique de ce document"
 
-#: templates/peachjam/_timeline_events.html:11
+#: templates/peachjam/_timeline_events.html:14
 msgid "this version"
 msgstr "cette version"
 
-#: templates/peachjam/_timeline_events.html:15
+#: templates/peachjam/_timeline_events.html:18
 msgid "amendment not yet applied"
 msgstr "Amendement non encore appliqué"
 
-#: templates/peachjam/_timeline_events.html:24
+#: templates/peachjam/_timeline_events.html:27
 msgid "Amended by"
 msgstr "Modifié par"
 
-#: templates/peachjam/_timeline_events.html:27
+#: templates/peachjam/_timeline_events.html:30
 msgid "Assented to"
 msgstr "Consenti à"
 
-#: templates/peachjam/_timeline_events.html:29
+#: templates/peachjam/_timeline_events.html:32
 msgid "Commences"
 msgstr "Commence"
 
-#: templates/peachjam/_timeline_events.html:31
+#: templates/peachjam/_timeline_events.html:34
 msgid "Published in"
 msgstr "Publié dans"
 
-#: templates/peachjam/_timeline_events.html:34
+#: templates/peachjam/_timeline_events.html:37
 msgid "Repealed by"
 msgstr "Abrogé par"
 
-#: templates/peachjam/_timeline_events.html:42
+#: templates/peachjam/_timeline_events.html:45
 msgid "Read this version"
 msgstr "Lire cette version"
 
-#: templates/peachjam/_years_list.html:9 templates/peachjam/_years_list.html:25
+#: templates/peachjam/_years_list.html:7 templates/peachjam/_years_list.html:24
 msgid "All years"
 msgstr "Toutes les années"
 
@@ -1296,20 +1466,30 @@ msgstr "À propos"
 
 #: templates/peachjam/article_detail.html:9
 #: templates/peachjam/article_list.html:4
+#: templates/peachjam/article_list.html:12
+#: templates/peachjam/article_list.html:17
 #: templates/peachjam/user_profile.html:21
 msgid "Articles"
 msgstr "Articles"
 
-#: templates/peachjam/article_detail.html:56
+#: templates/peachjam/article_detail.html:44
+#: templates/peachjam/layouts/document_detail.html:313
+#: templates/peachjam/layouts/document_detail.html:318
+#: templates/peachjam/layouts/document_detail.html:324
+#: templates/peachjam/layouts/document_detail.html:337
+msgid "Download"
+msgstr "Télécharger"
+
+#: templates/peachjam/article_detail.html:64
 msgid "About the author"
 msgstr "À propos de l'auteur"
 
-#: templates/peachjam/article_detail.html:61
+#: templates/peachjam/article_detail.html:69
 #, python-format
 msgid "Recent articles by %(username)s"
 msgstr "Articles récents par %(username)s"
 
-#: templates/peachjam/article_list.html:9
+#: templates/peachjam/article_list.html:23
 msgid "Latest Articles"
 msgstr "Derniers articles"
 
@@ -1323,6 +1503,7 @@ msgid "Books"
 msgstr "Livres"
 
 #: templates/peachjam/court_detail.html:9
+#: templates/peachjam/court_registry_detail.html:9
 #: templates/peachjam/judgment_list.html:4
 #: templates/peachjam/judgment_list.html:9
 msgid "Judgments"
@@ -1338,8 +1519,8 @@ msgstr "Jugements"
 msgid "Gazettes"
 msgstr "Journaux officiels"
 
-#: templates/peachjam/gazette_list.html:34
-#: templates/peachjam/gazette_list.html:59
+#: templates/peachjam/gazette_list.html:35
+#: templates/peachjam/gazette_list.html:60
 #, python-format
 msgid "%(num_gazettes)s gazette"
 msgid_plural "%(num_gazettes)s gazettes"
@@ -1365,17 +1546,17 @@ msgid "Media Neutral Citation"
 msgstr "Référence médiatique neutre"
 
 #: templates/peachjam/judgment_detail.html:13
-#: templates/peachjam/layouts/document_detail.html:155
+#: templates/peachjam/layouts/document_detail.html:165
 msgid "Copy to clipboard"
 msgstr "Copier dans le presse-papiers"
 
 #: templates/peachjam/judgment_detail.html:16
-#: templates/peachjam/layouts/document_detail.html:158
+#: templates/peachjam/layouts/document_detail.html:168
 msgid "Copied!"
 msgstr "Copié !"
 
 #: templates/peachjam/judgment_detail.html:17
-#: templates/peachjam/layouts/document_detail.html:159
+#: templates/peachjam/layouts/document_detail.html:169
 msgid "Copy"
 msgstr "Copie"
 
@@ -1384,86 +1565,101 @@ msgid "Hearing date"
 msgstr "Date de l'audience"
 
 #: templates/peachjam/judgment_detail.html:31
+msgid "Court"
+msgstr "Cour"
+
+#: templates/peachjam/judgment_detail.html:39
 msgid "Court Registry"
 msgstr "Registre des tribunaux"
 
-#: templates/peachjam/judgment_detail.html:39
+#: templates/peachjam/judgment_detail.html:47
 msgid "Order"
 msgstr "Commande"
 
-#: templates/peachjam/judgment_detail.html:48
+#: templates/peachjam/judgment_detail.html:56
 msgid "Case number"
 msgstr "Numéro de cas"
 
-#: templates/peachjam/judgment_detail.html:61
+#: templates/peachjam/judgment_detail.html:69
 msgid "Attorneys"
 msgstr "Avocats"
+
+#: templates/peachjam/judgment_detail.html:83
+#, fuzzy
+#| msgid "flynote"
+msgid "Flynote"
+msgstr "mot-clé"
+
+#: templates/peachjam/judgment_detail.html:93
+#, fuzzy
+#| msgid "summary"
+msgid "Case summary"
+msgstr "résumé"
 
 #: templates/peachjam/judgment_list.html:15
 msgid "Recent judgments"
 msgstr "Jugements récents"
 
-#: templates/peachjam/layouts/document_detail.html:59
+#: templates/peachjam/layouts/document_detail.html:66
 msgid "Document detail"
 msgstr "Détail du document"
 
-#: templates/peachjam/layouts/document_detail.html:71
+#: templates/peachjam/layouts/document_detail.html:79
 msgid "History"
 msgstr "Historique"
 
-#: templates/peachjam/layouts/document_detail.html:98
+#: templates/peachjam/layouts/document_detail.html:108
 msgid "Citations"
 msgstr "Citation"
 
-#: templates/peachjam/layouts/document_detail.html:112
+#: templates/peachjam/layouts/document_detail.html:122
 msgid "Ratifications"
 msgstr "Ratifications"
 
-#: templates/peachjam/layouts/document_detail.html:136
+#: templates/peachjam/layouts/document_detail.html:146
 msgid "Jurisdiction"
 msgstr "Juridiction"
 
-#: templates/peachjam/layouts/document_detail.html:149
+#: templates/peachjam/layouts/document_detail.html:159
 msgid "Citation"
 msgstr "Référence"
 
-#: templates/peachjam/layouts/document_detail.html:168
+#: templates/peachjam/layouts/document_detail.html:179
+#, fuzzy
+#| msgid "Media neutral citation"
+msgid "Law report citations"
+msgstr "Citation neutre des médias"
+
+#: templates/peachjam/layouts/document_detail.html:183
 msgid "Alternative names"
 msgstr "Noms alternatifs"
 
-#: templates/peachjam/layouts/document_detail.html:187
-msgid "Court"
-msgstr "Cour"
+#: templates/peachjam/layouts/document_detail.html:213
+msgid "Judges"
+msgstr "Juges"
 
-#: templates/peachjam/layouts/document_detail.html:210
+#: templates/peachjam/layouts/document_detail.html:228
 msgid "Judgment date"
 msgstr "Date du jugement"
 
-#: templates/peachjam/layouts/document_detail.html:246
+#: templates/peachjam/layouts/document_detail.html:264
 msgid "Language"
 msgstr "Langue"
 
-#: templates/peachjam/layouts/document_detail.html:277
+#: templates/peachjam/layouts/document_detail.html:304
 msgid "Type"
 msgstr "Type"
 
-#: templates/peachjam/layouts/document_detail.html:286
-#: templates/peachjam/layouts/document_detail.html:291
-#: templates/peachjam/layouts/document_detail.html:297
-#: templates/peachjam/layouts/document_detail.html:310
-msgid "Download"
-msgstr "Télécharger"
-
-#: templates/peachjam/layouts/document_detail.html:332
+#: templates/peachjam/layouts/document_detail.html:362
 #, python-format
 msgid "%(n_relationships)s related documents"
 msgstr "%(n_relationships)s documents connexes"
 
-#: templates/peachjam/layouts/document_list.html:30
+#: templates/peachjam/layouts/document_list.html:27
 msgid "Documents"
 msgstr "Documents"
 
-#: templates/peachjam/layouts/document_list.html:42
+#: templates/peachjam/layouts/document_list.html:43
 msgid "Filters"
 msgstr "Filtres"
 
@@ -1481,6 +1677,18 @@ msgstr "Travail principal"
 msgid "Legislation"
 msgstr "Législation"
 
+#: templates/peachjam/metabase_stats.html:4
+msgid "Site Statistics"
+msgstr ""
+
+#: templates/peachjam/metabase_stats.html:9
+msgid "Statistics"
+msgstr ""
+
+#: templates/peachjam/taxonomy_list.html:4
+msgid "Taxonomy"
+msgstr "Taxonomie"
+
 #: templates/peachjam/terms_of_use.html:4
 #: templates/peachjam/terms_of_use.html:29
 msgid "Terms of Use"
@@ -1492,30 +1700,56 @@ msgstr "Termes et conditions d'utilisation"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: templates/peachjam/top_level_taxonomy_list.html:4
-msgid "Taxonomy"
-msgstr "Taxonomie"
-
-#: views/legislation.py:280
-msgid "This is the version of this Act as it was when it was repealed."
-msgstr "Il s'agit de la version de la présente loi telle qu'elle était au moment de son abrogation."
-
-#: views/legislation.py:281
-msgid "This is the latest version of this Act."
-msgstr "Il s'agit de la dernière version de la présente Loi."
-
-#: views/legislation.py:283
-#, python-format
-msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+#: views/legislation.py:51
+#, fuzzy, python-format
+#| msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+msgid "This %(friendly_type)s was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 msgstr "Cette loi a été abrogé le %(date)s par <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 
-#: views/legislation.py:286
+#: views/legislation.py:59
 #, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This %(friendly_type)s has not yet commenced and is not yet law."
+msgstr ""
+
+#: views/legislation.py:90
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was when it was repealed."
+msgid "This is the version of this %(friendly_type)s as it was when it was repealed."
+msgstr "Il s'agit de la version de la présente loi telle qu'elle était au moment de son abrogation."
+
+#: views/legislation.py:103
+#, fuzzy, python-format
+#| msgid "This is the latest version of this Act."
+msgid "This is the latest version of this %(friendly_type)s."
+msgstr "Il s'agit de la dernière version de la présente Loi."
+
+#: views/legislation.py:117
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
 msgstr "Il s'agit de la version de cette loi telle qu'elle était de %(date_from)s à %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Lire la version telle qu'elle était quand elle a été abrogée</a>."
 
-#: views/legislation.py:290
-#, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+#: views/legislation.py:122
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
 msgstr "Il s'agit de la version de cette loi telle qu'elle était de %(date_from)s à %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Lire la version actuellement en vigueur</a>."
 
+#: views/legislation.py:162
+msgid "There are outstanding amendments that have not yet been applied. See the History tab for more information."
+msgstr ""
+
+#~ msgid "Refresh all content"
+#~ msgstr "Actualiser tout le contenu"
+
+#~ msgid "Invalid Date"
+#~ msgstr "Date non valide"
+
+#~ msgid "headnote holding"
+#~ msgstr "résumé détaillé"
+
+#~ msgid "additional citations"
+#~ msgstr "références supplémentaires"
+
+#~ msgid "string override"
+#~ msgstr "remplacement de chaîne de caractères"

--- a/peachjam/locale/pt/LC_MESSAGES/django.po
+++ b/peachjam/locale/pt/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-13 09:08+0200\n"
+"POT-Creation-Date: 2023-08-30 10:47+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese\n"
@@ -17,105 +17,136 @@ msgstr ""
 "X-Crowdin-File: /main/peachjam/locale/en/LC_MESSAGES/django.po\n"
 "X-Crowdin-File-ID: 99\n"
 
-#: admin.py:291
+#: admin.py:120
+msgid "Import"
+msgstr ""
+
+#: admin.py:363
 msgid "Key details"
 msgstr "Detalhes da chave"
 
-#: admin.py:304
+#: admin.py:376
 msgid "Additional details"
 msgstr "Detalhes adicionais"
 
-#: admin.py:317
+#: admin.py:389
 msgid "Work identification"
 msgstr "Identificação do trabalho"
 
-#: admin.py:330
+#: admin.py:402
 msgid "Content"
 msgstr "Conteúdo"
 
-#: admin.py:338
+#: admin.py:410
 msgid "Advanced"
 msgstr "Avançado"
 
-#: admin.py:493 models/judgment.py:319
+#: admin.py:650 models/judgment.py:370
 msgid "case number"
 msgstr "número do processo"
 
-#: admin.py:494 models/judgment.py:320
+#: admin.py:651 models/judgment.py:371
 msgid "case numbers"
 msgstr "números de casos"
 
-#: admin.py:586
+#: admin.py:665 models/judgment.py:36 models/judgment.py:158
+msgid "judge"
+msgstr "juiz"
+
+#: admin.py:666 models/judgment.py:37 models/judgment.py:179
+msgid "judges"
+msgstr "juízes"
+
+#: admin.py:766
 msgid "Refreshing content in the background."
 msgstr "Atualizando o conteúdo em segundo plano."
 
-#: admin.py:588
-msgid "Refresh all content"
-msgstr "Atualizar todo o conteúdo"
+#: admin.py:769
+msgid "Refresh content selected ingestors"
+msgstr ""
 
-#: models/article.py:20 models/core_document_model.py:241
+#: admin.py:817
+#, fuzzy
+#| msgid "published"
+msgid "Articles published."
+msgstr "Publicado"
+
+#: admin.py:819
+msgid "Publish selected articles"
+msgstr ""
+
+#: admin.py:823
+#, fuzzy
+#| msgid "published"
+msgid "Articles unpublished."
+msgstr "Publicado"
+
+#: admin.py:825
+msgid "Unpublish selected articles"
+msgstr ""
+
+#: models/article.py:21 models/core_document_model.py:326
 msgid "date"
 msgstr "data"
 
-#: models/article.py:21 models/core_document_model.py:78
-#: models/core_document_model.py:240 models/core_document_model.py:661
+#: models/article.py:22 models/core_document_model.py:161
+#: models/core_document_model.py:325
 msgid "title"
 msgstr "título"
 
-#: models/article.py:22
+#: models/article.py:23
 msgid "body"
 msgstr "Corpo"
 
-#: models/article.py:27 models/author.py:20 models/generic_document.py:20
-#: models/generic_document.py:48
+#: models/article.py:28 models/author.py:21
 msgid "author"
 msgstr "autor"
 
-#: models/article.py:30 models/core_document_model.py:573
+#: models/article.py:31 models/core_document_model.py:738
 msgid "image"
 msgstr "Imagem"
 
-#: models/article.py:32
+#: models/article.py:33
 msgid "summary"
 msgstr "summary"
 
-#: models/article.py:33 models/relationships.py:7 models/taxonomies.py:11
+#: models/article.py:34 models/relationships.py:7 models/taxonomies.py:12
 msgid "slug"
 msgstr "eixo"
 
-#: models/article.py:34
+#: models/article.py:35
 msgid "published"
 msgstr "Publicado"
 
-#: models/article.py:35
+#: models/article.py:37
 msgid "topics"
 msgstr "tópicos"
 
-#: models/article.py:38
+#: models/article.py:41
 msgid "article"
 msgstr "artigo"
 
-#: models/article.py:39
+#: models/article.py:42
 msgid "articles"
 msgstr "artigos"
 
-#: models/article.py:64
+#: models/article.py:75
 msgid "user"
 msgstr "usuário"
 
-#: models/article.py:67
+#: models/article.py:78
 msgid "photo"
 msgstr "fotografia"
 
-#: models/article.py:69
+#: models/article.py:80
 msgid "profile description"
 msgstr "Descrição do perfil"
 
-#: models/article.py:72
+#: models/article.py:83
 msgid "user profile"
 msgstr "perfil do usuário"
 
-#: models/article.py:73
+#: models/article.py:84
 msgid "user profiles"
 msgstr "perfis de usuário"
 
@@ -123,285 +154,349 @@ msgstr "perfis de usuário"
 msgid "Author"
 msgstr "Autor"
 
-#: models/author.py:9 models/core_document_model.py:41
-#: models/core_document_model.py:55 models/core_document_model.py:624
-#: models/ingestors.py:14 models/ingestors.py:33 models/judgment.py:14
-#: models/judgment.py:28 models/judgment.py:41 models/judgment.py:55
-#: models/judgment.py:69 models/judgment.py:86 models/judgment.py:120
-#: models/relationships.py:6 models/taxonomies.py:10
+#: models/author.py:8
+#, fuzzy
+#| msgid "Author"
+msgid "Authors"
+msgstr "Autor"
+
+#: models/author.py:10 models/core_document_model.py:44
+#: models/core_document_model.py:72 models/core_document_model.py:86
+#: models/core_document_model.py:810 models/ingestors.py:14
+#: models/ingestors.py:33 models/judgment.py:15 models/judgment.py:30
+#: models/judgment.py:45 models/judgment.py:60 models/judgment.py:74
+#: models/judgment.py:91 models/judgment.py:125 models/relationships.py:6
+#: models/taxonomies.py:11
 msgid "name"
 msgstr "Nome"
 
-#: models/author.py:10 models/core_document_model.py:43
-#: models/core_document_model.py:59 models/judgment.py:87
-#: models/judgment.py:121
+#: models/author.py:11 models/core_document_model.py:46
+#: models/core_document_model.py:74 models/core_document_model.py:90
+#: models/judgment.py:92 models/judgment.py:126
 msgid "code"
 msgstr "Código"
 
-#: models/author.py:13 models/judgment.py:96 models/profile.py:35
-#: models/profile.py:36
+#: models/author.py:14 models/core_document_model.py:92 models/judgment.py:101
+#: models/profile.py:35 models/profile.py:36 models/taxonomies.py:15
 msgid "profile"
 msgstr "perfil"
 
-#: models/author.py:21
+#: models/author.py:22 models/generic_document.py:19
+#: models/generic_document.py:45
 msgid "authors"
 msgstr "autores"
 
-#: models/citations.py:10 models/core_document_model.py:568
-#: models/core_document_model.py:594 models/core_document_model.py:640
-#: models/core_document_model.py:659 models/core_document_model.py:680
-#: models/judgment.py:314 models/taxonomies.py:32
+#: models/citations.py:16 models/core_document_model.py:733
+#: models/core_document_model.py:759 models/core_document_model.py:826
+#: models/core_document_model.py:855 models/core_document_model.py:881
+#: models/judgment.py:365 models/taxonomies.py:46
 msgid "document"
 msgstr "Documento"
 
-#: models/citations.py:12
+#: models/citations.py:18
 msgid "text"
 msgstr "Texto"
 
-#: models/citations.py:13
+#: models/citations.py:19
 msgid "url"
 msgstr "URL"
 
-#: models/citations.py:15
+#: models/citations.py:21
 msgid "target id"
 msgstr "target id"
 
-#: models/citations.py:17
+#: models/citations.py:23
 msgid "target selectors"
 msgstr "seletores de destino"
 
-#: models/citations.py:20
+#: models/citations.py:26
 msgid "citation link"
 msgstr "link de citação"
 
-#: models/citations.py:21
+#: models/citations.py:27
 msgid "citation links"
 msgstr "links de citação"
 
-#: models/citations.py:56
+#: models/citations.py:62
 msgid "citing work"
 msgstr "citando trabalho"
 
-#: models/citations.py:63
+#: models/citations.py:69
 msgid "target work"
 msgstr "trabalho alvo"
 
-#: models/core_document_model.py:44 models/core_document_model.py:626
-#: models/judgment.py:16 models/judgment.py:29 models/judgment.py:42
-#: models/judgment.py:57 models/judgment.py:70
+#: models/citations.py:90
+#, fuzzy
+#| msgid "Hearing date"
+msgid "processing date"
+msgstr "Data da audiência"
+
+#: models/citations.py:93
+#, fuzzy
+#| msgid "citation link"
+msgid "citation processing"
+msgstr "link de citação"
+
+#: models/core_document_model.py:48
+msgid "level"
+msgstr ""
+
+#: models/core_document_model.py:62
+msgid "label"
+msgstr ""
+
+#: models/core_document_model.py:63 models/core_document_model.py:433
+msgid "labels"
+msgstr ""
+
+#: models/core_document_model.py:75 models/core_document_model.py:812
+#: models/judgment.py:17 models/judgment.py:32 models/judgment.py:47
+#: models/judgment.py:62 models/judgment.py:75
 msgid "description"
 msgstr "Descrição"
 
-#: models/core_document_model.py:47
+#: models/core_document_model.py:78
 msgid "document nature"
 msgstr "natureza do documento"
 
-#: models/core_document_model.py:48
+#: models/core_document_model.py:79
 msgid "document natures"
 msgstr "índices de documentos"
 
-#: models/core_document_model.py:57 models/core_document_model.py:261
+#: models/core_document_model.py:88 models/core_document_model.py:346
 msgid "jurisdiction"
 msgstr "jurisdição"
 
-#: models/core_document_model.py:62 models/core_document_model.py:268
+#: models/core_document_model.py:96 models/core_document_model.py:353
 msgid "locality"
 msgstr "localidade"
 
-#: models/core_document_model.py:63
+#: models/core_document_model.py:97
 msgid "localities"
 msgstr "localidades"
 
-#: models/core_document_model.py:76
+#: models/core_document_model.py:110
 msgid "FRBR URI"
 msgstr "FRBR URI"
 
-#: models/core_document_model.py:84
-msgid "languages"
-msgstr "Idiomas"
+#: models/core_document_model.py:114
+#, fuzzy
+#| msgid "FRBR URI actor"
+msgid "FRBR URI country"
+msgstr "Ator URI FRBR"
 
-#: models/core_document_model.py:87
-msgid "ranking"
-msgstr "classificação"
+#: models/core_document_model.py:120
+#, fuzzy
+#| msgid "FRBR URI doctype"
+msgid "FRBR URI locality"
+msgstr "Doctype FRBR URI"
 
-#: models/core_document_model.py:90 models/core_document_model.py:230
-msgid "work"
-msgstr "Trabalho"
+#: models/core_document_model.py:126
+#, fuzzy
+#| msgid "FRBR URI date"
+msgid "FRBR URI place"
+msgstr "FRBR URI date"
 
-#: models/core_document_model.py:91
-msgid "works"
-msgstr "obras"
-
-#: models/core_document_model.py:233
-msgid "document type"
-msgstr "tipo de documento"
-
-#: models/core_document_model.py:243 models/core_document_model.py:597
-msgid "source URL"
-msgstr "URL fonte"
-
-#: models/core_document_model.py:245
-msgid "citation"
-msgstr "citação"
-
-#: models/core_document_model.py:246
-msgid "content HTML"
-msgstr "conteúdo HTML"
-
-#: models/core_document_model.py:247
-msgid "content HTML is AKN"
-msgstr "HTML do conteúdo é AKN"
-
-#: models/core_document_model.py:248
-msgid "TOC JSON"
-msgstr "JSON TOC"
-
-#: models/core_document_model.py:254
-msgid "language"
-msgstr "idioma"
-
-#: models/core_document_model.py:275 models/core_document_model.py:643
-msgid "nature"
-msgstr "natureza"
-
-#: models/core_document_model.py:279
-msgid "work FRBR URI"
-msgstr "work FRBR URI"
-
-#: models/core_document_model.py:284
+#: models/core_document_model.py:132 models/core_document_model.py:369
 msgid "FRBR URI doctype"
 msgstr "Doctype FRBR URI"
 
-#: models/core_document_model.py:291
+#: models/core_document_model.py:138 models/core_document_model.py:376
 msgid "FRBR URI subtype"
 msgstr "FRBR URI subtype"
 
-#: models/core_document_model.py:296
-msgid "Document subtype. Lowercase letters, numbers _ and - only."
-msgstr "Subtipo do documento. Letras minúsculas, números _ e - apenas."
-
-#: models/core_document_model.py:299
+#: models/core_document_model.py:144 models/core_document_model.py:384
 msgid "FRBR URI actor"
 msgstr "Ator URI FRBR"
 
-#: models/core_document_model.py:304
-msgid "Originating actor. Lowercase letters, numbers _ and - only."
-msgstr "Originando ator. Letras minúsculas, números _ e - apenas."
-
-#: models/core_document_model.py:307
+#: models/core_document_model.py:150 models/core_document_model.py:392
 msgid "FRBR URI date"
 msgstr "FRBR URI date"
 
-#: models/core_document_model.py:312
-msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
-msgstr "AAAA, AAAA-MM, ou AAAA-MM-DD"
-
-#: models/core_document_model.py:315
+#: models/core_document_model.py:156 models/core_document_model.py:400
 msgid "FRBR URI number"
 msgstr "FRBR URI number"
 
-#: models/core_document_model.py:321
+#: models/core_document_model.py:167
+msgid "languages"
+msgstr "Idiomas"
+
+#: models/core_document_model.py:170
+msgid "ranking"
+msgstr "classificação"
+
+#: models/core_document_model.py:173 models/core_document_model.py:315
+msgid "work"
+msgstr "Trabalho"
+
+#: models/core_document_model.py:174
+msgid "works"
+msgstr "obras"
+
+#: models/core_document_model.py:318
+msgid "document type"
+msgstr "tipo de documento"
+
+#: models/core_document_model.py:328 models/core_document_model.py:762
+msgid "source URL"
+msgstr "URL fonte"
+
+#: models/core_document_model.py:330
+msgid "citation"
+msgstr "citação"
+
+#: models/core_document_model.py:331
+msgid "content HTML"
+msgstr "conteúdo HTML"
+
+#: models/core_document_model.py:332
+msgid "content HTML is AKN"
+msgstr "HTML do conteúdo é AKN"
+
+#: models/core_document_model.py:333
+msgid "TOC JSON"
+msgstr "JSON TOC"
+
+#: models/core_document_model.py:339
+msgid "language"
+msgstr "idioma"
+
+#: models/core_document_model.py:360 models/core_document_model.py:829
+msgid "nature"
+msgstr "natureza"
+
+#: models/core_document_model.py:364
+msgid "work FRBR URI"
+msgstr "work FRBR URI"
+
+#: models/core_document_model.py:381
+msgid "Document subtype. Lowercase letters, numbers _ and - only."
+msgstr "Subtipo do documento. Letras minúsculas, números _ e - apenas."
+
+#: models/core_document_model.py:389
+msgid "Originating actor. Lowercase letters, numbers _ and - only."
+msgstr "Originando ator. Letras minúsculas, números _ e - apenas."
+
+#: models/core_document_model.py:397
+msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
+msgstr "AAAA, AAAA-MM, ou AAAA-MM-DD"
+
+#: models/core_document_model.py:406
 msgid "Unique number or short title identifying this work. Lowercase letters, numbers _ and - only."
 msgstr "Número único ou título curto que identifique este trabalho. Letras minúsculas, números _ e - apenas."
 
-#: models/core_document_model.py:326
+#: models/core_document_model.py:411
 msgid "expression FRBR URI"
 msgstr "expression FRBR URI"
 
-#: models/core_document_model.py:330
+#: models/core_document_model.py:415
 msgid "created at"
 msgstr "criado em"
 
-#: models/core_document_model.py:331
+#: models/core_document_model.py:416
 msgid "updated at"
 msgstr "atualizado em"
 
-#: models/core_document_model.py:336
+#: models/core_document_model.py:422
 msgid "created by"
 msgstr "criado por"
 
-#: models/core_document_model.py:339
+#: models/core_document_model.py:425
 msgid "allow robots"
 msgstr "allow robots"
 
-#: models/core_document_model.py:342
+#: models/core_document_model.py:428
 msgid "Allow this document to be indexed by search engine robots."
 msgstr "Permitir que este documento seja indexado por robôs mecanismos de busca."
 
-#: models/core_document_model.py:368
-msgid "Invalid Date"
-msgstr "Data Inválida"
-
-#: models/core_document_model.py:371
+#: models/core_document_model.py:469
 msgid "You cannot set a future date for the document"
 msgstr "Você não pode definir uma data futura para o documento"
 
-#: models/core_document_model.py:377
+#: models/core_document_model.py:477
 #, python-format
 msgid "Invalid FRBR URI: %(uri)s"
 msgstr "Invalid FRBR URI: %(uri)s"
 
-#: models/core_document_model.py:540
+#: models/core_document_model.py:488
+msgid "Document with this Expression FRBR URI already exists!"
+msgstr ""
+
+#: models/core_document_model.py:705
 msgid "filename"
 msgstr "nome_arquivo"
 
-#: models/core_document_model.py:541
+#: models/core_document_model.py:706
 msgid "mimetype"
 msgstr "mimetype"
 
-#: models/core_document_model.py:542
+#: models/core_document_model.py:707
 msgid "size"
 msgstr "tamanho"
 
-#: models/core_document_model.py:543 models/core_document_model.py:570
+#: models/core_document_model.py:708 models/core_document_model.py:735
 msgid "file"
 msgstr "arquivo"
 
-#: models/core_document_model.py:574
+#: models/core_document_model.py:739
 msgid "images"
 msgstr "Imagens"
 
-#: models/core_document_model.py:601
+#: models/core_document_model.py:766
+msgid "file as pdf"
+msgstr ""
+
+#: models/core_document_model.py:774
 msgid "source file"
 msgstr "arquivo de origem"
 
-#: models/core_document_model.py:602
+#: models/core_document_model.py:775
 msgid "source files"
 msgstr "arquivos de origem"
 
-#: models/core_document_model.py:629
+#: models/core_document_model.py:815
 msgid "attached file nature"
 msgstr "arquivo anexado natureza"
 
-#: models/core_document_model.py:630
+#: models/core_document_model.py:816
 msgid "attached file natures"
 msgstr "índices de arquivos anexados"
 
-#: models/core_document_model.py:647
+#: models/core_document_model.py:833
 msgid "attached file"
 msgstr "arquivo anexado"
 
-#: models/core_document_model.py:648
+#: models/core_document_model.py:834
 msgid "attached files"
 msgstr "arquivos anexados"
 
-#: models/core_document_model.py:664
+#: models/core_document_model.py:858
+msgid "Law report citation/Alternative known name"
+msgstr ""
+
+#: models/core_document_model.py:865
 msgid "alternative name"
 msgstr "nome alternativo"
 
-#: models/core_document_model.py:665
+#: models/core_document_model.py:866
 msgid "alternative names"
 msgstr "nomes alternativos"
 
-#: models/core_document_model.py:685
+#: models/core_document_model.py:886
 msgid "document text"
 msgstr "texto do documento"
 
-#: models/core_document_model.py:689
+#: models/core_document_model.py:890
+#, fuzzy
+#| msgid "document"
+msgid "document XML"
+msgstr "Documento"
+
+#: models/core_document_model.py:894
 msgid "document content"
 msgstr "conteúdo do documento"
 
-#: models/core_document_model.py:690
+#: models/core_document_model.py:895
 msgid "document contents"
 msgstr "conteúdo documento"
 
@@ -413,35 +508,35 @@ msgstr "olhar"
 msgid "gazettes"
 msgstr "olhares"
 
-#: models/generic_document.py:26
+#: models/generic_document.py:25
 msgid "generic document"
 msgstr "documento genérico"
 
-#: models/generic_document.py:27
+#: models/generic_document.py:26
 msgid "generic documents"
 msgstr "documentos genéricos"
 
-#: models/generic_document.py:54
+#: models/generic_document.py:51
 msgid "legal instrument"
 msgstr "instrumento jurídico"
 
-#: models/generic_document.py:55
+#: models/generic_document.py:52
 msgid "legal instruments"
 msgstr "instrumentos jurídicos"
 
-#: models/generic_document.py:77
+#: models/generic_document.py:74
 msgid "metadata JSON"
 msgstr "metadados JSON"
 
-#: models/generic_document.py:78 templates/peachjam/document_popup.html:9
+#: models/generic_document.py:75 templates/peachjam/document_popup.html:9
 msgid "repealed"
 msgstr "revogado"
 
-#: models/generic_document.py:80
+#: models/generic_document.py:77
 msgid "parent work"
 msgstr "trabalho pai"
 
-#: models/generic_document.py:86 models/generic_document.py:87
+#: models/generic_document.py:83 models/generic_document.py:84
 msgid "legislation"
 msgstr "legislação"
 
@@ -473,135 +568,125 @@ msgstr "última atualização em"
 msgid "enabled"
 msgstr "habilitado"
 
-#: models/judgment.py:20
+#: models/judgment.py:21
 msgid "attorney"
 msgstr "advogado"
 
-#: models/judgment.py:21 models/judgment.py:149
+#: models/judgment.py:22 models/judgment.py:182
 msgid "attorneys"
 msgstr "advogados"
 
-#: models/judgment.py:33
-msgid "judge"
-msgstr "juiz"
-
-#: models/judgment.py:34 models/judgment.py:147
-msgid "judges"
-msgstr "juízes"
-
-#: models/judgment.py:46
+#: models/judgment.py:51
 msgid "order outcome"
 msgstr "resultado do pedido"
 
-#: models/judgment.py:47
+#: models/judgment.py:52
 msgid "order outcomes"
 msgstr "resultados de pedidos"
 
-#: models/judgment.py:61 models/judgment.py:307
+#: models/judgment.py:66 models/judgment.py:358
 msgid "matter type"
 msgstr "tipo de matéria"
 
-#: models/judgment.py:62
+#: models/judgment.py:67
 msgid "matter types"
 msgstr "tipos de assuntos"
 
-#: models/judgment.py:71 models/judgment.py:98
+#: models/judgment.py:76 models/judgment.py:103
 msgid "order"
 msgstr "ordem"
 
-#: models/judgment.py:78 models/judgment.py:93
+#: models/judgment.py:83 models/judgment.py:98
 msgid "court class"
 msgstr "aula do tribunal"
 
-#: models/judgment.py:79
+#: models/judgment.py:84
 msgid "court classes"
 msgstr "aulas de corte"
 
-#: models/judgment.py:105 models/judgment.py:118 models/judgment.py:138
+#: models/judgment.py:110 models/judgment.py:123 models/judgment.py:169
 msgid "court"
 msgstr "tribunal"
 
-#: models/judgment.py:106
+#: models/judgment.py:111
 msgid "courts"
 msgstr "Tribunais"
 
-#: models/judgment.py:124
+#: models/judgment.py:129
 msgid "court registry"
 msgstr "tribunal de registro"
 
-#: models/judgment.py:125
+#: models/judgment.py:130
 msgid "court registries"
 msgstr "Tribunal de registros"
 
-#: models/judgment.py:158
-msgid "headnote holding"
-msgstr "segurando headnote"
-
-#: models/judgment.py:160
-msgid "additional citations"
-msgstr "citações adicionais"
-
-#: models/judgment.py:162
-msgid "flynote"
-msgstr "nota"
-
-#: models/judgment.py:164
-msgid "case name"
-msgstr "nome do caso"
-
-#: models/judgment.py:166
-msgid "Party names for use in title"
-msgstr "Nome da party para uso no título"
-
-#: models/judgment.py:172
-msgid "serial number"
-msgstr "número de série"
-
-#: models/judgment.py:174
-msgid "Serial number for MNC, unique for a year and an author."
-msgstr "Número de série para MNC, único por um ano e autor."
-
-#: models/judgment.py:177
-msgid "serial number override"
-msgstr "substituição de número de série"
-
-#: models/judgment.py:180
-msgid "Specific MNC serial number assigned by the court."
-msgstr "Número de série MNC específico atribuído pelo tribunal."
-
-#: models/judgment.py:184
-msgid "MNC"
-msgstr "MNC"
-
-#: models/judgment.py:186
-msgid "Media neutral citation"
-msgstr "Citação neutra de mídia"
-
-#: models/judgment.py:201
+#: models/judgment.py:156 models/judgment.py:231
 msgid "judgment"
 msgstr "julgamento"
 
+#: models/judgment.py:191
+#, fuzzy
+#| msgid "summary"
+msgid "case summary"
+msgstr "summary"
+
+#: models/judgment.py:192
+msgid "flynote"
+msgstr "nota"
+
+#: models/judgment.py:194
+msgid "case name"
+msgstr "nome do caso"
+
+#: models/judgment.py:196
+msgid "Party names for use in title"
+msgstr "Nome da party para uso no título"
+
 #: models/judgment.py:202
+msgid "serial number"
+msgstr "número de série"
+
+#: models/judgment.py:204
+msgid "Serial number for MNC, unique for a year and an author."
+msgstr "Número de série para MNC, único por um ano e autor."
+
+#: models/judgment.py:207
+msgid "serial number override"
+msgstr "substituição de número de série"
+
+#: models/judgment.py:210
+msgid "Specific MNC serial number assigned by the court."
+msgstr "Número de série MNC específico atribuído pelo tribunal."
+
+#: models/judgment.py:214
+msgid "MNC"
+msgstr "MNC"
+
+#: models/judgment.py:216
+msgid "Media neutral citation"
+msgstr "Citação neutra de mídia"
+
+#: models/judgment.py:232
 msgid "judgments"
 msgstr "julgamentos"
 
-#: models/judgment.py:293
-msgid "string override"
-msgstr "substituição de string"
+#: models/judgment.py:344
+msgid "Full case number as printed on judgment"
+msgstr ""
 
-#: models/judgment.py:297
+#: models/judgment.py:348
 msgid "Override for full case number string"
 msgstr "Substituir para string de número de caso completo"
 
-#: models/judgment.py:299
+#: models/judgment.py:350
 msgid "string"
 msgstr "sequência"
 
-#: models/judgment.py:300 templates/peachjam/_timeline_events.html:32
+#: models/judgment.py:351 templates/peachjam/_timeline_events.html:35
 msgid "number"
 msgstr "Número"
 
-#: models/judgment.py:301
+#: models/judgment.py:352
 msgid "year"
 msgstr "ano"
 
@@ -670,55 +755,101 @@ msgstr "idioma padrão do documento"
 msgid "document languages"
 msgstr "idiomas do documento"
 
-#: models/settings.py:40
+#: models/settings.py:41
+#, fuzzy
+#| msgid "document jurisdictions"
+msgid "default document jurisdiction"
+msgstr "jurisdições de documentos"
+
+#: models/settings.py:47
 msgid "document jurisdictions"
 msgstr "jurisdições de documentos"
 
-#: models/settings.py:43
+#: models/settings.py:50
 msgid "subsidiary legislation label"
 msgstr "Rótulo de legislação subsidiária"
 
-#: models/settings.py:48
+#: models/settings.py:55
 msgid "google analytics id"
 msgstr "identificação do google analytics"
 
-#: models/settings.py:51
+#: models/settings.py:59
+msgid "Enter one or more Google Analytics IDs separated by spaces."
+msgstr ""
+
+#: models/settings.py:62
 msgid "pagerank boost value"
 msgstr "valor de aumento de classificação de página"
 
-#: models/settings.py:55
+#: models/settings.py:65
+msgid "allowed login domains"
+msgstr ""
+
+#: models/settings.py:69
+msgid "metabase dashboard link"
+msgstr ""
+
+#: models/settings.py:73
+msgid "mailchimp form url"
+msgstr ""
+
+#: models/settings.py:76
+#, fuzzy
+#| msgid "citation link"
+msgid "twitter link"
+msgstr "link de citação"
+
+#: models/settings.py:79
+msgid "facebook link"
+msgstr ""
+
+#: models/settings.py:82
+#, fuzzy
+#| msgid "Media neutral citation"
+msgid "re-extract citations"
+msgstr "Citação neutra de mídia"
+
+#: models/settings.py:85
+msgid "Pocket Law repo"
+msgstr ""
+
+#: models/settings.py:88
+msgid "help link"
+msgstr ""
+
+#: models/settings.py:95
 msgid "site settings"
 msgstr "configurações do site"
 
-#: models/taxonomies.py:15 models/taxonomies.py:16
+#: models/taxonomies.py:19 models/taxonomies.py:20
 msgid "taxonomies"
 msgstr "taxonomies"
 
-#: models/taxonomies.py:35
+#: models/taxonomies.py:49
 msgid "topic"
 msgstr "Tópico"
 
-#: models/taxonomies.py:40
+#: models/taxonomies.py:54
 msgid "document topic"
 msgstr "tópico do documento"
 
-#: models/taxonomies.py:41
+#: models/taxonomies.py:55
 msgid "document topics"
 msgstr "tópicos do documento"
 
-#: settings.py:210
+#: settings.py:235
 msgid "English"
 msgstr "Inglês"
 
-#: settings.py:211
+#: settings.py:236
 msgid "French"
 msgstr "Francês"
 
-#: settings.py:212
+#: settings.py:237
 msgid "Portuguese"
 msgstr "Português"
 
-#: settings.py:213
+#: settings.py:238
 msgid "Swahili"
 msgstr "Suaíli"
 
@@ -775,10 +906,12 @@ msgstr "Esqueceu-se da sua senha?"
 
 #: templates/account/login.html:76
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            Log in with %(provider.name)s\n"
 "          "
-msgstr "\n"
+msgstr ""
+"\n"
 "            Efetuar Login com %(provider.name)s\n"
 "          "
 
@@ -838,6 +971,10 @@ msgstr "Mudar a Senha"
 msgid "Your password has been reset."
 msgstr "Sua senha foi redefinida."
 
+#: templates/admin/change_form.html:7 templates/admin/change_list.html:10
+msgid "Help"
+msgstr ""
+
 #: templates/admin/login.html:20
 msgid "Please correct the error below."
 msgstr "Por favor corrige o erro abaixo."
@@ -855,6 +992,19 @@ msgstr "Você está autenticado como %(username)s, mas não está autorizado a a
 msgid "Forgotten your password or username?"
 msgstr "Esqueceu sua senha ou usuário?"
 
+#: templates/admin/tree_change_list.html:7
+#: templates/peachjam/_document_content.html:48
+msgid "Search"
+msgstr "Pesquisa"
+
+#: templates/admin/tree_change_list.html:8
+msgid "Collapse all"
+msgstr ""
+
+#: templates/admin/tree_change_list.html:9
+msgid "Expand all"
+msgstr ""
+
 #: templates/peachjam/_child_documents.html:2
 msgid "Subsidiary legislation"
 msgstr "Legislação subsidiária"
@@ -869,62 +1019,68 @@ msgstr "Título"
 msgid "Numbered title"
 msgstr "Título numerado"
 
-#: templates/peachjam/_citations.html:6
+#: templates/peachjam/_citations.html:7
 msgid "Cited documents"
 msgstr "Documentos citados"
 
-#: templates/peachjam/_citations.html:18
+#: templates/peachjam/_citations.html:13
 msgid "Documents citing this one"
 msgstr "Documentos citando este"
 
-#: templates/peachjam/_court_list.html:14
-#: templates/peachjam/_court_list.html:20
+#: templates/peachjam/_citations_list.html:27
+msgid "Show/Hide all"
+msgstr ""
+
+#: templates/peachjam/_court_list.html:16
+#: templates/peachjam/_court_list.html:22
 msgid "No courts found."
 msgstr "Não foram encontrados tribunais."
 
-#: templates/peachjam/_document_content.html:24
+#: templates/peachjam/_document_content.html:25
 msgid "Table of contents"
 msgstr "Tabela de conteúdos"
 
-#: templates/peachjam/_document_content.html:36
+#: templates/peachjam/_document_content.html:37
 msgid "Pages"
 msgstr "Páginas"
 
-#: templates/peachjam/_document_content.html:47
-msgid "Search"
-msgstr "Pesquisa"
-
-#: templates/peachjam/_document_content.html:134
+#: templates/peachjam/_document_content.html:136
 msgid "Loading PDF..."
 msgstr "Carregando PDF..."
 
-#: templates/peachjam/_document_content.html:144
+#: templates/peachjam/_document_content.html:146
 #, python-format
 msgid "This document is %(filesize)s. Do you want to load it?"
 msgstr "Este documento é %(filesize)s. Deseja carregá-lo?"
 
-#: templates/peachjam/_document_content.html:148
+#: templates/peachjam/_document_content.html:150
 msgid "Load document"
 msgstr "Carregar documento"
 
-#: templates/peachjam/_document_content.html:157
+#: templates/peachjam/_document_content.html:159
 msgid "To the top"
 msgstr "Para o topo"
 
-#: templates/peachjam/_document_count.html:4
+#: templates/peachjam/_document_count.html:3
 #, python-format
 msgid "%(doc_count)s document"
 msgid_plural "%(doc_count)s documents"
 msgstr[0] "%(doc_count)s documento"
 msgstr[1] "%(doc_count)s documentos"
 
-#: templates/peachjam/_document_table.html:10
-#: templates/peachjam/_judgment_table.html:8
-#: templates/peachjam/layouts/document_detail.html:214
+#: templates/peachjam/_document_table.html:8
+#: templates/peachjam/_ratifications.html:17
+msgid "Country"
+msgstr "País/região"
+
+#: templates/peachjam/_document_table.html:13
+#: templates/peachjam/_judgment_table.html:7
+#: templates/peachjam/layouts/document_detail.html:232
 msgid "Date"
 msgstr "Data"
 
-#: templates/peachjam/_document_table.html:28
+#: templates/peachjam/_document_table.html:33
+#: templates/peachjam/layouts/document_detail.html:268
 msgid "Multiple languages available"
 msgstr "Vários idiomas disponíveis"
 
@@ -936,23 +1092,31 @@ msgstr "Endereço físico"
 msgid "Visit website"
 msgstr "Visitar site"
 
-#: templates/peachjam/_header.html:32 templates/peachjam/_header.html:33
+#: templates/peachjam/_header.html:33 templates/peachjam/_header.html:34
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr "Pesquisar %(APP_NAME)s"
 
-#: templates/peachjam/_header.html:55
+#: templates/peachjam/_header.html:57
 msgid "Admin"
 msgstr "Administrador"
 
-#: templates/peachjam/_header.html:56
+#: templates/peachjam/_header.html:58
 msgid "Logout"
 msgstr "Desconectar"
 
-#: templates/peachjam/_judgment_table.html:7
-#: templates/peachjam/layouts/document_detail.html:196
-msgid "Judges"
-msgstr "Juízes"
+#: templates/peachjam/_mailchimp_form.html:4
+msgid "Subscribe"
+msgstr ""
+
+#: templates/peachjam/_mailchimp_form.html:11
+msgid "Subscribe to our newsletter for updates and news."
+msgstr ""
+
+#: templates/peachjam/_months_list.html:7
+#: templates/peachjam/_months_list.html:24
+msgid "All months"
+msgstr ""
 
 #: templates/peachjam/_pagination.html:6
 msgid "Previous"
@@ -970,43 +1134,49 @@ msgstr "fonte"
 msgid "Last updated"
 msgstr "Última atualização"
 
-#: templates/peachjam/_ratifications.html:17
-msgid "Country"
-msgstr "País/região"
-
 #: templates/peachjam/_ratifications.html:18
-msgid "Ratification Date"
-msgstr "Data de ratificação"
-
-#: templates/peachjam/_ratifications.html:19
-msgid "Deposit Date"
-msgstr "Data do Depósito"
-
-#: templates/peachjam/_ratifications.html:20
 msgid "Signature Date"
 msgstr "Data da Assinatura"
 
+#: templates/peachjam/_ratifications.html:19
+msgid "Ratification Date"
+msgstr "Data de ratificação"
+
+#: templates/peachjam/_ratifications.html:20
+msgid "Deposit Date"
+msgstr "Data do Depósito"
+
 #: templates/peachjam/_recent_document_list.html:14
-#: templates/peachjam/court_detail.html:35
-#: templates/peachjam/layouts/document_list.html:59
+#: templates/peachjam/court_detail.html:42
+#: templates/peachjam/layouts/document_list.html:60
 msgid "No documents found."
 msgstr "Nenhum documento encontrado."
 
-#: templates/peachjam/_related_documents.html:2
-#: templates/peachjam/layouts/document_detail.html:84
-#: templates/peachjam/layouts/document_detail.html:328
+#: templates/peachjam/_registries.html:3
+#, fuzzy
+#| msgid "court registries"
+msgid "Registries"
+msgstr "Tribunal de registros"
+
+#: templates/peachjam/_related_documents.html:4
+#: templates/peachjam/layouts/document_detail.html:93
+#: templates/peachjam/layouts/document_detail.html:357
 msgid "Related documents"
 msgstr "Documentos relacionados"
 
-#: templates/peachjam/_taxonomies.html:2
-#: templates/peachjam/first_level_taxonomy_detail.html:9
-#: templates/peachjam/taxonomy_detail.html:13
-#: templates/peachjam/top_level_taxonomy_list.html:8
+#: templates/peachjam/_social_media.html:2
+msgid "Follow us on social media"
+msgstr ""
+
+#: templates/peachjam/_taxonomies.html:4
+#: templates/peachjam/taxonomy_detail.html:10
+#: templates/peachjam/taxonomy_first_level_detail.html:10
+#: templates/peachjam/taxonomy_list.html:8
 msgid "Taxonomies"
 msgstr "Taxonomies"
 
 #: templates/peachjam/_taxonomy_list.html:23
-#: templates/peachjam/first_level_taxonomy_detail.html:25
+#: templates/peachjam/taxonomy_first_level_detail.html:28
 msgid "No taxonomies found"
 msgstr "Nenhuma taxonomia encontrada"
 
@@ -1250,43 +1420,43 @@ msgstr "Se você tiver comentários ou sugestões sobre esta política, por favo
 msgid "Date of notice: 14 November 2022"
 msgstr "Data do aviso: 14 de novembro de 2022"
 
-#: templates/peachjam/_timeline_events.html:2
+#: templates/peachjam/_timeline_events.html:4
 msgid "History of this document"
 msgstr "Histórico deste documento"
 
-#: templates/peachjam/_timeline_events.html:11
+#: templates/peachjam/_timeline_events.html:14
 msgid "this version"
 msgstr "esta versão"
 
-#: templates/peachjam/_timeline_events.html:15
+#: templates/peachjam/_timeline_events.html:18
 msgid "amendment not yet applied"
 msgstr "emenda ainda não aplicada"
 
-#: templates/peachjam/_timeline_events.html:24
+#: templates/peachjam/_timeline_events.html:27
 msgid "Amended by"
 msgstr "Alterado por"
 
-#: templates/peachjam/_timeline_events.html:27
+#: templates/peachjam/_timeline_events.html:30
 msgid "Assented to"
 msgstr "Assentiu em"
 
-#: templates/peachjam/_timeline_events.html:29
+#: templates/peachjam/_timeline_events.html:32
 msgid "Commences"
 msgstr "Commenus"
 
-#: templates/peachjam/_timeline_events.html:31
+#: templates/peachjam/_timeline_events.html:34
 msgid "Published in"
 msgstr "Publicado em"
 
-#: templates/peachjam/_timeline_events.html:34
+#: templates/peachjam/_timeline_events.html:37
 msgid "Repealed by"
 msgstr "Repetido por"
 
-#: templates/peachjam/_timeline_events.html:42
+#: templates/peachjam/_timeline_events.html:45
 msgid "Read this version"
 msgstr "Ler essa versão"
 
-#: templates/peachjam/_years_list.html:9 templates/peachjam/_years_list.html:25
+#: templates/peachjam/_years_list.html:7 templates/peachjam/_years_list.html:24
 msgid "All years"
 msgstr "Todos os anos"
 
@@ -1296,20 +1466,30 @@ msgstr "Sobre"
 
 #: templates/peachjam/article_detail.html:9
 #: templates/peachjam/article_list.html:4
+#: templates/peachjam/article_list.html:12
+#: templates/peachjam/article_list.html:17
 #: templates/peachjam/user_profile.html:21
 msgid "Articles"
 msgstr "Artigos"
 
-#: templates/peachjam/article_detail.html:56
+#: templates/peachjam/article_detail.html:44
+#: templates/peachjam/layouts/document_detail.html:313
+#: templates/peachjam/layouts/document_detail.html:318
+#: templates/peachjam/layouts/document_detail.html:324
+#: templates/peachjam/layouts/document_detail.html:337
+msgid "Download"
+msgstr "Descarregar"
+
+#: templates/peachjam/article_detail.html:64
 msgid "About the author"
 msgstr "Sobre o autor"
 
-#: templates/peachjam/article_detail.html:61
+#: templates/peachjam/article_detail.html:69
 #, python-format
 msgid "Recent articles by %(username)s"
 msgstr "Artigos recentes por %(username)s"
 
-#: templates/peachjam/article_list.html:9
+#: templates/peachjam/article_list.html:23
 msgid "Latest Articles"
 msgstr "Artigos mais Recentes"
 
@@ -1323,6 +1503,7 @@ msgid "Books"
 msgstr "Livros"
 
 #: templates/peachjam/court_detail.html:9
+#: templates/peachjam/court_registry_detail.html:9
 #: templates/peachjam/judgment_list.html:4
 #: templates/peachjam/judgment_list.html:9
 msgid "Judgments"
@@ -1338,8 +1519,8 @@ msgstr "Julgamentos"
 msgid "Gazettes"
 msgstr "Gazettes"
 
-#: templates/peachjam/gazette_list.html:34
-#: templates/peachjam/gazette_list.html:59
+#: templates/peachjam/gazette_list.html:35
+#: templates/peachjam/gazette_list.html:60
 #, python-format
 msgid "%(num_gazettes)s gazette"
 msgid_plural "%(num_gazettes)s gazettes"
@@ -1365,17 +1546,17 @@ msgid "Media Neutral Citation"
 msgstr "Referência Neutra da Mídia"
 
 #: templates/peachjam/judgment_detail.html:13
-#: templates/peachjam/layouts/document_detail.html:155
+#: templates/peachjam/layouts/document_detail.html:165
 msgid "Copy to clipboard"
 msgstr "Copiar para área de transferência"
 
 #: templates/peachjam/judgment_detail.html:16
-#: templates/peachjam/layouts/document_detail.html:158
+#: templates/peachjam/layouts/document_detail.html:168
 msgid "Copied!"
 msgstr "Copiado!"
 
 #: templates/peachjam/judgment_detail.html:17
-#: templates/peachjam/layouts/document_detail.html:159
+#: templates/peachjam/layouts/document_detail.html:169
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1384,86 +1565,101 @@ msgid "Hearing date"
 msgstr "Data da audiência"
 
 #: templates/peachjam/judgment_detail.html:31
+msgid "Court"
+msgstr "Tribunal"
+
+#: templates/peachjam/judgment_detail.html:39
 msgid "Court Registry"
 msgstr "Registro do Tribunal"
 
-#: templates/peachjam/judgment_detail.html:39
+#: templates/peachjam/judgment_detail.html:47
 msgid "Order"
 msgstr "Ordem"
 
-#: templates/peachjam/judgment_detail.html:48
+#: templates/peachjam/judgment_detail.html:56
 msgid "Case number"
 msgstr "Número do processo"
 
-#: templates/peachjam/judgment_detail.html:61
+#: templates/peachjam/judgment_detail.html:69
 msgid "Attorneys"
 msgstr "Advogados"
+
+#: templates/peachjam/judgment_detail.html:83
+#, fuzzy
+#| msgid "flynote"
+msgid "Flynote"
+msgstr "nota"
+
+#: templates/peachjam/judgment_detail.html:93
+#, fuzzy
+#| msgid "summary"
+msgid "Case summary"
+msgstr "summary"
 
 #: templates/peachjam/judgment_list.html:15
 msgid "Recent judgments"
 msgstr "Julgamentos recentes"
 
-#: templates/peachjam/layouts/document_detail.html:59
+#: templates/peachjam/layouts/document_detail.html:66
 msgid "Document detail"
 msgstr "Detalhe do documento"
 
-#: templates/peachjam/layouts/document_detail.html:71
+#: templates/peachjam/layouts/document_detail.html:79
 msgid "History"
 msgstr "Histórico"
 
-#: templates/peachjam/layouts/document_detail.html:98
+#: templates/peachjam/layouts/document_detail.html:108
 msgid "Citations"
 msgstr "Citações"
 
-#: templates/peachjam/layouts/document_detail.html:112
+#: templates/peachjam/layouts/document_detail.html:122
 msgid "Ratifications"
 msgstr "Tarifas"
 
-#: templates/peachjam/layouts/document_detail.html:136
+#: templates/peachjam/layouts/document_detail.html:146
 msgid "Jurisdiction"
 msgstr "Jurisdição"
 
-#: templates/peachjam/layouts/document_detail.html:149
+#: templates/peachjam/layouts/document_detail.html:159
 msgid "Citation"
 msgstr "Citação"
 
-#: templates/peachjam/layouts/document_detail.html:168
+#: templates/peachjam/layouts/document_detail.html:179
+#, fuzzy
+#| msgid "Media neutral citation"
+msgid "Law report citations"
+msgstr "Citação neutra de mídia"
+
+#: templates/peachjam/layouts/document_detail.html:183
 msgid "Alternative names"
 msgstr "Nomes alternativos"
 
-#: templates/peachjam/layouts/document_detail.html:187
-msgid "Court"
-msgstr "Tribunal"
+#: templates/peachjam/layouts/document_detail.html:213
+msgid "Judges"
+msgstr "Juízes"
 
-#: templates/peachjam/layouts/document_detail.html:210
+#: templates/peachjam/layouts/document_detail.html:228
 msgid "Judgment date"
 msgstr "data do julgamento"
 
-#: templates/peachjam/layouts/document_detail.html:246
+#: templates/peachjam/layouts/document_detail.html:264
 msgid "Language"
 msgstr "Idioma"
 
-#: templates/peachjam/layouts/document_detail.html:277
+#: templates/peachjam/layouts/document_detail.html:304
 msgid "Type"
 msgstr "tipo"
 
-#: templates/peachjam/layouts/document_detail.html:286
-#: templates/peachjam/layouts/document_detail.html:291
-#: templates/peachjam/layouts/document_detail.html:297
-#: templates/peachjam/layouts/document_detail.html:310
-msgid "Download"
-msgstr "Descarregar"
-
-#: templates/peachjam/layouts/document_detail.html:332
+#: templates/peachjam/layouts/document_detail.html:362
 #, python-format
 msgid "%(n_relationships)s related documents"
 msgstr "%(n_relationships)s documentos relacionados"
 
-#: templates/peachjam/layouts/document_list.html:30
+#: templates/peachjam/layouts/document_list.html:27
 msgid "Documents"
 msgstr "Documentos"
 
-#: templates/peachjam/layouts/document_list.html:42
+#: templates/peachjam/layouts/document_list.html:43
 msgid "Filters"
 msgstr "Filtros"
 
@@ -1481,6 +1677,18 @@ msgstr "Trabalho principal"
 msgid "Legislation"
 msgstr "Legislação"
 
+#: templates/peachjam/metabase_stats.html:4
+msgid "Site Statistics"
+msgstr ""
+
+#: templates/peachjam/metabase_stats.html:9
+msgid "Statistics"
+msgstr ""
+
+#: templates/peachjam/taxonomy_list.html:4
+msgid "Taxonomy"
+msgstr "Taxonomia"
+
 #: templates/peachjam/terms_of_use.html:4
 #: templates/peachjam/terms_of_use.html:29
 msgid "Terms of Use"
@@ -1492,30 +1700,56 @@ msgstr "Termos de Utilização"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: templates/peachjam/top_level_taxonomy_list.html:4
-msgid "Taxonomy"
-msgstr "Taxonomia"
-
-#: views/legislation.py:280
-msgid "This is the version of this Act as it was when it was repealed."
-msgstr "Esta é a versão desta lei tal como era quando foi revogada."
-
-#: views/legislation.py:281
-msgid "This is the latest version of this Act."
-msgstr "Esta é a versão mais recente deste Act."
-
-#: views/legislation.py:283
-#, python-format
-msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+#: views/legislation.py:51
+#, fuzzy, python-format
+#| msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+msgid "This %(friendly_type)s was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 msgstr "Esta Lei foi revogada em %(date)s por <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 
-#: views/legislation.py:286
+#: views/legislation.py:59
 #, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This %(friendly_type)s has not yet commenced and is not yet law."
+msgstr ""
+
+#: views/legislation.py:90
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was when it was repealed."
+msgid "This is the version of this %(friendly_type)s as it was when it was repealed."
+msgstr "Esta é a versão desta lei tal como era quando foi revogada."
+
+#: views/legislation.py:103
+#, fuzzy, python-format
+#| msgid "This is the latest version of this Act."
+msgid "This is the latest version of this %(friendly_type)s."
+msgstr "Esta é a versão mais recente deste Act."
+
+#: views/legislation.py:117
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
 msgstr "Esta é a versão desta Act como era de %(date_from)s para %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Leia a versão, como era, quando foi revogada</a>."
 
-#: views/legislation.py:290
-#, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+#: views/legislation.py:122
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
 msgstr "Esta é a versão desta Act, como era de %(date_from)s para %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Leia a versão em vigor</a>."
 
+#: views/legislation.py:162
+msgid "There are outstanding amendments that have not yet been applied. See the History tab for more information."
+msgstr ""
+
+#~ msgid "Refresh all content"
+#~ msgstr "Atualizar todo o conteúdo"
+
+#~ msgid "Invalid Date"
+#~ msgstr "Data Inválida"
+
+#~ msgid "headnote holding"
+#~ msgstr "segurando headnote"
+
+#~ msgid "additional citations"
+#~ msgstr "citações adicionais"
+
+#~ msgid "string override"
+#~ msgstr "substituição de string"

--- a/peachjam/locale/sw/LC_MESSAGES/django.po
+++ b/peachjam/locale/sw/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-13 09:08+0200\n"
+"POT-Creation-Date: 2023-08-30 10:47+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Swahili\n"
@@ -17,105 +17,136 @@ msgstr ""
 "X-Crowdin-File: /main/peachjam/locale/en/LC_MESSAGES/django.po\n"
 "X-Crowdin-File-ID: 99\n"
 
-#: admin.py:291
+#: admin.py:120
+msgid "Import"
+msgstr ""
+
+#: admin.py:363
 msgid "Key details"
 msgstr "Maelezo muhimu"
 
-#: admin.py:304
+#: admin.py:376
 msgid "Additional details"
 msgstr "Maelezo ya ziada"
 
-#: admin.py:317
+#: admin.py:389
 msgid "Work identification"
 msgstr "Utambulisho wa kazi"
 
-#: admin.py:330
+#: admin.py:402
 msgid "Content"
 msgstr "Maudhui"
 
-#: admin.py:338
+#: admin.py:410
 msgid "Advanced"
 msgstr "Ya hali ya juu"
 
-#: admin.py:493 models/judgment.py:319
+#: admin.py:650 models/judgment.py:370
 msgid "case number"
 msgstr "namba ya kesi"
 
-#: admin.py:494 models/judgment.py:320
+#: admin.py:651 models/judgment.py:371
 msgid "case numbers"
 msgstr "namba za kesi"
 
-#: admin.py:586
+#: admin.py:665 models/judgment.py:36 models/judgment.py:158
+msgid "judge"
+msgstr "jaji"
+
+#: admin.py:666 models/judgment.py:37 models/judgment.py:179
+msgid "judges"
+msgstr "majaji"
+
+#: admin.py:766
 msgid "Refreshing content in the background."
 msgstr "Inaonyesha upya maudhui kwa nyuma."
 
-#: admin.py:588
-msgid "Refresh all content"
-msgstr "Onyesha upya maudhui yote"
+#: admin.py:769
+msgid "Refresh content selected ingestors"
+msgstr ""
 
-#: models/article.py:20 models/core_document_model.py:241
+#: admin.py:817
+#, fuzzy
+#| msgid "published"
+msgid "Articles published."
+msgstr "iliyochapishwa"
+
+#: admin.py:819
+msgid "Publish selected articles"
+msgstr ""
+
+#: admin.py:823
+#, fuzzy
+#| msgid "published"
+msgid "Articles unpublished."
+msgstr "iliyochapishwa"
+
+#: admin.py:825
+msgid "Unpublish selected articles"
+msgstr ""
+
+#: models/article.py:21 models/core_document_model.py:326
 msgid "date"
 msgstr "tarehe"
 
-#: models/article.py:21 models/core_document_model.py:78
-#: models/core_document_model.py:240 models/core_document_model.py:661
+#: models/article.py:22 models/core_document_model.py:161
+#: models/core_document_model.py:325
 msgid "title"
 msgstr "mada"
 
-#: models/article.py:22
+#: models/article.py:23
 msgid "body"
 msgstr "matini"
 
-#: models/article.py:27 models/author.py:20 models/generic_document.py:20
-#: models/generic_document.py:48
+#: models/article.py:28 models/author.py:21
 msgid "author"
 msgstr "mwandishi"
 
-#: models/article.py:30 models/core_document_model.py:573
+#: models/article.py:31 models/core_document_model.py:738
 msgid "image"
 msgstr "picha"
 
-#: models/article.py:32
+#: models/article.py:33
 msgid "summary"
 msgstr "muhtasari"
 
-#: models/article.py:33 models/relationships.py:7 models/taxonomies.py:11
+#: models/article.py:34 models/relationships.py:7 models/taxonomies.py:12
 msgid "slug"
 msgstr "namna rahisi"
 
-#: models/article.py:34
+#: models/article.py:35
 msgid "published"
 msgstr "iliyochapishwa"
 
-#: models/article.py:35
+#: models/article.py:37
 msgid "topics"
 msgstr "mada"
 
-#: models/article.py:38
+#: models/article.py:41
 msgid "article"
 msgstr "makala"
 
-#: models/article.py:39
+#: models/article.py:42
 msgid "articles"
 msgstr "makala"
 
-#: models/article.py:64
+#: models/article.py:75
 msgid "user"
 msgstr "mtumiaji"
 
-#: models/article.py:67
+#: models/article.py:78
 msgid "photo"
 msgstr "picha"
 
-#: models/article.py:69
+#: models/article.py:80
 msgid "profile description"
 msgstr "maelezo ya wasifu"
 
-#: models/article.py:72
+#: models/article.py:83
 msgid "user profile"
 msgstr "wasifu wa mtumiaji"
 
-#: models/article.py:73
+#: models/article.py:84
 msgid "user profiles"
 msgstr "wasifu wa mtumiaji"
 
@@ -123,285 +154,349 @@ msgstr "wasifu wa mtumiaji"
 msgid "Author"
 msgstr "Mwandishi"
 
-#: models/author.py:9 models/core_document_model.py:41
-#: models/core_document_model.py:55 models/core_document_model.py:624
-#: models/ingestors.py:14 models/ingestors.py:33 models/judgment.py:14
-#: models/judgment.py:28 models/judgment.py:41 models/judgment.py:55
-#: models/judgment.py:69 models/judgment.py:86 models/judgment.py:120
-#: models/relationships.py:6 models/taxonomies.py:10
+#: models/author.py:8
+#, fuzzy
+#| msgid "Author"
+msgid "Authors"
+msgstr "Mwandishi"
+
+#: models/author.py:10 models/core_document_model.py:44
+#: models/core_document_model.py:72 models/core_document_model.py:86
+#: models/core_document_model.py:810 models/ingestors.py:14
+#: models/ingestors.py:33 models/judgment.py:15 models/judgment.py:30
+#: models/judgment.py:45 models/judgment.py:60 models/judgment.py:74
+#: models/judgment.py:91 models/judgment.py:125 models/relationships.py:6
+#: models/taxonomies.py:11
 msgid "name"
 msgstr "jina"
 
-#: models/author.py:10 models/core_document_model.py:43
-#: models/core_document_model.py:59 models/judgment.py:87
-#: models/judgment.py:121
+#: models/author.py:11 models/core_document_model.py:46
+#: models/core_document_model.py:74 models/core_document_model.py:90
+#: models/judgment.py:92 models/judgment.py:126
 msgid "code"
 msgstr "mfumo"
 
-#: models/author.py:13 models/judgment.py:96 models/profile.py:35
-#: models/profile.py:36
+#: models/author.py:14 models/core_document_model.py:92 models/judgment.py:101
+#: models/profile.py:35 models/profile.py:36 models/taxonomies.py:15
 msgid "profile"
 msgstr "wasifu"
 
-#: models/author.py:21
+#: models/author.py:22 models/generic_document.py:19
+#: models/generic_document.py:45
 msgid "authors"
 msgstr "waandishi"
 
-#: models/citations.py:10 models/core_document_model.py:568
-#: models/core_document_model.py:594 models/core_document_model.py:640
-#: models/core_document_model.py:659 models/core_document_model.py:680
-#: models/judgment.py:314 models/taxonomies.py:32
+#: models/citations.py:16 models/core_document_model.py:733
+#: models/core_document_model.py:759 models/core_document_model.py:826
+#: models/core_document_model.py:855 models/core_document_model.py:881
+#: models/judgment.py:365 models/taxonomies.py:46
 msgid "document"
 msgstr "hati"
 
-#: models/citations.py:12
+#: models/citations.py:18
 msgid "text"
 msgstr "maandishi"
 
-#: models/citations.py:13
+#: models/citations.py:19
 msgid "url"
 msgstr "url"
 
-#: models/citations.py:15
+#: models/citations.py:21
 msgid "target id"
 msgstr "kitambulisho cha lengo"
 
-#: models/citations.py:17
+#: models/citations.py:23
 msgid "target selectors"
 msgstr "wateuzi lengwa"
 
-#: models/citations.py:20
+#: models/citations.py:26
 msgid "citation link"
 msgstr "kiungo cha dondoo"
 
-#: models/citations.py:21
+#: models/citations.py:27
 msgid "citation links"
 msgstr "viungo vya dondoo"
 
-#: models/citations.py:56
+#: models/citations.py:62
 msgid "citing work"
 msgstr "kukunukuu kazi"
 
-#: models/citations.py:63
+#: models/citations.py:69
 msgid "target work"
 msgstr "kazi lengwa"
 
-#: models/core_document_model.py:44 models/core_document_model.py:626
-#: models/judgment.py:16 models/judgment.py:29 models/judgment.py:42
-#: models/judgment.py:57 models/judgment.py:70
+#: models/citations.py:90
+#, fuzzy
+#| msgid "Hearing date"
+msgid "processing date"
+msgstr "Tarehe ya kusikilizwa"
+
+#: models/citations.py:93
+#, fuzzy
+#| msgid "citation link"
+msgid "citation processing"
+msgstr "kiungo cha dondoo"
+
+#: models/core_document_model.py:48
+msgid "level"
+msgstr ""
+
+#: models/core_document_model.py:62
+msgid "label"
+msgstr ""
+
+#: models/core_document_model.py:63 models/core_document_model.py:433
+msgid "labels"
+msgstr ""
+
+#: models/core_document_model.py:75 models/core_document_model.py:812
+#: models/judgment.py:17 models/judgment.py:32 models/judgment.py:47
+#: models/judgment.py:62 models/judgment.py:75
 msgid "description"
 msgstr "maelezo"
 
-#: models/core_document_model.py:47
+#: models/core_document_model.py:78
 msgid "document nature"
 msgstr "asili ya hati"
 
-#: models/core_document_model.py:48
+#: models/core_document_model.py:79
 msgid "document natures"
 msgstr "asili za hati"
 
-#: models/core_document_model.py:57 models/core_document_model.py:261
+#: models/core_document_model.py:88 models/core_document_model.py:346
 msgid "jurisdiction"
 msgstr "mamlaka ya kisheria"
 
-#: models/core_document_model.py:62 models/core_document_model.py:268
+#: models/core_document_model.py:96 models/core_document_model.py:353
 msgid "locality"
 msgstr "eneo"
 
-#: models/core_document_model.py:63
+#: models/core_document_model.py:97
 msgid "localities"
 msgstr "maeneo"
 
-#: models/core_document_model.py:76
+#: models/core_document_model.py:110
 msgid "FRBR URI"
 msgstr "FRBR URI"
 
-#: models/core_document_model.py:84
-msgid "languages"
-msgstr "lugha"
+#: models/core_document_model.py:114
+#, fuzzy
+#| msgid "FRBR URI actor"
+msgid "FRBR URI country"
+msgstr "Mwigizaji wa FRBR URI "
 
-#: models/core_document_model.py:87
-msgid "ranking"
-msgstr "cheo"
+#: models/core_document_model.py:120
+#, fuzzy
+#| msgid "FRBR URI doctype"
+msgid "FRBR URI locality"
+msgstr "Aina ya hati ya FRBR URI"
 
-#: models/core_document_model.py:90 models/core_document_model.py:230
-msgid "work"
-msgstr "kazi"
+#: models/core_document_model.py:126
+#, fuzzy
+#| msgid "FRBR URI date"
+msgid "FRBR URI place"
+msgstr "Tarehe ya FRBR URI"
 
-#: models/core_document_model.py:91
-msgid "works"
-msgstr "kazi"
-
-#: models/core_document_model.py:233
-msgid "document type"
-msgstr "aina ya hati"
-
-#: models/core_document_model.py:243 models/core_document_model.py:597
-msgid "source URL"
-msgstr "chanzo cha URL"
-
-#: models/core_document_model.py:245
-msgid "citation"
-msgstr "nukuu"
-
-#: models/core_document_model.py:246
-msgid "content HTML"
-msgstr "HTML ya maudhui"
-
-#: models/core_document_model.py:247
-msgid "content HTML is AKN"
-msgstr "HTML ya maudhui ni AKN"
-
-#: models/core_document_model.py:248
-msgid "TOC JSON"
-msgstr "TOC JSON"
-
-#: models/core_document_model.py:254
-msgid "language"
-msgstr "lugha"
-
-#: models/core_document_model.py:275 models/core_document_model.py:643
-msgid "nature"
-msgstr "asili"
-
-#: models/core_document_model.py:279
-msgid "work FRBR URI"
-msgstr "fanya kazi FRBR URI"
-
-#: models/core_document_model.py:284
+#: models/core_document_model.py:132 models/core_document_model.py:369
 msgid "FRBR URI doctype"
 msgstr "Aina ya hati ya FRBR URI"
 
-#: models/core_document_model.py:291
+#: models/core_document_model.py:138 models/core_document_model.py:376
 msgid "FRBR URI subtype"
 msgstr "Aina ndogo ya FRBR URI"
 
-#: models/core_document_model.py:296
-msgid "Document subtype. Lowercase letters, numbers _ and - only."
-msgstr "Aina ndogo ya hati. Herufi ndogo, namba _ na - pekee."
-
-#: models/core_document_model.py:299
+#: models/core_document_model.py:144 models/core_document_model.py:384
 msgid "FRBR URI actor"
 msgstr "Mwigizaji wa FRBR URI "
 
-#: models/core_document_model.py:304
-msgid "Originating actor. Lowercase letters, numbers _ and - only."
-msgstr "Mwigizaji wa asili. Herufi ndogo, namba _ na - pekee."
-
-#: models/core_document_model.py:307
+#: models/core_document_model.py:150 models/core_document_model.py:392
 msgid "FRBR URI date"
 msgstr "Tarehe ya FRBR URI"
 
-#: models/core_document_model.py:312
-msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
-msgstr "YYYY, YYYY-MM, au YYYY-MM-DD"
-
-#: models/core_document_model.py:315
+#: models/core_document_model.py:156 models/core_document_model.py:400
 msgid "FRBR URI number"
 msgstr "Namba ya URI FRBR"
 
-#: models/core_document_model.py:321
+#: models/core_document_model.py:167
+msgid "languages"
+msgstr "lugha"
+
+#: models/core_document_model.py:170
+msgid "ranking"
+msgstr "cheo"
+
+#: models/core_document_model.py:173 models/core_document_model.py:315
+msgid "work"
+msgstr "kazi"
+
+#: models/core_document_model.py:174
+msgid "works"
+msgstr "kazi"
+
+#: models/core_document_model.py:318
+msgid "document type"
+msgstr "aina ya hati"
+
+#: models/core_document_model.py:328 models/core_document_model.py:762
+msgid "source URL"
+msgstr "chanzo cha URL"
+
+#: models/core_document_model.py:330
+msgid "citation"
+msgstr "nukuu"
+
+#: models/core_document_model.py:331
+msgid "content HTML"
+msgstr "HTML ya maudhui"
+
+#: models/core_document_model.py:332
+msgid "content HTML is AKN"
+msgstr "HTML ya maudhui ni AKN"
+
+#: models/core_document_model.py:333
+msgid "TOC JSON"
+msgstr "TOC JSON"
+
+#: models/core_document_model.py:339
+msgid "language"
+msgstr "lugha"
+
+#: models/core_document_model.py:360 models/core_document_model.py:829
+msgid "nature"
+msgstr "asili"
+
+#: models/core_document_model.py:364
+msgid "work FRBR URI"
+msgstr "fanya kazi FRBR URI"
+
+#: models/core_document_model.py:381
+msgid "Document subtype. Lowercase letters, numbers _ and - only."
+msgstr "Aina ndogo ya hati. Herufi ndogo, namba _ na - pekee."
+
+#: models/core_document_model.py:389
+msgid "Originating actor. Lowercase letters, numbers _ and - only."
+msgstr "Mwigizaji wa asili. Herufi ndogo, namba _ na - pekee."
+
+#: models/core_document_model.py:397
+msgid "YYYY, YYYY-MM, or YYYY-MM-DD"
+msgstr "YYYY, YYYY-MM, au YYYY-MM-DD"
+
+#: models/core_document_model.py:406
 msgid "Unique number or short title identifying this work. Lowercase letters, numbers _ and - only."
 msgstr "Namba ya kipekee au jina fupi linalotambulisha kazi hii. Herufi ndogo, namba _ na - pekee."
 
-#: models/core_document_model.py:326
+#: models/core_document_model.py:411
 msgid "expression FRBR URI"
 msgstr "maelezo FRBR URI"
 
-#: models/core_document_model.py:330
+#: models/core_document_model.py:415
 msgid "created at"
 msgstr "imeundwa saa"
 
-#: models/core_document_model.py:331
+#: models/core_document_model.py:416
 msgid "updated at"
 msgstr "imesasishwa saa"
 
-#: models/core_document_model.py:336
+#: models/core_document_model.py:422
 msgid "created by"
 msgstr "imetengenezwa na"
 
-#: models/core_document_model.py:339
+#: models/core_document_model.py:425
 msgid "allow robots"
 msgstr "ruhusu roboti"
 
-#: models/core_document_model.py:342
+#: models/core_document_model.py:428
 msgid "Allow this document to be indexed by search engine robots."
 msgstr "Ruhusu hati hii kuorodheshwa na roboti za mtambo tafutizi."
 
-#: models/core_document_model.py:368
-msgid "Invalid Date"
-msgstr "Tarehe sio sahihi"
-
-#: models/core_document_model.py:371
+#: models/core_document_model.py:469
 msgid "You cannot set a future date for the document"
 msgstr "Huwezi kuweka tarehe ya baadaye kwa ajili ya hati"
 
-#: models/core_document_model.py:377
+#: models/core_document_model.py:477
 #, python-format
 msgid "Invalid FRBR URI: %(uri)s"
 msgstr "URI FRBR sio sahihi: %(uri)s"
 
-#: models/core_document_model.py:540
+#: models/core_document_model.py:488
+msgid "Document with this Expression FRBR URI already exists!"
+msgstr ""
+
+#: models/core_document_model.py:705
 msgid "filename"
 msgstr "jina la faili"
 
-#: models/core_document_model.py:541
+#: models/core_document_model.py:706
 msgid "mimetype"
 msgstr "aina ya maudhui"
 
-#: models/core_document_model.py:542
+#: models/core_document_model.py:707
 msgid "size"
 msgstr "ukubwa"
 
-#: models/core_document_model.py:543 models/core_document_model.py:570
+#: models/core_document_model.py:708 models/core_document_model.py:735
 msgid "file"
 msgstr "faili"
 
-#: models/core_document_model.py:574
+#: models/core_document_model.py:739
 msgid "images"
 msgstr "picha"
 
-#: models/core_document_model.py:601
+#: models/core_document_model.py:766
+msgid "file as pdf"
+msgstr ""
+
+#: models/core_document_model.py:774
 msgid "source file"
 msgstr "faili la chanzo"
 
-#: models/core_document_model.py:602
+#: models/core_document_model.py:775
 msgid "source files"
 msgstr "mafaili ya chanzo"
 
-#: models/core_document_model.py:629
+#: models/core_document_model.py:815
 msgid "attached file nature"
 msgstr "aina ya faili lililoambatishwa"
 
-#: models/core_document_model.py:630
+#: models/core_document_model.py:816
 msgid "attached file natures"
 msgstr "aina ya faili lililoambatishwa"
 
-#: models/core_document_model.py:647
+#: models/core_document_model.py:833
 msgid "attached file"
 msgstr "faili lililoambatishwa"
 
-#: models/core_document_model.py:648
+#: models/core_document_model.py:834
 msgid "attached files"
 msgstr "mafaili yaliyoambatishwa"
 
-#: models/core_document_model.py:664
+#: models/core_document_model.py:858
+msgid "Law report citation/Alternative known name"
+msgstr ""
+
+#: models/core_document_model.py:865
 msgid "alternative name"
 msgstr "jina mbadala"
 
-#: models/core_document_model.py:665
+#: models/core_document_model.py:866
 msgid "alternative names"
 msgstr "majina mbadala"
 
-#: models/core_document_model.py:685
+#: models/core_document_model.py:886
 msgid "document text"
 msgstr "maandishi ya hati"
 
-#: models/core_document_model.py:689
+#: models/core_document_model.py:890
+#, fuzzy
+#| msgid "document"
+msgid "document XML"
+msgstr "hati"
+
+#: models/core_document_model.py:894
 msgid "document content"
 msgstr "maudhui ya hati"
 
-#: models/core_document_model.py:690
+#: models/core_document_model.py:895
 msgid "document contents"
 msgstr "maudhui ya hati"
 
@@ -413,35 +508,35 @@ msgstr "gazeti la serikali"
 msgid "gazettes"
 msgstr "magazeti ya serikali"
 
-#: models/generic_document.py:26
+#: models/generic_document.py:25
 msgid "generic document"
 msgstr "waraka wa jumla"
 
-#: models/generic_document.py:27
+#: models/generic_document.py:26
 msgid "generic documents"
 msgstr "nyaraka za jumla"
 
-#: models/generic_document.py:54
+#: models/generic_document.py:51
 msgid "legal instrument"
 msgstr "hati ya kisheria"
 
-#: models/generic_document.py:55
+#: models/generic_document.py:52
 msgid "legal instruments"
 msgstr "hati za kisheria"
 
-#: models/generic_document.py:77
+#: models/generic_document.py:74
 msgid "metadata JSON"
 msgstr "mkusanyiko wa data za JSON"
 
-#: models/generic_document.py:78 templates/peachjam/document_popup.html:9
+#: models/generic_document.py:75 templates/peachjam/document_popup.html:9
 msgid "repealed"
 msgstr "kufutwa"
 
-#: models/generic_document.py:80
+#: models/generic_document.py:77
 msgid "parent work"
 msgstr "kazi ya mzazi"
 
-#: models/generic_document.py:86 models/generic_document.py:87
+#: models/generic_document.py:83 models/generic_document.py:84
 msgid "legislation"
 msgstr "sheria"
 
@@ -473,135 +568,125 @@ msgstr "ilibadilishwa upya mara ya mwisho saa"
 msgid "enabled"
 msgstr "wezeshwa"
 
-#: models/judgment.py:20
+#: models/judgment.py:21
 msgid "attorney"
 msgstr "wakili"
 
-#: models/judgment.py:21 models/judgment.py:149
+#: models/judgment.py:22 models/judgment.py:182
 msgid "attorneys"
 msgstr "mawakili"
 
-#: models/judgment.py:33
-msgid "judge"
-msgstr "jaji"
-
-#: models/judgment.py:34 models/judgment.py:147
-msgid "judges"
-msgstr "majaji"
-
-#: models/judgment.py:46
+#: models/judgment.py:51
 msgid "order outcome"
 msgstr "matokeo ya agizo"
 
-#: models/judgment.py:47
+#: models/judgment.py:52
 msgid "order outcomes"
 msgstr "kuagiza matokeo"
 
-#: models/judgment.py:61 models/judgment.py:307
+#: models/judgment.py:66 models/judgment.py:358
 msgid "matter type"
 msgstr "aina ya jambo"
 
-#: models/judgment.py:62
+#: models/judgment.py:67
 msgid "matter types"
 msgstr "aina za mambo"
 
-#: models/judgment.py:71 models/judgment.py:98
+#: models/judgment.py:76 models/judgment.py:103
 msgid "order"
 msgstr "agizo"
 
-#: models/judgment.py:78 models/judgment.py:93
+#: models/judgment.py:83 models/judgment.py:98
 msgid "court class"
 msgstr "daraja la mahakama"
 
-#: models/judgment.py:79
+#: models/judgment.py:84
 msgid "court classes"
 msgstr "makundi ya mahakama"
 
-#: models/judgment.py:105 models/judgment.py:118 models/judgment.py:138
+#: models/judgment.py:110 models/judgment.py:123 models/judgment.py:169
 msgid "court"
 msgstr "mahakama"
 
-#: models/judgment.py:106
+#: models/judgment.py:111
 msgid "courts"
 msgstr "mahakama"
 
-#: models/judgment.py:124
+#: models/judgment.py:129
 msgid "court registry"
 msgstr "usajili wa mahakama"
 
-#: models/judgment.py:125
+#: models/judgment.py:130
 msgid "court registries"
 msgstr "masijala za mahakama"
 
-#: models/judgment.py:158
-msgid "headnote holding"
-msgstr "kushikilia muhtasari"
-
-#: models/judgment.py:160
-msgid "additional citations"
-msgstr "nukuu za ziada"
-
-#: models/judgment.py:162
-msgid "flynote"
-msgstr "mada"
-
-#: models/judgment.py:164
-msgid "case name"
-msgstr "jina la kesi"
-
-#: models/judgment.py:166
-msgid "Party names for use in title"
-msgstr "Majina ya Upande mmoja kwa ajili ya matumizi katika cheo"
-
-#: models/judgment.py:172
-msgid "serial number"
-msgstr "mfuatano wa namba"
-
-#: models/judgment.py:174
-msgid "Serial number for MNC, unique for a year and an author."
-msgstr "Mfuatano wa namba kwa MNC, ya kipekee kwa mwaka mmoja na mwandishi."
-
-#: models/judgment.py:177
-msgid "serial number override"
-msgstr "kubadilisha mfuatano wa namba"
-
-#: models/judgment.py:180
-msgid "Specific MNC serial number assigned by the court."
-msgstr "Mfuatano wa namba maalumu ya MNC iliyotolewa na mahakama."
-
-#: models/judgment.py:184
-msgid "MNC"
-msgstr "MNC"
-
-#: models/judgment.py:186
-msgid "Media neutral citation"
-msgstr "Nukuu isiyoegemea upande wowote"
-
-#: models/judgment.py:201
+#: models/judgment.py:156 models/judgment.py:231
 msgid "judgment"
 msgstr "hukumu"
 
+#: models/judgment.py:191
+#, fuzzy
+#| msgid "summary"
+msgid "case summary"
+msgstr "muhtasari"
+
+#: models/judgment.py:192
+msgid "flynote"
+msgstr "mada"
+
+#: models/judgment.py:194
+msgid "case name"
+msgstr "jina la kesi"
+
+#: models/judgment.py:196
+msgid "Party names for use in title"
+msgstr "Majina ya Upande mmoja kwa ajili ya matumizi katika cheo"
+
 #: models/judgment.py:202
+msgid "serial number"
+msgstr "mfuatano wa namba"
+
+#: models/judgment.py:204
+msgid "Serial number for MNC, unique for a year and an author."
+msgstr "Mfuatano wa namba kwa MNC, ya kipekee kwa mwaka mmoja na mwandishi."
+
+#: models/judgment.py:207
+msgid "serial number override"
+msgstr "kubadilisha mfuatano wa namba"
+
+#: models/judgment.py:210
+msgid "Specific MNC serial number assigned by the court."
+msgstr "Mfuatano wa namba maalumu ya MNC iliyotolewa na mahakama."
+
+#: models/judgment.py:214
+msgid "MNC"
+msgstr "MNC"
+
+#: models/judgment.py:216
+msgid "Media neutral citation"
+msgstr "Nukuu isiyoegemea upande wowote"
+
+#: models/judgment.py:232
 msgid "judgments"
 msgstr "hukumu"
 
-#: models/judgment.py:293
-msgid "string override"
-msgstr "kuunganisha nukuu"
+#: models/judgment.py:344
+msgid "Full case number as printed on judgment"
+msgstr ""
 
-#: models/judgment.py:297
+#: models/judgment.py:348
 msgid "Override for full case number string"
 msgstr "Batilisha kwa mfuatano wa nukuu ya kesi kamili"
 
-#: models/judgment.py:299
+#: models/judgment.py:350
 msgid "string"
 msgstr "nukuu nyingi"
 
-#: models/judgment.py:300 templates/peachjam/_timeline_events.html:32
+#: models/judgment.py:351 templates/peachjam/_timeline_events.html:35
 msgid "number"
 msgstr "namba"
 
-#: models/judgment.py:301
+#: models/judgment.py:352
 msgid "year"
 msgstr "mwaka"
 
@@ -670,55 +755,101 @@ msgstr "kutokuwa na lugha ya hati"
 msgid "document languages"
 msgstr "lugha za hati"
 
-#: models/settings.py:40
+#: models/settings.py:41
+#, fuzzy
+#| msgid "document jurisdictions"
+msgid "default document jurisdiction"
+msgstr "mamlaka ya kisheria ya hati"
+
+#: models/settings.py:47
 msgid "document jurisdictions"
 msgstr "mamlaka ya kisheria ya hati"
 
-#: models/settings.py:43
+#: models/settings.py:50
 msgid "subsidiary legislation label"
 msgstr "lebo ya sheria ndogo"
 
-#: models/settings.py:48
+#: models/settings.py:55
 msgid "google analytics id"
 msgstr "utambulisho wa kichanganuzi cha google"
 
-#: models/settings.py:51
+#: models/settings.py:59
+msgid "Enter one or more Google Analytics IDs separated by spaces."
+msgstr ""
+
+#: models/settings.py:62
 msgid "pagerank boost value"
 msgstr "thamani ya kukuza cheo"
 
-#: models/settings.py:55
+#: models/settings.py:65
+msgid "allowed login domains"
+msgstr ""
+
+#: models/settings.py:69
+msgid "metabase dashboard link"
+msgstr ""
+
+#: models/settings.py:73
+msgid "mailchimp form url"
+msgstr ""
+
+#: models/settings.py:76
+#, fuzzy
+#| msgid "citation link"
+msgid "twitter link"
+msgstr "kiungo cha dondoo"
+
+#: models/settings.py:79
+msgid "facebook link"
+msgstr ""
+
+#: models/settings.py:82
+#, fuzzy
+#| msgid "Media neutral citation"
+msgid "re-extract citations"
+msgstr "Nukuu isiyoegemea upande wowote"
+
+#: models/settings.py:85
+msgid "Pocket Law repo"
+msgstr ""
+
+#: models/settings.py:88
+msgid "help link"
+msgstr ""
+
+#: models/settings.py:95
 msgid "site settings"
 msgstr "mipangilio ya tovuti"
 
-#: models/taxonomies.py:15 models/taxonomies.py:16
+#: models/taxonomies.py:19 models/taxonomies.py:20
 msgid "taxonomies"
 msgstr "taksonomia"
 
-#: models/taxonomies.py:35
+#: models/taxonomies.py:49
 msgid "topic"
 msgstr "mada"
 
-#: models/taxonomies.py:40
+#: models/taxonomies.py:54
 msgid "document topic"
 msgstr "mada ya hati"
 
-#: models/taxonomies.py:41
+#: models/taxonomies.py:55
 msgid "document topics"
 msgstr "mada za hati"
 
-#: settings.py:210
+#: settings.py:235
 msgid "English"
 msgstr "Kiingereza"
 
-#: settings.py:211
+#: settings.py:236
 msgid "French"
 msgstr "Kifaransa"
 
-#: settings.py:212
+#: settings.py:237
 msgid "Portuguese"
 msgstr "Kireno"
 
-#: settings.py:213
+#: settings.py:238
 msgid "Swahili"
 msgstr "Kiswahili"
 
@@ -775,10 +906,12 @@ msgstr "Umesahau nenosiri lako?"
 
 #: templates/account/login.html:76
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            Log in with %(provider.name)s\n"
 "          "
-msgstr "\n"
+msgstr ""
+"\n"
 "            Ingia na %(provider.name)s\n"
 "          "
 
@@ -838,6 +971,10 @@ msgstr "Badilisha Nenosiri"
 msgid "Your password has been reset."
 msgstr "Nenosiri lako limewekwa upya."
 
+#: templates/admin/change_form.html:7 templates/admin/change_list.html:10
+msgid "Help"
+msgstr ""
+
 #: templates/admin/login.html:20
 msgid "Please correct the error below."
 msgstr "Tafadhali sahihisha kosa hapo chini."
@@ -855,6 +992,19 @@ msgstr "Umethibitishwa kama %(username)s, lakini hujaidhinishwa kutumia ukurasa 
 msgid "Forgotten your password or username?"
 msgstr "Je, umesahau nenosiri lako au jina la mtumiaji?"
 
+#: templates/admin/tree_change_list.html:7
+#: templates/peachjam/_document_content.html:48
+msgid "Search"
+msgstr "Tafuta"
+
+#: templates/admin/tree_change_list.html:8
+msgid "Collapse all"
+msgstr ""
+
+#: templates/admin/tree_change_list.html:9
+msgid "Expand all"
+msgstr ""
+
 #: templates/peachjam/_child_documents.html:2
 msgid "Subsidiary legislation"
 msgstr "Sheria za nyongeza"
@@ -869,62 +1019,68 @@ msgstr "Mada"
 msgid "Numbered title"
 msgstr "Jina lenye namba"
 
-#: templates/peachjam/_citations.html:6
+#: templates/peachjam/_citations.html:7
 msgid "Cited documents"
 msgstr "Nyaraka zilizonukuliwa"
 
-#: templates/peachjam/_citations.html:18
+#: templates/peachjam/_citations.html:13
 msgid "Documents citing this one"
 msgstr "Nyaraka zinazonukuu hii"
 
-#: templates/peachjam/_court_list.html:14
-#: templates/peachjam/_court_list.html:20
+#: templates/peachjam/_citations_list.html:27
+msgid "Show/Hide all"
+msgstr ""
+
+#: templates/peachjam/_court_list.html:16
+#: templates/peachjam/_court_list.html:22
 msgid "No courts found."
 msgstr "Hakuna mahakama zilizopatikana."
 
-#: templates/peachjam/_document_content.html:24
+#: templates/peachjam/_document_content.html:25
 msgid "Table of contents"
 msgstr "Yaliyomo"
 
-#: templates/peachjam/_document_content.html:36
+#: templates/peachjam/_document_content.html:37
 msgid "Pages"
 msgstr "Kurasa"
 
-#: templates/peachjam/_document_content.html:47
-msgid "Search"
-msgstr "Tafuta"
-
-#: templates/peachjam/_document_content.html:134
+#: templates/peachjam/_document_content.html:136
 msgid "Loading PDF..."
 msgstr "Inapakia PDF..."
 
-#: templates/peachjam/_document_content.html:144
+#: templates/peachjam/_document_content.html:146
 #, python-format
 msgid "This document is %(filesize)s. Do you want to load it?"
 msgstr "Hati hii ni %(filesize)s. Je, ungependa kuipakia?"
 
-#: templates/peachjam/_document_content.html:148
+#: templates/peachjam/_document_content.html:150
 msgid "Load document"
 msgstr "Pakia hati"
 
-#: templates/peachjam/_document_content.html:157
+#: templates/peachjam/_document_content.html:159
 msgid "To the top"
 msgstr "Hadi juu"
 
-#: templates/peachjam/_document_count.html:4
+#: templates/peachjam/_document_count.html:3
 #, python-format
 msgid "%(doc_count)s document"
 msgid_plural "%(doc_count)s documents"
 msgstr[0] "%(doc_count)s hati"
 msgstr[1] "%(doc_count)s hati"
 
-#: templates/peachjam/_document_table.html:10
-#: templates/peachjam/_judgment_table.html:8
-#: templates/peachjam/layouts/document_detail.html:214
+#: templates/peachjam/_document_table.html:8
+#: templates/peachjam/_ratifications.html:17
+msgid "Country"
+msgstr "Nchi"
+
+#: templates/peachjam/_document_table.html:13
+#: templates/peachjam/_judgment_table.html:7
+#: templates/peachjam/layouts/document_detail.html:232
 msgid "Date"
 msgstr "Tarehe"
 
-#: templates/peachjam/_document_table.html:28
+#: templates/peachjam/_document_table.html:33
+#: templates/peachjam/layouts/document_detail.html:268
 msgid "Multiple languages available"
 msgstr "Lugha nyingi zinapatikana"
 
@@ -936,23 +1092,31 @@ msgstr "Anwani ya makazi"
 msgid "Visit website"
 msgstr "Fungua tovuti"
 
-#: templates/peachjam/_header.html:32 templates/peachjam/_header.html:33
+#: templates/peachjam/_header.html:33 templates/peachjam/_header.html:34
 #, python-format
 msgid "Search %(APP_NAME)s"
 msgstr "Tafuta %(APP_NAME)s"
 
-#: templates/peachjam/_header.html:55
+#: templates/peachjam/_header.html:57
 msgid "Admin"
 msgstr "Msimamizi"
 
-#: templates/peachjam/_header.html:56
+#: templates/peachjam/_header.html:58
 msgid "Logout"
 msgstr "Toka"
 
-#: templates/peachjam/_judgment_table.html:7
-#: templates/peachjam/layouts/document_detail.html:196
-msgid "Judges"
-msgstr "Majaji"
+#: templates/peachjam/_mailchimp_form.html:4
+msgid "Subscribe"
+msgstr ""
+
+#: templates/peachjam/_mailchimp_form.html:11
+msgid "Subscribe to our newsletter for updates and news."
+msgstr ""
+
+#: templates/peachjam/_months_list.html:7
+#: templates/peachjam/_months_list.html:24
+msgid "All months"
+msgstr ""
 
 #: templates/peachjam/_pagination.html:6
 msgid "Previous"
@@ -970,43 +1134,49 @@ msgstr "Chanzo"
 msgid "Last updated"
 msgstr "Ilisasishwa mara ya mwisho"
 
-#: templates/peachjam/_ratifications.html:17
-msgid "Country"
-msgstr "Nchi"
-
 #: templates/peachjam/_ratifications.html:18
-msgid "Ratification Date"
-msgstr "Tarehe ya Kuridhiwa"
-
-#: templates/peachjam/_ratifications.html:19
-msgid "Deposit Date"
-msgstr "Tarehe ya Kuweka"
-
-#: templates/peachjam/_ratifications.html:20
 msgid "Signature Date"
 msgstr "Tarehe ya Saini"
 
+#: templates/peachjam/_ratifications.html:19
+msgid "Ratification Date"
+msgstr "Tarehe ya Kuridhiwa"
+
+#: templates/peachjam/_ratifications.html:20
+msgid "Deposit Date"
+msgstr "Tarehe ya Kuweka"
+
 #: templates/peachjam/_recent_document_list.html:14
-#: templates/peachjam/court_detail.html:35
-#: templates/peachjam/layouts/document_list.html:59
+#: templates/peachjam/court_detail.html:42
+#: templates/peachjam/layouts/document_list.html:60
 msgid "No documents found."
 msgstr "Hakuna nyaraka zilizopatikana."
 
-#: templates/peachjam/_related_documents.html:2
-#: templates/peachjam/layouts/document_detail.html:84
-#: templates/peachjam/layouts/document_detail.html:328
+#: templates/peachjam/_registries.html:3
+#, fuzzy
+#| msgid "court registries"
+msgid "Registries"
+msgstr "masijala za mahakama"
+
+#: templates/peachjam/_related_documents.html:4
+#: templates/peachjam/layouts/document_detail.html:93
+#: templates/peachjam/layouts/document_detail.html:357
 msgid "Related documents"
 msgstr "Nyaraka zinazohusiana"
 
-#: templates/peachjam/_taxonomies.html:2
-#: templates/peachjam/first_level_taxonomy_detail.html:9
-#: templates/peachjam/taxonomy_detail.html:13
-#: templates/peachjam/top_level_taxonomy_list.html:8
+#: templates/peachjam/_social_media.html:2
+msgid "Follow us on social media"
+msgstr ""
+
+#: templates/peachjam/_taxonomies.html:4
+#: templates/peachjam/taxonomy_detail.html:10
+#: templates/peachjam/taxonomy_first_level_detail.html:10
+#: templates/peachjam/taxonomy_list.html:8
 msgid "Taxonomies"
 msgstr "Taksonomia"
 
 #: templates/peachjam/_taxonomy_list.html:23
-#: templates/peachjam/first_level_taxonomy_detail.html:25
+#: templates/peachjam/taxonomy_first_level_detail.html:28
 msgid "No taxonomies found"
 msgstr "Hakuna taksonomia zilizopatikana"
 
@@ -1250,43 +1420,43 @@ msgstr "Ikiwa una maoni au mapendekezo yoyote kuhusu sera hii, tafadhali wasilia
 msgid "Date of notice: 14 November 2022"
 msgstr "Tarehe ya taarifa: 14 Novemba 2022"
 
-#: templates/peachjam/_timeline_events.html:2
+#: templates/peachjam/_timeline_events.html:4
 msgid "History of this document"
 msgstr "Historia ya hati hii"
 
-#: templates/peachjam/_timeline_events.html:11
+#: templates/peachjam/_timeline_events.html:14
 msgid "this version"
 msgstr "toleo hili"
 
-#: templates/peachjam/_timeline_events.html:15
+#: templates/peachjam/_timeline_events.html:18
 msgid "amendment not yet applied"
 msgstr "marekebisho bado hayajatumika"
 
-#: templates/peachjam/_timeline_events.html:24
+#: templates/peachjam/_timeline_events.html:27
 msgid "Amended by"
 msgstr "Imerekebishwa na"
 
-#: templates/peachjam/_timeline_events.html:27
+#: templates/peachjam/_timeline_events.html:30
 msgid "Assented to"
 msgstr "Imeidhinishwa"
 
-#: templates/peachjam/_timeline_events.html:29
+#: templates/peachjam/_timeline_events.html:32
 msgid "Commences"
 msgstr "Kuanza"
 
-#: templates/peachjam/_timeline_events.html:31
+#: templates/peachjam/_timeline_events.html:34
 msgid "Published in"
 msgstr "Imechapishwa katika"
 
-#: templates/peachjam/_timeline_events.html:34
+#: templates/peachjam/_timeline_events.html:37
 msgid "Repealed by"
 msgstr "Imefutwa na"
 
-#: templates/peachjam/_timeline_events.html:42
+#: templates/peachjam/_timeline_events.html:45
 msgid "Read this version"
 msgstr "Soma toleo hili"
 
-#: templates/peachjam/_years_list.html:9 templates/peachjam/_years_list.html:25
+#: templates/peachjam/_years_list.html:7 templates/peachjam/_years_list.html:24
 msgid "All years"
 msgstr "Miaka yote"
 
@@ -1296,20 +1466,30 @@ msgstr "Kuhusu"
 
 #: templates/peachjam/article_detail.html:9
 #: templates/peachjam/article_list.html:4
+#: templates/peachjam/article_list.html:12
+#: templates/peachjam/article_list.html:17
 #: templates/peachjam/user_profile.html:21
 msgid "Articles"
 msgstr "Makala"
 
-#: templates/peachjam/article_detail.html:56
+#: templates/peachjam/article_detail.html:44
+#: templates/peachjam/layouts/document_detail.html:313
+#: templates/peachjam/layouts/document_detail.html:318
+#: templates/peachjam/layouts/document_detail.html:324
+#: templates/peachjam/layouts/document_detail.html:337
+msgid "Download"
+msgstr "Pakua"
+
+#: templates/peachjam/article_detail.html:64
 msgid "About the author"
 msgstr "Kuhusu mwandishi"
 
-#: templates/peachjam/article_detail.html:61
+#: templates/peachjam/article_detail.html:69
 #, python-format
 msgid "Recent articles by %(username)s"
 msgstr "Nakala za hivi karibuni na %(username)s"
 
-#: templates/peachjam/article_list.html:9
+#: templates/peachjam/article_list.html:23
 msgid "Latest Articles"
 msgstr "Makala za Hivi Karibuni"
 
@@ -1323,6 +1503,7 @@ msgid "Books"
 msgstr "Vitabu"
 
 #: templates/peachjam/court_detail.html:9
+#: templates/peachjam/court_registry_detail.html:9
 #: templates/peachjam/judgment_list.html:4
 #: templates/peachjam/judgment_list.html:9
 msgid "Judgments"
@@ -1338,8 +1519,8 @@ msgstr "Hukumu"
 msgid "Gazettes"
 msgstr "Magazeti ya serikali"
 
-#: templates/peachjam/gazette_list.html:34
-#: templates/peachjam/gazette_list.html:59
+#: templates/peachjam/gazette_list.html:35
+#: templates/peachjam/gazette_list.html:60
 #, python-format
 msgid "%(num_gazettes)s gazette"
 msgid_plural "%(num_gazettes)s gazettes"
@@ -1365,17 +1546,17 @@ msgid "Media Neutral Citation"
 msgstr "Nukuu ya Vyombo vya Habari Isiyo na Upande wowote"
 
 #: templates/peachjam/judgment_detail.html:13
-#: templates/peachjam/layouts/document_detail.html:155
+#: templates/peachjam/layouts/document_detail.html:165
 msgid "Copy to clipboard"
 msgstr "Nakili kwenye ubao"
 
 #: templates/peachjam/judgment_detail.html:16
-#: templates/peachjam/layouts/document_detail.html:158
+#: templates/peachjam/layouts/document_detail.html:168
 msgid "Copied!"
 msgstr "Imenakiliwa!"
 
 #: templates/peachjam/judgment_detail.html:17
-#: templates/peachjam/layouts/document_detail.html:159
+#: templates/peachjam/layouts/document_detail.html:169
 msgid "Copy"
 msgstr "Nakili"
 
@@ -1384,86 +1565,101 @@ msgid "Hearing date"
 msgstr "Tarehe ya kusikilizwa"
 
 #: templates/peachjam/judgment_detail.html:31
+msgid "Court"
+msgstr "Mahakama"
+
+#: templates/peachjam/judgment_detail.html:39
 msgid "Court Registry"
 msgstr "Usajili wa Mahakama"
 
-#: templates/peachjam/judgment_detail.html:39
+#: templates/peachjam/judgment_detail.html:47
 msgid "Order"
 msgstr "Agizo"
 
-#: templates/peachjam/judgment_detail.html:48
+#: templates/peachjam/judgment_detail.html:56
 msgid "Case number"
 msgstr "Namba ya kesi"
 
-#: templates/peachjam/judgment_detail.html:61
+#: templates/peachjam/judgment_detail.html:69
 msgid "Attorneys"
 msgstr "Wanasheria"
+
+#: templates/peachjam/judgment_detail.html:83
+#, fuzzy
+#| msgid "flynote"
+msgid "Flynote"
+msgstr "mada"
+
+#: templates/peachjam/judgment_detail.html:93
+#, fuzzy
+#| msgid "summary"
+msgid "Case summary"
+msgstr "muhtasari"
 
 #: templates/peachjam/judgment_list.html:15
 msgid "Recent judgments"
 msgstr "Hukumu za hivi karibuni"
 
-#: templates/peachjam/layouts/document_detail.html:59
+#: templates/peachjam/layouts/document_detail.html:66
 msgid "Document detail"
 msgstr "Maelezo ya hati"
 
-#: templates/peachjam/layouts/document_detail.html:71
+#: templates/peachjam/layouts/document_detail.html:79
 msgid "History"
 msgstr "Historia"
 
-#: templates/peachjam/layouts/document_detail.html:98
+#: templates/peachjam/layouts/document_detail.html:108
 msgid "Citations"
 msgstr "Nukuu"
 
-#: templates/peachjam/layouts/document_detail.html:112
+#: templates/peachjam/layouts/document_detail.html:122
 msgid "Ratifications"
 msgstr "Uridhiaji"
 
-#: templates/peachjam/layouts/document_detail.html:136
+#: templates/peachjam/layouts/document_detail.html:146
 msgid "Jurisdiction"
 msgstr "Mamlaka ya kisheria"
 
-#: templates/peachjam/layouts/document_detail.html:149
+#: templates/peachjam/layouts/document_detail.html:159
 msgid "Citation"
 msgstr "Nukuu"
 
-#: templates/peachjam/layouts/document_detail.html:168
+#: templates/peachjam/layouts/document_detail.html:179
+#, fuzzy
+#| msgid "Media neutral citation"
+msgid "Law report citations"
+msgstr "Nukuu isiyoegemea upande wowote"
+
+#: templates/peachjam/layouts/document_detail.html:183
 msgid "Alternative names"
 msgstr "Majina mbadala"
 
-#: templates/peachjam/layouts/document_detail.html:187
-msgid "Court"
-msgstr "Mahakama"
+#: templates/peachjam/layouts/document_detail.html:213
+msgid "Judges"
+msgstr "Majaji"
 
-#: templates/peachjam/layouts/document_detail.html:210
+#: templates/peachjam/layouts/document_detail.html:228
 msgid "Judgment date"
 msgstr "Tarehe ya hukumu"
 
-#: templates/peachjam/layouts/document_detail.html:246
+#: templates/peachjam/layouts/document_detail.html:264
 msgid "Language"
 msgstr "Lugha"
 
-#: templates/peachjam/layouts/document_detail.html:277
+#: templates/peachjam/layouts/document_detail.html:304
 msgid "Type"
 msgstr "Aina"
 
-#: templates/peachjam/layouts/document_detail.html:286
-#: templates/peachjam/layouts/document_detail.html:291
-#: templates/peachjam/layouts/document_detail.html:297
-#: templates/peachjam/layouts/document_detail.html:310
-msgid "Download"
-msgstr "Pakua"
-
-#: templates/peachjam/layouts/document_detail.html:332
+#: templates/peachjam/layouts/document_detail.html:362
 #, python-format
 msgid "%(n_relationships)s related documents"
 msgstr "%(n_relationships)s nyaraka zinazohusiana"
 
-#: templates/peachjam/layouts/document_list.html:30
+#: templates/peachjam/layouts/document_list.html:27
 msgid "Documents"
 msgstr "Nyaraka"
 
-#: templates/peachjam/layouts/document_list.html:42
+#: templates/peachjam/layouts/document_list.html:43
 msgid "Filters"
 msgstr "Vichujio"
 
@@ -1481,6 +1677,18 @@ msgstr "Kazi ya msingi"
 msgid "Legislation"
 msgstr "Sheria"
 
+#: templates/peachjam/metabase_stats.html:4
+msgid "Site Statistics"
+msgstr ""
+
+#: templates/peachjam/metabase_stats.html:9
+msgid "Statistics"
+msgstr ""
+
+#: templates/peachjam/taxonomy_list.html:4
+msgid "Taxonomy"
+msgstr "Taksonomia"
+
 #: templates/peachjam/terms_of_use.html:4
 #: templates/peachjam/terms_of_use.html:29
 msgid "Terms of Use"
@@ -1492,30 +1700,56 @@ msgstr "Masharti ya matumizi"
 msgid "Navigation"
 msgstr "Urambazaji"
 
-#: templates/peachjam/top_level_taxonomy_list.html:4
-msgid "Taxonomy"
-msgstr "Taksonomia"
-
-#: views/legislation.py:280
-msgid "This is the version of this Act as it was when it was repealed."
-msgstr "Hili ni toleo la Sheria hii kama ilivyokuwa wakati inafutwa."
-
-#: views/legislation.py:281
-msgid "This is the latest version of this Act."
-msgstr "Hili ni toleo la hivi karibuni la Sheria hii."
-
-#: views/legislation.py:283
-#, python-format
-msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+#: views/legislation.py:51
+#, fuzzy, python-format
+#| msgid "This Act was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
+msgid "This %(friendly_type)s was repealed on %(date)s by <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 msgstr "Sheria hii ilifutwa tarehe %(date)s na <a href=\"%(repealing_uri)s\">%(repealing_title)s</a>."
 
-#: views/legislation.py:286
+#: views/legislation.py:59
 #, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This %(friendly_type)s has not yet commenced and is not yet law."
+msgstr ""
+
+#: views/legislation.py:90
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was when it was repealed."
+msgid "This is the version of this %(friendly_type)s as it was when it was repealed."
+msgstr "Hili ni toleo la Sheria hii kama ilivyokuwa wakati inafutwa."
+
+#: views/legislation.py:103
+#, fuzzy, python-format
+#| msgid "This is the latest version of this Act."
+msgid "This is the latest version of this %(friendly_type)s."
+msgstr "Hili ni toleo la hivi karibuni la Sheria hii."
+
+#: views/legislation.py:117
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version as it was when it was repealed</a>."
 msgstr "Hili ni toleo la Sheria hii kama ilivyokuwa kutoka %(date_from)s hadi %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Soma toleo kama lilivyokuwa wakati lilipofutwa</a>."
 
-#: views/legislation.py:290
-#, python-format
-msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+#: views/legislation.py:122
+#, fuzzy, python-format
+#| msgid "This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
+msgid "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s.  <a href=\"%(expression_frbr_uri)s\">Read the version currently in force</a>."
 msgstr "Hili ni toleo la Sheria hii kama ilivyokuwa kutoka %(date_from)s hadi %(date_to)s. <a href=\"%(expression_frbr_uri)s\">Soma toleo linalotumika sasa</a>."
 
+#: views/legislation.py:162
+msgid "There are outstanding amendments that have not yet been applied. See the History tab for more information."
+msgstr ""
+
+#~ msgid "Refresh all content"
+#~ msgstr "Onyesha upya maudhui yote"
+
+#~ msgid "Invalid Date"
+#~ msgstr "Tarehe sio sahihi"
+
+#~ msgid "headnote holding"
+#~ msgstr "kushikilia muhtasari"
+
+#~ msgid "additional citations"
+#~ msgstr "nukuu za ziada"
+
+#~ msgid "string override"
+#~ msgstr "kuunganisha nukuu"

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -42,20 +42,31 @@ class LegislationDetailView(BaseDocumentDetailView):
         commenced = self.get_commencement_info()
 
         if self.object.repealed and repeal:
-            msg = (
-                f'This {friendly_type} was repealed on %(date)s by <a href="%(repealing_uri)s">'
-                "%(repealing_title)s</a>."
-            )
+            args = {"friendly_type": friendly_type}
+            args.update(repeal)
             notices.append(
                 {
                     "type": messages.ERROR,
-                    "html": mark_safe(_(msg) % repeal),
+                    "html": mark_safe(
+                        _(
+                            'This %(friendly_type)s was repealed on %(date)s by <a href="%(repealing_uri)s">'
+                            "%(repealing_title)s</a>."
+                        )
+                        % args
+                    ),
                 }
             )
 
         if not commenced:
-            msg = f"This {friendly_type} has not yet commenced and is not yet law."
-            notices.append({"type": messages.WARNING, "html": _(msg)})
+            notices.append(
+                {
+                    "type": messages.WARNING,
+                    "html": _(
+                        "This %(friendly_type)s has not yet commenced and is not yet law."
+                    )
+                    % {"friendly_type": friendly_type},
+                }
+            )
 
         points_in_time = self.get_points_in_time()
         work_amendments = self.get_work_amendments()
@@ -81,11 +92,13 @@ class LegislationDetailView(BaseDocumentDetailView):
 
             if index == len(point_in_time_dates) - 1:
                 if self.object.repealed and repeal:
-                    msg = f"This is the version of this {friendly_type} as it was when it was repealed."
                     notices.append(
                         {
                             "type": messages.INFO,
-                            "html": _(msg),
+                            "html": _(
+                                "This is the version of this %(friendly_type)s as it was when it was repealed."
+                            )
+                            % {"friendly_type": friendly_type},
                         }
                     )
 
@@ -93,11 +106,13 @@ class LegislationDetailView(BaseDocumentDetailView):
                     self.set_unapplied_amendment_notice(notices, friendly_type)
 
                 else:
-                    msg = f"This is the latest version of this {friendly_type}."
                     notices.append(
                         {
                             "type": messages.INFO,
-                            "html": _(msg),
+                            "html": _(
+                                "This is the latest version of this %(friendly_type)s."
+                            )
+                            % {"friendly_type": friendly_type},
                         }
                     )
             else:
@@ -108,21 +123,27 @@ class LegislationDetailView(BaseDocumentDetailView):
                     "expression_frbr_uri"
                 ]
 
-                msg = f"This is the version of this {friendly_type} as it was from %(date_from)s to %(date_to)s."
                 if self.object.repealed and repeal:
-                    msg += ' <a href="%(expression_frbr_uri)s">Read the version as it was when it was repealed</a>.'
+                    msg = _(
+                        "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s. "
+                        ' <a href="%(expression_frbr_uri)s">Read the version as it was when it was repealed</a>.'
+                    )
                 else:
-                    msg += ' <a href="%(expression_frbr_uri)s">Read the version currently in force</a>.'
+                    msg = _(
+                        "This is the version of this %(friendly_type)s as it was from %(date_from)s to %(date_to)s. "
+                        ' <a href="%(expression_frbr_uri)s">Read the version currently in force</a>.'
+                    )
 
                 notices.append(
                     {
                         "type": messages.WARNING,
                         "html": mark_safe(
-                            _(msg)
+                            msg
                             % {
                                 "date_from": format_date(self.object.date, "j F Y"),
                                 "date_to": format_date(date, "j F Y"),
                                 "expression_frbr_uri": expression_frbr_uri,
+                                "friendly_type": friendly_type,
                             }
                         ),
                     }
@@ -146,15 +167,13 @@ class LegislationDetailView(BaseDocumentDetailView):
         return self.object.metadata_json.get("commenced", None)
 
     def set_unapplied_amendment_notice(self, notices, friendly_type):
-        unapplied_amendment_msg = (
-            f"This is the latest available version of this {friendly_type}. "
-            f"There are outstanding amendments that have not yet been applied. "
-            f"See the History tab for more information."
-        )
         notices.append(
             {
                 "type": messages.WARNING,
-                "html": _(unapplied_amendment_msg),
+                "html": _(
+                    "There are outstanding amendments that have not yet been applied. "
+                    "See the History tab for more information."
+                ),
             }
         )
 
@@ -274,19 +293,3 @@ class LegislationDetailView(BaseDocumentDetailView):
         # TODO: we're not guaranteed to get documents in the same language, here
         docs = sorted(docs, key=lambda d: d.title)
         return docs
-
-
-# Translation strings that include the friendly document type to ensure we have translations for the full string.
-_("This is the version of this Act as it was when it was repealed.")
-_("This is the latest version of this Act.")
-_(
-    'This Act was repealed on %(date)s by <a href="%(repealing_uri)s">%(repealing_title)s</a>.'
-)
-_(
-    'This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href="%(expression_frbr_uri)s">'
-    "Read the version as it was when it was repealed</a>."
-)
-_(
-    'This is the version of this Act as it was from %(date_from)s to %(date_to)s. <a href="%(expression_frbr_uri)s">'
-    "Read the version currently in force</a>."
-)

--- a/scripts/extract-translations.sh
+++ b/scripts/extract-translations.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Extracting translatable strings from django"
-for d in peachjam africanlii liiweb senlii tanzlii zanzibarlii; do
+for d in peachjam africanlii liiweb tanzlii zanzibarlii; do
   pushd $d
   django-admin makemessages -a --no-wrap
   popd

--- a/tanzlii/locale/en/LC_MESSAGES/django.po
+++ b/tanzlii/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,32 +26,28 @@ msgstr ""
 msgid "Swahili"
 msgstr ""
 
-#: templates/liiweb/home.html:19
-msgid "Karibu kwenye Tanzania Legal Information Institute"
+#: templates/liiweb/home.html:10
+msgid "Karibu Katika Mfumo wa Taarifa za Maamuzi, Sheria na Kanuni za Tanzania"
 msgstr ""
 
-#: templates/liiweb/home.html:21
-msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+#: templates/liiweb/home.html:12
+msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, sheria na kanuni bure mtandaoni. TanzLII inaruhusu ufikiaji bure wa maamuzi, sheria na kanuni za Tanzania na ni mwanachama wa Jumuiya ya Afrika ya LIIs."
 msgstr ""
 
-#: templates/liiweb/home.html:29 templates/peachjam/_header.html:26
+#: templates/liiweb/home.html:21 templates/peachjam/_header.html:44
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr ""
 
-#: templates/liiweb/home.html:32 templates/peachjam/about.html:11
+#: templates/liiweb/home.html:24 templates/peachjam/about.html:11
 msgid "TanzLII is a project of the Tanzanian Judiciary. We aim to support the rule of law by publishing the law of Tanzania for free online access."
 msgstr ""
 
-#: templates/peachjam/_footer.html:31
+#: templates/peachjam/_footer.html:5
 msgid "TanzLII is based at the Judiciary of Tanzania and publishes the law of Tanzania for free online access for all. Free Access to the law supports the rule of law and access to justice. TanzLII partners with African Legal Information Institute (AfricanLII) and <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, who provide it with technical support."
 msgstr ""
 
-#: templates/peachjam/_footer.html:38
-msgid "Terms of Use"
-msgstr ""
-
-#: templates/peachjam/_footer.html:42
+#: templates/peachjam/_footer.html:13
 msgid "Our partners"
 msgstr ""
 
@@ -64,7 +60,19 @@ msgid "Legislation"
 msgstr ""
 
 #: templates/peachjam/_header.html:20
+msgid "Law Reform"
+msgstr ""
+
+#: templates/peachjam/_header.html:26
 msgid "Gazettes"
+msgstr ""
+
+#: templates/peachjam/_header.html:32
+msgid "Speeches"
+msgstr ""
+
+#: templates/peachjam/_header.html:38
+msgid "JOT Documents and Guidelines"
 msgstr ""
 
 #: templates/peachjam/about.html:9

--- a/tanzlii/locale/fr/LC_MESSAGES/django.po
+++ b/tanzlii/locale/fr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
@@ -25,32 +25,30 @@ msgstr "Anglais"
 msgid "Swahili"
 msgstr "Swahili"
 
-#: templates/liiweb/home.html:19
-msgid "Karibu kwenye Tanzania Legal Information Institute"
-msgstr "Karibu kwenye Institut d'information juridique de Tanzanie"
+#: templates/liiweb/home.html:10
+msgid "Karibu Katika Mfumo wa Taarifa za Maamuzi, Sheria na Kanuni za Tanzania"
+msgstr ""
 
-#: templates/liiweb/home.html:21
-msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+#: templates/liiweb/home.html:12
+#, fuzzy
+#| msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, sheria na kanuni bure mtandaoni. TanzLII inaruhusu ufikiaji bure wa maamuzi, sheria na kanuni za Tanzania na ni mwanachama wa Jumuiya ya Afrika ya LIIs."
 msgstr "TanzLII ni tovuti ya Mahakama ya Tanzanie inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII offre un accès gratuit au droit tanzanien et est membre de la communauté africaine LII."
 
-#: templates/liiweb/home.html:29 templates/peachjam/_header.html:26
+#: templates/liiweb/home.html:21 templates/peachjam/_header.html:44
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr "À propos"
 
-#: templates/liiweb/home.html:32 templates/peachjam/about.html:11
+#: templates/liiweb/home.html:24 templates/peachjam/about.html:11
 msgid "TanzLII is a project of the Tanzanian Judiciary. We aim to support the rule of law by publishing the law of Tanzania for free online access."
 msgstr "TanzLII est un projet du pouvoir judiciaire tanzanien. Notre objectif est de soutenir l'état de droit en publiant la loi de la Tanzanie pour un accès en ligne gratuit."
 
-#: templates/peachjam/_footer.html:31
+#: templates/peachjam/_footer.html:5
 msgid "TanzLII is based at the Judiciary of Tanzania and publishes the law of Tanzania for free online access for all. Free Access to the law supports the rule of law and access to justice. TanzLII partners with African Legal Information Institute (AfricanLII) and <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, who provide it with technical support."
 msgstr "TanzLII est basé au pouvoir judiciaire de la Tanzanie et publie la loi de la Tanzanie pour un accès en ligne gratuit pour tous. Le libre accès à la loi soutient l'état de droit et l'accès à la justice. TanzLII est partenaire de l'Institut Africain d'Information Juridique (AfricanLII) et <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, qui lui apportent un soutien technique."
 
-#: templates/peachjam/_footer.html:38
-msgid "Terms of Use"
-msgstr "Termes et conditions d'utilisation"
-
-#: templates/peachjam/_footer.html:42
+#: templates/peachjam/_footer.html:13
 msgid "Our partners"
 msgstr "Nos partenaires"
 
@@ -63,8 +61,20 @@ msgid "Legislation"
 msgstr "Législation"
 
 #: templates/peachjam/_header.html:20
+msgid "Law Reform"
+msgstr ""
+
+#: templates/peachjam/_header.html:26
 msgid "Gazettes"
 msgstr "Journaux officiels"
+
+#: templates/peachjam/_header.html:32
+msgid "Speeches"
+msgstr ""
+
+#: templates/peachjam/_header.html:38
+msgid "JOT Documents and Guidelines"
+msgstr ""
 
 #: templates/peachjam/about.html:9
 msgid "About TanzLII"
@@ -86,3 +96,8 @@ msgstr "Contactez-nous"
 msgid "<div> <a href=\"mailto:info@tanzlii.org\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-envelope mr-2\"></i></span>info@tanzlii.org</a> </div> <div> <a href=\"https://facebook.com/africanlii/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-facebook mr-2\"></i></span>facebook.com/africanlii</a> </div> <div> <a href=\"https://twitter.com/AfricanLII/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-twitter mr-2\"></i></span>twitter.com/AfricanLII</a> </div>"
 msgstr "<div> <a href=\"mailto:info@tanzlii.org\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-envelope mr-2\"></i></span>info@tanzlii.org</a> </div> <div> <a href=\"https://facebook.com/africanlii/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-facebook mr-2\"></i></span>facebook.com/africanlii</a> </div> <div> <a href=\"https://twitter.com/AfricanLII/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-twitter mr-2\"></i></span>twitter.com/AfricanLII</a> </div>"
 
+#~ msgid "Karibu kwenye Tanzania Legal Information Institute"
+#~ msgstr "Karibu kwenye Institut d'information juridique de Tanzanie"
+
+#~ msgid "Terms of Use"
+#~ msgstr "Termes et conditions d'utilisation"

--- a/tanzlii/locale/pt/LC_MESSAGES/django.po
+++ b/tanzlii/locale/pt/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese\n"
@@ -25,32 +25,30 @@ msgstr "Inglês"
 msgid "Swahili"
 msgstr "Suaíli"
 
-#: templates/liiweb/home.html:19
-msgid "Karibu kwenye Tanzania Legal Information Institute"
-msgstr "Karibu kwenye Instituto de Informações Jurídicas da Tanzânia"
+#: templates/liiweb/home.html:10
+msgid "Karibu Katika Mfumo wa Taarifa za Maamuzi, Sheria na Kanuni za Tanzania"
+msgstr ""
 
-#: templates/liiweb/home.html:21
-msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+#: templates/liiweb/home.html:12
+#, fuzzy
+#| msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, sheria na kanuni bure mtandaoni. TanzLII inaruhusu ufikiaji bure wa maamuzi, sheria na kanuni za Tanzania na ni mwanachama wa Jumuiya ya Afrika ya LIIs."
 msgstr "TanzLII ni tovuti ya Mahakama ya Tanzânia inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII fornece acesso gratuito à lei da Tanzânia e é membro da comunidade African LII."
 
-#: templates/liiweb/home.html:29 templates/peachjam/_header.html:26
+#: templates/liiweb/home.html:21 templates/peachjam/_header.html:44
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr "Sobre"
 
-#: templates/liiweb/home.html:32 templates/peachjam/about.html:11
+#: templates/liiweb/home.html:24 templates/peachjam/about.html:11
 msgid "TanzLII is a project of the Tanzanian Judiciary. We aim to support the rule of law by publishing the law of Tanzania for free online access."
 msgstr "TanzLII é um projeto do Judiciário da Tanzânia. Nosso objetivo é apoiar o estado de direito publicando a lei da Tanzânia para acesso online gratuito."
 
-#: templates/peachjam/_footer.html:31
+#: templates/peachjam/_footer.html:5
 msgid "TanzLII is based at the Judiciary of Tanzania and publishes the law of Tanzania for free online access for all. Free Access to the law supports the rule of law and access to justice. TanzLII partners with African Legal Information Institute (AfricanLII) and <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, who provide it with technical support."
 msgstr "TanzLII é baseado no Judiciário da Tanzânia e publica a lei da Tanzânia para acesso online gratuito para todos. O livre acesso à lei apoia o estado de direito e o acesso à justiça. O TanzLII tem parceria com o African Legal Information Institute (AfricanLII) e <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, que fornecem suporte técnico."
 
-#: templates/peachjam/_footer.html:38
-msgid "Terms of Use"
-msgstr "Termos de Utilização"
-
-#: templates/peachjam/_footer.html:42
+#: templates/peachjam/_footer.html:13
 msgid "Our partners"
 msgstr "Nossos parceiros"
 
@@ -63,8 +61,20 @@ msgid "Legislation"
 msgstr "Legislação"
 
 #: templates/peachjam/_header.html:20
+msgid "Law Reform"
+msgstr ""
+
+#: templates/peachjam/_header.html:26
 msgid "Gazettes"
 msgstr "Gazettes"
+
+#: templates/peachjam/_header.html:32
+msgid "Speeches"
+msgstr ""
+
+#: templates/peachjam/_header.html:38
+msgid "JOT Documents and Guidelines"
+msgstr ""
 
 #: templates/peachjam/about.html:9
 msgid "About TanzLII"
@@ -86,3 +96,8 @@ msgstr "Contate-nos"
 msgid "<div> <a href=\"mailto:info@tanzlii.org\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-envelope mr-2\"></i></span>info@tanzlii.org</a> </div> <div> <a href=\"https://facebook.com/africanlii/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-facebook mr-2\"></i></span>facebook.com/africanlii</a> </div> <div> <a href=\"https://twitter.com/AfricanLII/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-twitter mr-2\"></i></span>twitter.com/AfricanLII</a> </div>"
 msgstr "<div> <a href=\"mailto:info@tanzlii.org\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-envelope mr-2\"></i></span>info@tanzlii.org</a> </div> <div> <a href=\"https://facebook.com/africanlii/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-facebook mr-2\"></i></span>facebook.com/africanlii</a> </div> <div> <a href=\"https://twitter.com/AfricanLII/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-twitter mr-2\"></i></span>twitter.com/AfricanLII</a> </div>"
 
+#~ msgid "Karibu kwenye Tanzania Legal Information Institute"
+#~ msgstr "Karibu kwenye Instituto de Informações Jurídicas da Tanzânia"
+
+#~ msgid "Terms of Use"
+#~ msgstr "Termos de Utilização"

--- a/tanzlii/locale/sw/LC_MESSAGES/django.po
+++ b/tanzlii/locale/sw/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Swahili\n"
@@ -25,32 +25,30 @@ msgstr "Kiingereza"
 msgid "Swahili"
 msgstr "Kiswahili"
 
-#: templates/liiweb/home.html:19
-msgid "Karibu kwenye Tanzania Legal Information Institute"
-msgstr "Karibu kwenye Taasisi ya Taarifa za Sheria Tanzania"
+#: templates/liiweb/home.html:10
+msgid "Karibu Katika Mfumo wa Taarifa za Maamuzi, Sheria na Kanuni za Tanzania"
+msgstr ""
 
-#: templates/liiweb/home.html:21
-msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+#: templates/liiweb/home.html:12
+#, fuzzy
+#| msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. TanzLII provides free access to the law of Tanzania and is a member of the African LII community."
+msgid "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, sheria na kanuni bure mtandaoni. TanzLII inaruhusu ufikiaji bure wa maamuzi, sheria na kanuni za Tanzania na ni mwanachama wa Jumuiya ya Afrika ya LIIs."
 msgstr "TanzLII ni tovuti ya Mahakama ya Tanzania inayochapisha maamuzi, Sheria na Kanuni kwa bure Mtandaoni. TanzLII inatoa ufikiaji wa bure kwa sheria ya Tanzania na ni mwanachama wa Jumuiya ya Kiafrika ya LII."
 
-#: templates/liiweb/home.html:29 templates/peachjam/_header.html:26
+#: templates/liiweb/home.html:21 templates/peachjam/_header.html:44
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr "Kuhusu"
 
-#: templates/liiweb/home.html:32 templates/peachjam/about.html:11
+#: templates/liiweb/home.html:24 templates/peachjam/about.html:11
 msgid "TanzLII is a project of the Tanzanian Judiciary. We aim to support the rule of law by publishing the law of Tanzania for free online access."
 msgstr "TanzLII ni mradi wa Mahakama ya Tanzania. Tunalenga kuunga mkono utawala wa sheria kwa kuchapisha sheria ya Tanzania kwa ufikiaji wa mtandaoni bila malipo."
 
-#: templates/peachjam/_footer.html:31
+#: templates/peachjam/_footer.html:5
 msgid "TanzLII is based at the Judiciary of Tanzania and publishes the law of Tanzania for free online access for all. Free Access to the law supports the rule of law and access to justice. TanzLII partners with African Legal Information Institute (AfricanLII) and <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, who provide it with technical support."
 msgstr "TanzLII ina makao yake katika Mahakama ya Tanzania na inachapisha sheria ya Tanzania kwa upatikanaji wa bure mtandaoni kwa wote. Upatikanaji Huru wa sheria unasaidia utawala wa sheria na upatikanaji wa haki. TanzLII inashirikiana na Taasisi ya Taarifa za Kisheria ya Afrika (AfricanLII) na <a href=\"http://laws.africa/\">Laws.Africa</a> NPO, ambao huipatia msaada wa kiufundi."
 
-#: templates/peachjam/_footer.html:38
-msgid "Terms of Use"
-msgstr "Masharti ya matumizi"
-
-#: templates/peachjam/_footer.html:42
+#: templates/peachjam/_footer.html:13
 msgid "Our partners"
 msgstr "Washirika wetu"
 
@@ -63,8 +61,20 @@ msgid "Legislation"
 msgstr "Sheria"
 
 #: templates/peachjam/_header.html:20
+msgid "Law Reform"
+msgstr ""
+
+#: templates/peachjam/_header.html:26
 msgid "Gazettes"
 msgstr "Magazeti ya serikali"
+
+#: templates/peachjam/_header.html:32
+msgid "Speeches"
+msgstr ""
+
+#: templates/peachjam/_header.html:38
+msgid "JOT Documents and Guidelines"
+msgstr ""
 
 #: templates/peachjam/about.html:9
 msgid "About TanzLII"
@@ -86,3 +96,8 @@ msgstr "Wasiliana nasi"
 msgid "<div> <a href=\"mailto:info@tanzlii.org\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-envelope mr-2\"></i></span>info@tanzlii.org</a> </div> <div> <a href=\"https://facebook.com/africanlii/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-facebook mr-2\"></i></span>facebook.com/africanlii</a> </div> <div> <a href=\"https://twitter.com/AfricanLII/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-twitter mr-2\"></i></span>twitter.com/AfricanLII</a> </div>"
 msgstr "<div> <a href=\"mailto:info@tanzlii.org\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-envelope mr-2\"></i></span>info@tanzlii.org</a> </div> <div> <a href=\"https://facebook.com/africanlii/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-facebook mr-2\"></i></span>facebook.com/africanlii</a> </div> <div> <a href=\"https://twitter.com/AfricanLII/\"><span style=\"margin-right: .2rem\"><i class=\"bi bi-twitter mr-2\"></i></span>twitter.com/AfricanLII</a> </div>"
 
+#~ msgid "Karibu kwenye Tanzania Legal Information Institute"
+#~ msgstr "Karibu kwenye Taasisi ya Taarifa za Sheria Tanzania"
+
+#~ msgid "Terms of Use"
+#~ msgstr "Masharti ya matumizi"

--- a/zanzibarlii/locale/en/LC_MESSAGES/django.po
+++ b/zanzibarlii/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,33 +26,33 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: templates/liiweb/home.html:18
+#: templates/liiweb/home.html:10
 msgid "Karibu kwenye Zanzibar Legal Information Institute"
 msgstr ""
 
-#: templates/liiweb/home.html:20
+#: templates/liiweb/home.html:12
 msgid "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. ZanzibarLII provides free access to the law of Zanzibar and is a member of the African LII community."
 msgstr ""
 
-#: templates/liiweb/home.html:27 templates/peachjam/_header.html:32
+#: templates/liiweb/home.html:19 templates/peachjam/_header.html:26
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr ""
 
-#: templates/liiweb/home.html:30 templates/peachjam/_footer.html:30
+#: templates/liiweb/home.html:22 templates/peachjam/_footer.html:5
 #: templates/peachjam/about.html:11
 msgid "ZanzibarLII is developed under the auspices of the Judiciary of Zanzibar and publishes the law of Zanzibar for free online access to all. ZanzibarLII promotes the rule of law and access to justice in Zanzibar."
 msgstr ""
 
-#: templates/liiweb/home.html:50
+#: templates/liiweb/home.html:28
 msgid "Tweets by AfricanLII"
 msgstr ""
 
-#: templates/peachjam/_footer.html:35
+#: templates/peachjam/_footer.html:10
 msgid "Terms of Use"
 msgstr ""
 
-#: templates/peachjam/_footer.html:39
+#: templates/peachjam/_footer.html:14
 msgid "Our partners"
 msgstr ""
 
@@ -65,11 +65,7 @@ msgid "Legislation"
 msgstr ""
 
 #: templates/peachjam/_header.html:20
-msgid "Documents and Guidelines"
-msgstr ""
-
-#: templates/peachjam/_header.html:26
-msgid "Speeches"
+msgid "Licensed Advocates"
 msgstr ""
 
 #: templates/peachjam/about.html:9

--- a/zanzibarlii/locale/fr/LC_MESSAGES/django.po
+++ b/zanzibarlii/locale/fr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
@@ -25,33 +25,33 @@ msgstr "Swahili"
 msgid "English"
 msgstr "Anglais"
 
-#: templates/liiweb/home.html:18
+#: templates/liiweb/home.html:10
 msgid "Karibu kwenye Zanzibar Legal Information Institute"
 msgstr "Karibu kwenye Zanzibar Institut d'information juridique"
 
-#: templates/liiweb/home.html:20
+#: templates/liiweb/home.html:12
 msgid "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. ZanzibarLII provides free access to the law of Zanzibar and is a member of the African LII community."
 msgstr "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. ZanzibarLII offre un accès gratuit au droit de Zanzibar et est membre de la communauté africaine LII."
 
-#: templates/liiweb/home.html:27 templates/peachjam/_header.html:32
+#: templates/liiweb/home.html:19 templates/peachjam/_header.html:26
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr "À propos"
 
-#: templates/liiweb/home.html:30 templates/peachjam/_footer.html:30
+#: templates/liiweb/home.html:22 templates/peachjam/_footer.html:5
 #: templates/peachjam/about.html:11
 msgid "ZanzibarLII is developed under the auspices of the Judiciary of Zanzibar and publishes the law of Zanzibar for free online access to all. ZanzibarLII promotes the rule of law and access to justice in Zanzibar."
 msgstr "ZanzibarLII est développé sous les auspices du pouvoir judiciaire de Zanzibar et publie la loi de Zanzibar pour un accès en ligne gratuit à tous. ZanzibarLII promeut l'état de droit et l'accès à la justice à Zanzibar."
 
-#: templates/liiweb/home.html:50
+#: templates/liiweb/home.html:28
 msgid "Tweets by AfricanLII"
 msgstr "Tweets par AfricanLII"
 
-#: templates/peachjam/_footer.html:35
+#: templates/peachjam/_footer.html:10
 msgid "Terms of Use"
 msgstr "Termes et conditions d'utilisation"
 
-#: templates/peachjam/_footer.html:39
+#: templates/peachjam/_footer.html:14
 msgid "Our partners"
 msgstr "Nos partenaires"
 
@@ -64,12 +64,8 @@ msgid "Legislation"
 msgstr "Législation"
 
 #: templates/peachjam/_header.html:20
-msgid "Documents and Guidelines"
-msgstr "Documents et lignes directrices"
-
-#: templates/peachjam/_header.html:26
-msgid "Speeches"
-msgstr "Discours"
+msgid "Licensed Advocates"
+msgstr ""
 
 #: templates/peachjam/about.html:9
 msgid "About ZanzibarLII"
@@ -91,3 +87,8 @@ msgstr "Contactez-nous"
 msgid "Contact us on <a href=\"mailto:info@zanzibarlii.org\">info@zanzibarlii.org</a> for more information."
 msgstr "Contactez-nous au <a href=\"mailto:info@zanzibarlii.org\">info@zanzibarlii.org</a> pour plus d'informations."
 
+#~ msgid "Documents and Guidelines"
+#~ msgstr "Documents et lignes directrices"
+
+#~ msgid "Speeches"
+#~ msgstr "Discours"

--- a/zanzibarlii/locale/pt/LC_MESSAGES/django.po
+++ b/zanzibarlii/locale/pt/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese\n"
@@ -25,33 +25,33 @@ msgstr "Suaíli"
 msgid "English"
 msgstr "Inglês"
 
-#: templates/liiweb/home.html:18
+#: templates/liiweb/home.html:10
 msgid "Karibu kwenye Zanzibar Legal Information Institute"
 msgstr "Karibu kwenye Instituto de Informações Jurídicas de Zanzibar"
 
-#: templates/liiweb/home.html:20
+#: templates/liiweb/home.html:12
 msgid "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. ZanzibarLII provides free access to the law of Zanzibar and is a member of the African LII community."
 msgstr "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. ZanzibarLII fornece acesso gratuito à lei de Zanzibar e é membro da comunidade africana LII."
 
-#: templates/liiweb/home.html:27 templates/peachjam/_header.html:32
+#: templates/liiweb/home.html:19 templates/peachjam/_header.html:26
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr "Sobre"
 
-#: templates/liiweb/home.html:30 templates/peachjam/_footer.html:30
+#: templates/liiweb/home.html:22 templates/peachjam/_footer.html:5
 #: templates/peachjam/about.html:11
 msgid "ZanzibarLII is developed under the auspices of the Judiciary of Zanzibar and publishes the law of Zanzibar for free online access to all. ZanzibarLII promotes the rule of law and access to justice in Zanzibar."
 msgstr "ZanzibarLII é desenvolvido sob os auspícios do Judiciário de Zanzibar e publica a lei de Zanzibar para acesso online gratuito a todos. O ZanzibarLII promove o estado de direito e o acesso à justiça em Zanzibar."
 
-#: templates/liiweb/home.html:50
+#: templates/liiweb/home.html:28
 msgid "Tweets by AfricanLII"
 msgstr "Tweets de AfricanLII"
 
-#: templates/peachjam/_footer.html:35
+#: templates/peachjam/_footer.html:10
 msgid "Terms of Use"
 msgstr "Termos de Utilização"
 
-#: templates/peachjam/_footer.html:39
+#: templates/peachjam/_footer.html:14
 msgid "Our partners"
 msgstr "Nossos parceiros"
 
@@ -64,12 +64,8 @@ msgid "Legislation"
 msgstr "Legislação"
 
 #: templates/peachjam/_header.html:20
-msgid "Documents and Guidelines"
-msgstr "Documentos e Diretrizes"
-
-#: templates/peachjam/_header.html:26
-msgid "Speeches"
-msgstr "Discursos"
+msgid "Licensed Advocates"
+msgstr ""
 
 #: templates/peachjam/about.html:9
 msgid "About ZanzibarLII"
@@ -91,3 +87,8 @@ msgstr "Contate-nos"
 msgid "Contact us on <a href=\"mailto:info@zanzibarlii.org\">info@zanzibarlii.org</a> for more information."
 msgstr "Contacte-nos em <a href=\"mailto:info@zanzibarlii.org\">info@zanzibarlii.org</a> para mais informações."
 
+#~ msgid "Documents and Guidelines"
+#~ msgstr "Documentos e Diretrizes"
+
+#~ msgid "Speeches"
+#~ msgstr "Discursos"

--- a/zanzibarlii/locale/sw/LC_MESSAGES/django.po
+++ b/zanzibarlii/locale/sw/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 39b2fd8e1f2e7f60a21a2ff40372741a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-11 14:05+0300\n"
+"POT-Creation-Date: 2023-08-30 10:34+0200\n"
 "PO-Revision-Date: 2023-05-16 07:12\n"
 "Last-Translator: \n"
 "Language-Team: Swahili\n"
@@ -25,33 +25,33 @@ msgstr "Kiswahili"
 msgid "English"
 msgstr "Kiingereza"
 
-#: templates/liiweb/home.html:18
+#: templates/liiweb/home.html:10
 msgid "Karibu kwenye Zanzibar Legal Information Institute"
 msgstr "Karibu kwenye Taasisi ya Habari za Sheria Zanzibar"
 
-#: templates/liiweb/home.html:20
+#: templates/liiweb/home.html:12
 msgid "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa ufikiaji bure Mtandaoni. ZanzibarLII provides free access to the law of Zanzibar and is a member of the African LII community."
 msgstr "ZanzibarLII ni tovuti ya Mahakama ya Zanzibar inayochapisha maamuzi, Sheria na Kanuni kwa bure Mtandaoni. ZanzibarLII inatoa ufikiaji wa bure kwa sheria ya Zanzibar na ni mwanachama wa jumuiya ya LII ya Kiafrika."
 
-#: templates/liiweb/home.html:27 templates/peachjam/_header.html:32
+#: templates/liiweb/home.html:19 templates/peachjam/_header.html:26
 #: templates/peachjam/about.html:4
 msgid "About"
 msgstr "Kuhusu"
 
-#: templates/liiweb/home.html:30 templates/peachjam/_footer.html:30
+#: templates/liiweb/home.html:22 templates/peachjam/_footer.html:5
 #: templates/peachjam/about.html:11
 msgid "ZanzibarLII is developed under the auspices of the Judiciary of Zanzibar and publishes the law of Zanzibar for free online access to all. ZanzibarLII promotes the rule of law and access to justice in Zanzibar."
 msgstr "ZanzibarLII imetengenezwa chini ya usimamizi wa Mahakama ya Zanzibar na inachapisha sheria ya Zanzibar kwa upatikanaji wa bure mtandaoni kwa wote. ZanzibarLII inakuza utawala wa sheria na upatikanaji wa haki Zanzibar."
 
-#: templates/liiweb/home.html:50
+#: templates/liiweb/home.html:28
 msgid "Tweets by AfricanLII"
 msgstr "Tweets na AfricanLII"
 
-#: templates/peachjam/_footer.html:35
+#: templates/peachjam/_footer.html:10
 msgid "Terms of Use"
 msgstr "Masharti ya matumizi"
 
-#: templates/peachjam/_footer.html:39
+#: templates/peachjam/_footer.html:14
 msgid "Our partners"
 msgstr "Washirika wetu"
 
@@ -64,12 +64,8 @@ msgid "Legislation"
 msgstr "Sheria"
 
 #: templates/peachjam/_header.html:20
-msgid "Documents and Guidelines"
-msgstr "Nyaraka na Miongozo"
-
-#: templates/peachjam/_header.html:26
-msgid "Speeches"
-msgstr "Hotuba"
+msgid "Licensed Advocates"
+msgstr ""
 
 #: templates/peachjam/about.html:9
 msgid "About ZanzibarLII"
@@ -91,3 +87,8 @@ msgstr "Wasiliana nasi"
 msgid "Contact us on <a href=\"mailto:info@zanzibarlii.org\">info@zanzibarlii.org</a> for more information."
 msgstr "Wasiliana nasi kwa <a href=\"mailto:info@zanzibarlii.org\">info@zanzibarlii.org</a> kwa maelezo zaidi."
 
+#~ msgid "Documents and Guidelines"
+#~ msgstr "Nyaraka na Miongozo"
+
+#~ msgid "Speeches"
+#~ msgstr "Hotuba"


### PR DESCRIPTION
* fixed warnings so that they can be correctly translated. The full string must be passed to `_()` directly, otherwise the gettext pre-processing can't find the strings to translate. The `friendly_type` must be passed in as a parameter.
* updated translation string extractions

(translations still pending):

![image](https://github.com/laws-africa/peachjam/assets/4178542/25e53ecb-6257-4652-ac9d-58dcc8475771)
