### PR TITLE
fix latest expression in taxonomy view; faster faceting.

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -115,14 +115,13 @@ class BaseDocumentFilterForm(forms.Form):
         attorneys = self.params.getlist("attorneys")
         order_outcomes = self.params.getlist("order_outcomes")
 
-        # Order by date descending initially
-        queryset = queryset.order_by("-date", "title")
+        queryset = self.order_queryset(queryset, exclude)
 
         if years and exclude != "years":
             queryset = queryset.filter(date__year__in=years)
 
         if alphabet and exclude != "alphabet":
-            queryset = queryset.order_by("title").filter(title__istartswith=alphabet)
+            queryset = queryset.filter(title__istartswith=alphabet)
 
         if authors and exclude != "authors":
             queryset = queryset.filter(authors__name__in=authors)
@@ -151,6 +150,13 @@ class BaseDocumentFilterForm(forms.Form):
         if order_outcomes and exclude != "order_outcomes":
             queryset = queryset.filter(order_outcome__name__in=order_outcomes)
 
+        return queryset
+
+    def order_queryset(self, queryset, exclude=None):
+        if self.cleaned_data.get("alphabet") and exclude != "alphabet":
+            queryset = queryset.order_by("title")
+        else:
+            queryset = queryset.order_by("-date", "title")
         return queryset
 
 

--- a/peachjam/js/components/FilterFacets/SingleFacet.vue
+++ b/peachjam/js/components/FilterFacets/SingleFacet.vue
@@ -18,7 +18,7 @@
           />
         </div>
       </div>
-      <div class="facets-scrollable">
+      <div :class="`${facet.type === 'letter-radio' ? '' : 'facets-scrollable'}`">
         <template v-if="facet.type === 'checkboxes'">
           <div
             v-for="(option, optIndex) in facet.options"

--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -249,8 +249,8 @@ class CoreDocumentManager(PolymorphicManager):
 
 class CoreDocumentQuerySet(PolymorphicQuerySet):
     def latest_expression(self):
-        """Select only the most recent expression for documents with the same frbr_uri."""
-        return self.distinct("work_frbr_uri").order_by("work_frbr_uri", "-date")
+        """Select only the most recent expression for documents from the same work."""
+        return self.distinct("work_id").order_by("work_id", "-date")
 
     def preferred_language(self, language):
         """Return documents whose language match the preferred one,

--- a/peachjam/views/authors.py
+++ b/peachjam/views/authors.py
@@ -27,9 +27,10 @@ class AuthorDetailView(FilteredDocumentListView):
         context = super().get_context_data(**kwargs)
         doc_types = list(
             set(
-                self.form.filter_queryset(
-                    self.get_base_queryset(), exclude="doc_type"
-                ).values_list("doc_type", flat=True)
+                self.form.filter_queryset(self.get_base_queryset(), exclude="doc_type")
+                .order_by()
+                .values_list("doc_type", flat=True)
+                .distinct()
             )
         )
 

--- a/peachjam/views/authors.py
+++ b/peachjam/views/authors.py
@@ -26,12 +26,10 @@ class AuthorDetailView(FilteredDocumentListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         doc_types = list(
-            set(
-                self.form.filter_queryset(self.get_base_queryset(), exclude="doc_type")
-                .order_by()
-                .values_list("doc_type", flat=True)
-                .distinct()
-            )
+            self.form.filter_queryset(self.get_base_queryset(), exclude="doc_type")
+            .order_by()
+            .values_list("doc_type", flat=True)
+            .distinct()
         )
 
         context["author"] = self.author

--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -70,42 +70,36 @@ class CourtDetailView(FilteredDocumentListView):
 
     def populate_facets(self, context):
         judges = list(
-            {
-                judge
-                for judge in self.form.filter_queryset(
-                    self.get_base_queryset(), exclude="judges"
-                )
-                .order_by()
-                .values_list("judges__name", flat=True)
-                .distinct()
-                if judge
-            }
+            judge
+            for judge in self.form.filter_queryset(
+                self.get_base_queryset(), exclude="judges"
+            )
+            .order_by()
+            .values_list("judges__name", flat=True)
+            .distinct()
+            if judge
         )
 
         attorneys = list(
-            {
-                attorney
-                for attorney in self.form.filter_queryset(
-                    self.get_base_queryset(), exclude="attorneys"
-                )
-                .order_by()
-                .values_list("attorneys__name", flat=True)
-                .distinct()
-                if attorney
-            }
+            attorney
+            for attorney in self.form.filter_queryset(
+                self.get_base_queryset(), exclude="attorneys"
+            )
+            .order_by()
+            .values_list("attorneys__name", flat=True)
+            .distinct()
+            if attorney
         )
 
         order_outcomes = list(
-            {
-                order_outcome
-                for order_outcome in self.form.filter_queryset(
-                    self.get_base_queryset(), exclude="order_outcomes"
-                )
-                .order_by()
-                .values_list("order_outcome__name", flat=True)
-                .distinct()
-                if order_outcome
-            }
+            order_outcome
+            for order_outcome in self.form.filter_queryset(
+                self.get_base_queryset(), exclude="order_outcomes"
+            )
+            .order_by()
+            .values_list("order_outcome__name", flat=True)
+            .distinct()
+            if order_outcome
         )
 
         context["facet_data"] = {

--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -74,7 +74,10 @@ class CourtDetailView(FilteredDocumentListView):
                 judge
                 for judge in self.form.filter_queryset(
                     self.get_base_queryset(), exclude="judges"
-                ).values_list("judges__name", flat=True)
+                )
+                .order_by()
+                .values_list("judges__name", flat=True)
+                .distinct()
                 if judge
             }
         )
@@ -84,7 +87,10 @@ class CourtDetailView(FilteredDocumentListView):
                 attorney
                 for attorney in self.form.filter_queryset(
                     self.get_base_queryset(), exclude="attorneys"
-                ).values_list("attorneys__name", flat=True)
+                )
+                .order_by()
+                .values_list("attorneys__name", flat=True)
+                .distinct()
                 if attorney
             }
         )
@@ -94,7 +100,10 @@ class CourtDetailView(FilteredDocumentListView):
                 order_outcome
                 for order_outcome in self.form.filter_queryset(
                     self.get_base_queryset(), exclude="order_outcomes"
-                ).values_list("order_outcome__name", flat=True)
+                )
+                .order_by()
+                .values_list("order_outcome__name", flat=True)
+                .distinct()
                 if order_outcome
             }
         )

--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -86,38 +86,32 @@ class FilteredDocumentListView(DocumentListView):
         authors = []
         # Initialize facet data values
         natures = list(
-            {
-                doc_n
-                for doc_n in self.form.filter_queryset(
-                    self.get_base_queryset(), exclude="natures"
-                )
-                .order_by()
-                .values_list("nature__name", flat=True)
-                .distinct()
-                if doc_n
-            }
+            doc_n
+            for doc_n in self.form.filter_queryset(
+                self.get_base_queryset(), exclude="natures"
+            )
+            .order_by()
+            .values_list("nature__name", flat=True)
+            .distinct()
+            if doc_n
         )
         if self.model in [GenericDocument, LegalInstrument]:
             authors = list(
-                {
-                    a
-                    for a in self.form.filter_queryset(
-                        self.get_base_queryset(), exclude="authors"
-                    )
-                    .order_by()
-                    .values_list("authors__name", flat=True)
-                    .distinct()
-                    if a
-                }
+                a
+                for a in self.form.filter_queryset(
+                    self.get_base_queryset(), exclude="authors"
+                )
+                .order_by()
+                .values_list("authors__name", flat=True)
+                .distinct()
+                if a
             )
 
         years = list(
-            set(
-                self.form.filter_queryset(self.get_base_queryset(), exclude="years")
-                .order_by()
-                .values_list("date__year", flat=True)
-                .distinct()
-            )
+            self.form.filter_queryset(self.get_base_queryset(), exclude="years")
+            .order_by()
+            .values_list("date__year", flat=True)
+            .distinct()
         )
 
         context["doc_table_show_author"] = bool(authors)

--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -90,7 +90,10 @@ class FilteredDocumentListView(DocumentListView):
                 doc_n
                 for doc_n in self.form.filter_queryset(
                     self.get_base_queryset(), exclude="natures"
-                ).values_list("nature__name", flat=True)
+                )
+                .order_by()
+                .values_list("nature__name", flat=True)
+                .distinct()
                 if doc_n
             }
         )
@@ -100,16 +103,20 @@ class FilteredDocumentListView(DocumentListView):
                     a
                     for a in self.form.filter_queryset(
                         self.get_base_queryset(), exclude="authors"
-                    ).values_list("authors__name", flat=True)
+                    )
+                    .order_by()
+                    .values_list("authors__name", flat=True)
+                    .distinct()
                     if a
                 }
             )
 
         years = list(
             set(
-                self.form.filter_queryset(
-                    self.get_base_queryset(), exclude="years"
-                ).values_list("date__year", flat=True)
+                self.form.filter_queryset(self.get_base_queryset(), exclude="years")
+                .order_by()
+                .values_list("date__year", flat=True)
+                .distinct()
             )
         )
 

--- a/peachjam/views/taxonomy.py
+++ b/peachjam/views/taxonomy.py
@@ -30,6 +30,8 @@ class TaxonomyFirstLevelView(DetailView):
 class TaxonomyDetailView(FilteredDocumentListView):
     template_name = "peachjam/taxonomy_detail.html"
     navbar_link = "taxonomy"
+    # taxonomies may include legislation, so we want to show the latest expression only
+    latest_expression_only = True
 
     def get(self, request, *args, **kwargs):
         self.taxonomy = self.get_taxonomy()


### PR DESCRIPTION
This does three things:

1. allows us to fetch only the latest expression in taxonmy views, since they may include legislation, which has multiple points in time. Otherwise, the same act will show up multiple times. It's opt-in, because it's a bit more expensive, and many views (eg. court and place listing views) don't care about it.
2. fixes https://github.com/laws-africa/peachjam/issues/1522 by applying language filtering only to the queryset that is actually used for document listing. This makes faceting calculations faster because we don't care about languages when calculating facets.
3. pushes facet calculations into the db, rather than fetching all rows and then calculating facets in python

Before:

![image](https://github.com/laws-africa/peachjam/assets/4178542/b32ec388-53d5-4ea0-b4dd-65391ad53f4a)


After:

![image](https://github.com/laws-africa/peachjam/assets/4178542/6b8108c5-14f1-4ec3-bf6f-0e9ab322c0e1)
