### PR TITLE
Fix null in commencements metadata

### DIFF
--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -208,7 +208,7 @@ class LegislationDetailView(BaseDocumentDetailView):
     def get_latest_commencement_date(self):
         commencement_dates = [
             commencement["date"]
-            for commencement in self.object.metadata_json.get("commencements", [])
+            for commencement in self.object.metadata_json.get("commencements", []) or []
             if commencement["date"]
         ]
         if commencement_dates:


### PR DESCRIPTION
fixes #1590

- Sometimes the metadata has "commencments: null" and which passes None to the list comprehension
- Sometimes the commencements keyword is missing altogether
- This should guard against those two cases