### PR TITLE
Selection context menu not showing up for HTML documents

### DIFF
--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -128,7 +128,8 @@
         {% endif %}
         {% if display_type == 'html' %}
           <div class="content content__html frbr-doctype-{{ document.frbr_uri_doctype }} frbr-subtype-{{ document.frbr_uri_subtype }}"
-               lang="{{ document.language.iso }}">
+               lang="{{ document.language.iso }}"
+               id="document_content">
             {{ document.content_html|safe }}
           </div>
         {% endif %}


### PR DESCRIPTION
![Screenshot 2024-01-12 at 14 44 52](https://github.com/laws-africa/peachjam/assets/52611827/761aa98d-0f70-4975-8640-e15dcbbf7eaf)
