### PR TITLE
Related documents in metadata

### DIFF
--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -387,7 +387,7 @@
                                 </li>
                               {% endif %}
                             {% endfor %}
-                            {% for rel in document.relationships_as_object %}
+                            {% for rel in relationships_as_object %}
                               {% if rel.subject_work %}
                                 <li>
                                   {% translate rel.predicate.reverse_verb as verb %}


### PR DESCRIPTION
- fixes showing relationships as object.

![image](https://github.com/laws-africa/peachjam/assets/25079238/be8b0e81-827c-47d6-9fce-50677e132a07)

closes #1572 
