### PR TITLE
Sentry updates: ignore /static/ and correctly wrap background tasks

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -322,7 +322,10 @@ if not DEBUG:
         event_level=None,  # Don't send errors based on log messages
     )
 
-    def exclude_static(event, hint):
+    def before_send(event, hint):
+        # set the app name on all events
+        event.setdefault("tags", {})["app_name"] = PEACHJAM["APP_NAME"]
+
         # don't set /static to Sentry, to avoid using up quota
         if "request" in event and event["request"].get("url"):
             url = urlparse(event["request"]["url"])
@@ -334,7 +337,7 @@ if not DEBUG:
         dsn=PEACHJAM["SENTRY_DSN_KEY"],
         environment=PEACHJAM["SENTRY_ENVIRONMENT"],
         integrations=[DjangoIntegration(), sentry_logging],
-        before_send_transaction=exclude_static,
+        before_send_transaction=before_send,
         send_default_pii=True,
         # sample x% of requests for performance metrics
         traces_sample_rate=float(os.environ.get("SENTRY_SAMPLE_RATE", "0.25")),

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -14,6 +14,7 @@ import base64
 import logging
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 import dj_database_url
 import sentry_sdk
@@ -320,10 +321,20 @@ if not DEBUG:
         level=logging.INFO,  # Capture info and above as breadcrumbs
         event_level=None,  # Don't send errors based on log messages
     )
+
+    def exclude_static(event, hint):
+        # don't set /static to Sentry, to avoid using up quota
+        if "request" in event and event["request"].get("url"):
+            url = urlparse(event["request"]["url"])
+            if url.path.startswith("/static/"):
+                return None
+        return event
+
     sentry_sdk.init(
         dsn=PEACHJAM["SENTRY_DSN_KEY"],
         environment=PEACHJAM["SENTRY_ENVIRONMENT"],
         integrations=[DjangoIntegration(), sentry_logging],
+        before_send_transaction=exclude_static,
         send_default_pii=True,
         # sample x% of requests for performance metrics
         traces_sample_rate=float(os.environ.get("SENTRY_SAMPLE_RATE", "0.25")),

--- a/peachjam/signals.py
+++ b/peachjam/signals.py
@@ -1,49 +1,8 @@
-import sentry_sdk
-from background_task.signals import (
-    task_error,
-    task_finished,
-    task_started,
-    task_successful,
-)
 from django.db.models import signals
 from django.dispatch import receiver
 
 from peachjam.models import CoreDocument, SourceFile, Work
 from peachjam.tasks import update_extracted_citations_for_a_work
-
-
-# monitor background tasks with sentry
-@receiver(task_started)
-def bg_task_started(sender, **kwargs):
-    transaction = sentry_sdk.start_transaction(op="queue.task.bg")
-    transaction.set_tag("transaction_type", "task")
-    # fake an entry into the context
-    transaction.__enter__()
-
-
-@receiver(task_successful)
-def bg_task_success(sender, completed_task, **kwargs):
-    transaction = sentry_sdk.Hub.current.scope.transaction
-    if transaction:
-        transaction.name = completed_task.task_name
-
-
-@receiver(task_error)
-def bg_task_error(sender, task, **kwargs):
-    transaction = sentry_sdk.Hub.current.scope.transaction
-    if transaction:
-        transaction.name = task.task_name
-
-    # report error to sentry
-    sentry_sdk.capture_exception()
-
-
-@receiver(task_finished)
-def bg_task_finished(sender, **kwargs):
-    transaction = sentry_sdk.Hub.current.scope.transaction
-    if transaction:
-        # fake an exit from the transaction context
-        transaction.__exit__(None, None, None)
 
 
 @receiver(signals.post_save)


### PR DESCRIPTION
* `/static/...` aren't useful and take up request quota with sentry
* correctly wrap background tasks so we can check performance and get better errors
* attach `app_name` tag to all events to differentiate more easily between apps

example of background task:

![image](https://github.com/laws-africa/peachjam/assets/4178542/7dede105-2c7b-4fbc-b66c-f7bc7c348387)
