### PR TITLE
As a user, I'm frustrated that so many PDF judgments require me to click a button before displaying

### DIFF
--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -82,7 +82,7 @@
   {% if display_type == 'pdf' %}
     <div data-pdf="{% url 'document_source_pdf' document.expression_frbr_uri|strip_first_character %}"
          data-pdf-size="{{ document.source_file.size }}"
-         {% if document.source_file.size > 5242880 %} data-large-pdf{% endif %}
+         {% if document.source_file.size > 10485760 %} data-large-pdf{% endif %}
          data-pdf-standby>
     </div>
   {% endif %}


### PR DESCRIPTION
Before: 
<img width="1119" alt="Screenshot 2024-01-10 at 16 01 04" src="https://github.com/laws-africa/peachjam/assets/52611827/ccb65610-dac5-4743-a5bf-a1f1c8669ccf">

After:
<img width="1125" alt="Screenshot 2024-01-10 at 16 21 20" src="https://github.com/laws-africa/peachjam/assets/52611827/80bcd7f0-0e33-4472-badc-765995753171">
