### PR TITLE
Fix n+1 in judgment admin

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -762,11 +762,6 @@ class JudgmentAdmin(ImportExportMixin, DocumentAdmin):
 
         return fieldsets
 
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        if db_field.name == "registry":
-            kwargs["queryset"] = CourtRegistry.objects.select_related("court")
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)
-
 
 @admin.register(Predicate)
 class PredicateAdmin(admin.ModelAdmin):

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -762,6 +762,11 @@ class JudgmentAdmin(ImportExportMixin, DocumentAdmin):
 
         return fieldsets
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "registry":
+            kwargs["queryset"] = CourtRegistry.objects.select_related("court")
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
 
 @admin.register(Predicate)
 class PredicateAdmin(admin.ModelAdmin):

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -114,7 +114,13 @@ class Court(models.Model):
         return self.name
 
 
+class CourtRegistryManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().select_related("court")
+
+
 class CourtRegistry(models.Model):
+    objects = CourtRegistryManager()
     court = models.ForeignKey(
         Court,
         on_delete=models.CASCADE,


### PR DESCRIPTION
- This was caused by the registry drop down.
- The __str__ method has self.name and self.court which causes the n+1 issue.
- Maybe a simple solution  could be to remove the court from the str method. The names of the registries that Tanzli are using are quite descriptive themselves, indicating the court itself, which may be enough
![image](https://github.com/laws-africa/peachjam/assets/25079238/5ad7d363-6e2f-444c-9372-b7b7de25e57f)


closes #1393