### PR TITLE
Recent legislation list on home page is acting weirdly

### DIFF
--- a/liiweb/views/general.py
+++ b/liiweb/views/general.py
@@ -11,9 +11,7 @@ class HomePageView(TemplateView):
 
         context["court_classes"] = CourtClass.objects.prefetch_related("courts")
         context["recent_judgments"] = Judgment.objects.order_by("-date")[:5]
-        context["recent_legislation"] = Legislation.objects.filter(
-            metadata_json__stub=False
-        ).order_by("-date")[:10]
+        context["recent_legislation"] = Legislation.objects.order_by("-date")[:10]
         context["taxonomies"] = Taxonomy.dump_bulk()
         context["taxonomy_url"] = "taxonomy_detail"
         context["recent_articles"] = (


### PR DESCRIPTION
Before:
<img width="895" alt="Screenshot 2024-01-10 at 15 58 12" src="https://github.com/laws-africa/peachjam/assets/52611827/29d21812-168b-4291-b3ce-9dcb3430a751">
After:
<img width="916" alt="Screenshot 2024-01-10 at 15 57 44" src="https://github.com/laws-africa/peachjam/assets/52611827/9876999a-fe9a-4336-adb4-5e4b1eb94a14">
