### PR TITLE
Add regex to article url

### DIFF
--- a/peachjam/helpers.py
+++ b/peachjam/helpers.py
@@ -2,6 +2,7 @@ import os
 import string
 import subprocess
 import tempfile
+from datetime import datetime
 from functools import wraps
 
 from django.utils.translation import get_language_from_request
@@ -57,3 +58,15 @@ def chunks(lst, n):
     """Yield successive n-sized chunks from list."""
     for i in range(n):
         yield lst[i::n]
+
+
+class ISODateConverter:
+    regex = r"\d{4}-\d{2}-\d{2}"
+
+    def to_python(self, value):
+        # invalid values will raise ValueError which will raise 404
+        return datetime.strptime(value, "%Y-%m-%d").date()
+
+    def to_url(self, value):
+        # invalid values will raise ValueError which will raise NoReverseMatch
+        return datetime.strptime(value, "%Y-%m-%d").date().strftime("%Y-%m-%d")

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path, re_path
+from django.urls import include, path, re_path, register_converter
 from django.views.decorators.cache import cache_page
 
 from peachjam.feeds import (
@@ -27,6 +27,7 @@ from peachjam.feeds import (
     LegalInstrumentAtomSiteNewsFeed,
     LegislationAtomSiteNewsFeed,
 )
+from peachjam.helpers import ISODateConverter
 from peachjam.views import (
     AboutPageView,
     ArticleDetailView,
@@ -67,6 +68,9 @@ from peachjam.views import (
     UserProfileDetailView,
 )
 from peachjam.views.metabase_stats import MetabaseStatsView
+
+register_converter(ISODateConverter, "isodate")
+
 
 # cache duration for most cached pages
 CACHE_DURATION = 60 * 60 * 24
@@ -206,8 +210,8 @@ urlpatterns = [
         ArticleTopicListView.as_view(),
         name="article_topic_list",
     ),
-    re_path(
-        "^articles/(?P<date>[0-9]{4}-[0-9]{2}-[0-9]{2})/(?P<author>[-a-zA-Z0-9_]+)/(?P<slug>[-a-zA-Z0-9_]+)$",
+    path(
+        "articles/<isodate:date>/<str:author>/<slug:slug>",
         ArticleDetailView.as_view(),
         name="article_detail",
     ),

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -206,8 +206,8 @@ urlpatterns = [
         ArticleTopicListView.as_view(),
         name="article_topic_list",
     ),
-    path(
-        "articles/<str:date>/<str:author>/<slug:slug>",
+    re_path(
+        "^articles/(?P<date>[0-9]{4}-[0-9]{2}-[0-9]{2})/(?P<author>[-a-zA-Z0-9_]+)/(?P<slug>[-a-zA-Z0-9_]+)$",
         ArticleDetailView.as_view(),
         name="article_detail",
     ),


### PR DESCRIPTION
fixes #1591 

The error occurs because the date captured by the urlconf was not being validated correctly.

Adding a more explicit regex that looks for the format `YYYY-MM-DD` fixes it.