### PR TITLE
search: boost title; don't double-index title as citation

### DIFF
--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -193,10 +193,6 @@ class SearchableDocument(Document):
     def prepare_doc_type(self, instance):
         return instance.get_doc_type_display()
 
-    def prepare_citation(self, instance):
-        # if there is no citation, fall back to the title so as not to penalise documents that don't have a citation
-        return instance.citation or instance.title
-
     def prepare_case_number(self, instance):
         if hasattr(instance, "case_numbers"):
             return [c.get_case_number_string() for c in instance.case_numbers.all()]

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -262,7 +262,7 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
     }
 
     search_fields = {
-        "title": {"boost": 6},
+        "title": {"boost": 8},
         "title_expanded": {"boost": 4},
         "authors": None,
         "citation": {"boost": 4},


### PR DESCRIPTION
previously we indexed the title as the citation. the problem is that then documents without a citation get double points for matching on the title, which skews results.

also, boost title slightly since many searches are directly on the title