### PR TITLE
Fix doc count string

### DIFF
--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -159,7 +159,7 @@
                 </div>
                 <div class="col-md order-md-1">
                   <span v-if="searchInfo.count > 9999">{{ $t('More than 10,000 documents found.') }}</span>
-                  <span v-else>{{ $t('{document_count} documents found.', { document_count: searchInfo.count }) }}</span>
+                  <span v-else>{{ $t('{document_count} documents found', { document_count: searchInfo.count }) }}</span>
                 </div>
               </div>
 


### PR DESCRIPTION
![image](https://github.com/laws-africa/peachjam/assets/25079238/6dd59fd7-c49c-43a0-8678-ce9d8c38956c)


The string wasn't matching correctly with the period.
The translations already have it so its fine.