### PR TITLE
Setup Plausible and Matomo

### DIFF
--- a/lawlibrary/templates/peachjam/layouts/main.html
+++ b/lawlibrary/templates/peachjam/layouts/main.html
@@ -5,3 +5,27 @@
         href="{% sass_src 'stylesheets/lawlibrary.scss' %}"
         type="text/css"/>
 {% endblock %}
+{% block head-js %}
+  <!-- Matomo -->
+  <script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(["disableCookies"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://lawlibraryorgza.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src='//cdn.matomo.cloud/lawlibraryorgza.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+  </script>
+  <!-- End Matomo Code -->
+  <!-- Plausible -->
+  <script defer
+          data-domain="lawlibrary.org.za"
+          src="https://plausible.io/js/script.js"></script>
+  <!-- End Plausible -->
+{% endblock %}


### PR DESCRIPTION
- Setup Plausible and Matomo analytics services as an alternative to Google Analytics for a trial run.