### PR TITLE
cache most of the site for anonymous and non-staff users

### DIFF
--- a/peachjam/middleware.py
+++ b/peachjam/middleware.py
@@ -73,10 +73,6 @@ class GeneralUpdateCacheMiddleware(UpdateCacheMiddleware):
         "/_",
     ]
 
-    def __init__(self, get_response):
-        super().__init__(get_response)
-        self.page_timeout = 60 * 30
-
     def _should_update_cache(self, request, response):
         if (
             hasattr(request, "_cache_update_cache")

--- a/peachjam/middleware.py
+++ b/peachjam/middleware.py
@@ -67,7 +67,10 @@ class GeneralUpdateCacheMiddleware(UpdateCacheMiddleware):
 
     # url prefixes that should never be cached
     never_cache_prefixes = [
-        "/admin/" "/accounts/" "/api/" "/_",
+        "/admin/",
+        "/accounts/",
+        "/api/",
+        "/_",
     ]
 
     def __init__(self, get_response):

--- a/peachjam/middleware.py
+++ b/peachjam/middleware.py
@@ -1,4 +1,6 @@
+from django.middleware.cache import UpdateCacheMiddleware
 from django.shortcuts import redirect
+from django.utils.cache import get_max_age
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -30,12 +32,6 @@ class RedirectWWWMiddleware(StripDomainPrefixMiddleware):
     prefix = "www."
 
 
-class RedirectNewMiddleware(StripDomainPrefixMiddleware):
-    """Redirect from new.example.com to example.com"""
-
-    prefix = "new."
-
-
 class ForceDefaultLanguageMiddleware(MiddlewareMixin):
     """
     Ignore Accept-Language HTTP headers
@@ -50,3 +46,50 @@ class ForceDefaultLanguageMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if "HTTP_ACCEPT_LANGUAGE" in request.META:
             del request.META["HTTP_ACCEPT_LANGUAGE"]
+
+
+class GeneralUpdateCacheMiddleware(UpdateCacheMiddleware):
+    """Custom caching for peachjam. Goals:
+
+    1. cache most pages, because content doesn't change that much
+    2. when content does change (eg. new judgments that should be shown on the homepage), reflect those ASAP
+    3. staff users who change content should see updates immediately.
+    4. an anonymous user who logs in should see fresh content
+
+    Views that have their own caching logic aren't changed. Views that don't have caching enabled and don't
+    opt-out of caching will be cached.
+
+    Views can opt-out by:
+
+    1. setting request._cache_update_cache = False OR
+    2. using the Django never_cache() decorator
+    """
+
+    # url prefixes that should never be cached
+    never_cache_prefixes = [
+        "/admin/" "/accounts/" "/api/" "/_",
+    ]
+
+    def __init__(self, get_response):
+        super().__init__(get_response)
+        self.page_timeout = 60 * 30
+
+    def _should_update_cache(self, request, response):
+        if (
+            hasattr(request, "_cache_update_cache")
+            and request._cache_update_cache is False
+        ):
+            # page has opted out
+            return False
+
+        for prefix in self.never_cache_prefixes:
+            if request.path.startswith(prefix):
+                return False
+
+        # support never_cache and explicit page cache times
+        max_age = get_max_age(response)
+        if max_age is not None:
+            return False
+
+        # anonymous and non-staff users should see cached content
+        return request.user.is_anonymous or not request.user.is_staff

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -551,6 +551,8 @@ if DEBUG:
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",
         },
     }
+    # don't cache in DEBUG mode
+    CACHE_MIDDLEWARE_SECONDS = 0
 else:
     CACHES = {
         "default": {
@@ -558,6 +560,8 @@ else:
             "LOCATION": "/var/tmp/django_cache",
         },
     }
+    # in general, cache most pages
+    CACHE_MIDDLEWARE_SECONDS = 60 * 30
 
 # Override X-Frame-Options header value
 X_FRAME_OPTIONS = "SAMEORIGIN"

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -80,9 +80,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "peachjam.middleware.GeneralUpdateCacheMiddleware",
     "log_request_id.middleware.RequestIDMiddleware",
     "peachjam.middleware.RedirectWWWMiddleware",
-    "peachjam.middleware.RedirectNewMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -93,6 +93,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "django.middleware.cache.FetchFromCacheMiddleware",
 ]
 
 ROOT_URLCONF = "peachjam.urls"


### PR DESCRIPTION
Caches successful GET and HEAD requests for anonymous and non-staff users, for 30 minutes.

Excludes /admin, /accounts, etc.