### PR TITLE
Updates to support improved text citation extraction and the new citator api

### DIFF
--- a/peachjam/models/citations.py
+++ b/peachjam/models/citations.py
@@ -26,6 +26,21 @@ class CitationLink(models.Model):
         verbose_name = _("citation link")
         verbose_name_plural = _("citation links")
 
+    def to_citator_api(self):
+        """Transform into a format suitable for the Citator API."""
+        selector = next(
+            (t for t in self.target_selectors if t["type"] == "TextPositionSelector"),
+            None,
+        )
+        return {
+            "href": self.url,
+            "text": self.text,
+            # strip the page- and just keep the num
+            "target_id": int(self.target_id.split("-", 1)[1]) - 1,
+            "start": selector["start"] if selector else -1,
+            "end": selector["end"] if selector else -1,
+        }
+
     def __str__(self):
         return f"Citation link for {self.document.doc_type} - {self.document.title}"
 

--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -659,7 +659,9 @@ class CoreDocument(PolymorphicModel):
         else:
             for citation_link in CitationLink.objects.filter(document_id=self.pk):
                 try:
-                    work_frbr_uris.add(FrbrUri.parse(citation_link.url).work_uri())
+                    uri = FrbrUri.parse(citation_link.url)
+                    uri.portion = None
+                    work_frbr_uris.add(uri.work_uri())
                 except ValueError:
                     # ignore malformed FRBR URIs
                     pass


### PR DESCRIPTION
* updates to calling Citator API for text documents
* update document resolver to handle FRBR URI portions (eg. `/akn/za/act/2009/1/~sec_31` is redirected to `/akn/za/act/2009/1/#sec_31`)


![image](https://github.com/laws-africa/peachjam/assets/4178542/f6e1cd51-4e60-47a9-80b9-de321bdef279)
