### PR TITLE
Gazettes

### DIFF
--- a/peachjam/static/stylesheets/components/_charts.scss
+++ b/peachjam/static/stylesheets/components/_charts.scss
@@ -1,0 +1,23 @@
+.monthly-column-chart {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  width: 100%;
+
+  .month {
+    width: 8.333%;
+    text-align: center;
+    font-size: $font-size-sm;
+    color: $text-muted;
+
+    .column {
+      display: block;
+      background-color: $gray-300;
+      margin-right: 3px;
+
+      &:hover {
+        background-color: $primary;
+      }
+    }
+  }
+}

--- a/peachjam/static/stylesheets/components/_index.scss
+++ b/peachjam/static/stylesheets/components/_index.scss
@@ -1,3 +1,4 @@
+@import "charts";
 @import "diffs";
 @import "document-content";
 @import "entity-profile";

--- a/peachjam/templates/peachjam/_gazette_localities.html
+++ b/peachjam/templates/peachjam/_gazette_localities.html
@@ -1,11 +1,13 @@
-{% for group in locality_groups %}
-  <div class="col-lg">
-    <ul class="list-unstyled mb-0">
-      {% for locality in group %}
-        <li>
-          <a href="{% url 'gazettes_by_locality' locality.code %}">{{ locality.name }}</a>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-{% endfor %}
+<div class="row">
+  {% for group in locality_groups %}
+    <div class="col-lg">
+      <ul class="list-unstyled mb-0">
+        {% for locality in group %}
+          <li>
+            <a href="{% url 'gazettes_by_locality' locality.code %}">{{ locality.name }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endfor %}
+</div>

--- a/peachjam/templates/peachjam/_monthly_column_chart.html
+++ b/peachjam/templates/peachjam/_monthly_column_chart.html
@@ -3,7 +3,7 @@
     <div class="month">
       <a href="{{ url }}#{{ month.month }}"
          class="column"
-         style="height: {% widthratio month.count year.month_max 40 %}px"></a>
+         style="height: {% if month.count %}{% widthratio month.count year.month_max 40 %}{% else %}1{% endif %}px"></a>
       <span>{{ month.label|slice:":1" }}</span>
     </div>
   {% endfor %}

--- a/peachjam/templates/peachjam/_monthly_column_chart.html
+++ b/peachjam/templates/peachjam/_monthly_column_chart.html
@@ -1,0 +1,10 @@
+<div class="monthly-column-chart">
+  {% for month in year.months %}
+    <div class="month">
+      <a href="{{ url }}#{{ month.month }}"
+         class="column"
+         style="height: {% widthratio month.count year.month_max 40 %}px"></a>
+      <span>{{ month.label|slice:":1" }}</span>
+    </div>
+  {% endfor %}
+</div>

--- a/peachjam/templates/peachjam/gazette_list.html
+++ b/peachjam/templates/peachjam/gazette_list.html
@@ -42,31 +42,35 @@
             <div class="col-md-10 mt-5 mb-5">
               <div class="row">
                 {% for year in years %}
-                  <div class="col-md-4 col-sm-6 col-12">
-                    <div>
-                      <h2 class="text-center">
-                        {% block gazette-year-link %}
+                  <div class="col-md-4 col-sm-6 col-12 mb-5 mr-3">
+                    <div class="card">
+                      <div class="card-body">
+                        <h2 class="text-center fw-bold">
+                          {% block gazette-year-link %}
+                            {% if locality %}
+                              <a href="{% url 'gazettes_by_year' locality.code year.year %}">{{ year.year }}</a>
+                            {% else %}
+                              <a href="{% url 'gazettes_by_year' year.year %}">{{ year.year }}</a>
+                            {% endif %}
+                          {% endblock %}
+                        </h2>
+                        <div class="text-center mb-3">
+                          {% blocktrans trimmed count num_gazettes=year.count %}
+                            {{ num_gazettes }} gazette
+                          {% plural %}
+                            {{ num_gazettes }} gazettes
+                          {% endblocktrans %}
+                        </div>
+                        {% block monthly-chart %}
                           {% if locality %}
-                            <a href="{% url 'gazettes_by_year' locality.code year.year %}">{{ year.year }}</a>
+                            {% url 'gazettes_by_year' locality.code year.year as url %}
                           {% else %}
-                            <a href="{% url 'gazettes_by_year' year.year %}">{{ year.year }}</a>
+                            {% url 'gazettes_by_year' year.year as url %}
                           {% endif %}
+                          {% include 'peachjam/_monthly_column_chart.html' %}
                         {% endblock %}
-                      </h2>
-                      <div class="text-center mb-2">
-                        {% blocktrans trimmed count num_gazettes=year.count %}
-                          {{ num_gazettes }} gazette
-                        {% plural %}
-                          {{ num_gazettes }} gazettes
-                        {% endblocktrans %}
                       </div>
                     </div>
-                    {% if locality %}
-                      {% url 'gazettes_by_year' locality.code year.year as url %}
-                    {% else %}
-                      {% url 'gazettes_by_year' year.year as url %}
-                    {% endif %}
-                    {% include 'peachjam/_monthly_column_chart.html' %}
                   </div>
                 {% endfor %}
               </div>

--- a/peachjam/templates/peachjam/gazette_list.html
+++ b/peachjam/templates/peachjam/gazette_list.html
@@ -30,41 +30,43 @@
             {% include 'peachjam/_gazette_localities.html' %}
           {% endif %}
         {% endblock %}
-        {% if num_gazettes %}
+        {% if doc_count %}
           <h4 class="sans-serif text-muted mt-3 mb-0">
-            {% blocktrans trimmed count num_gazettes=num_gazettes %}
-              {{ num_gazettes }} gazette
+            {% blocktrans trimmed count counter=doc_count %}
+              {{ counter }} gazette
             {% plural %}
-              {{ num_gazettes }} gazettes
+              {{ counter }} gazettes
             {% endblocktrans %}
           </h4>
           {% block years-list %}
             <div class="col-md-10 mt-5 mb-5">
               <div class="row">
                 {% for year in years %}
-                  <div class="col-md-4 col-sm-6 col-xs-12 status-box">
+                  <div class="col-md-4 col-sm-6 col-12">
                     <div>
-                      <h2>
+                      <h2 class="text-center">
                         {% block gazette-year-link %}
                           {% if locality %}
-                            <a class="text-decoration-none"
-                               href="{% url 'gazettes_by_year' locality.code year.year %}">{{ year.year }}</a>
+                            <a href="{% url 'gazettes_by_year' locality.code year.year %}">{{ year.year }}</a>
                           {% else %}
-                            <a class="text-decoration-none"
-                               href="{% url 'gazettes_by_year' year.year %}">{{ year.year }}</a>
+                            <a href="{% url 'gazettes_by_year' year.year %}">{{ year.year }}</a>
                           {% endif %}
                         {% endblock %}
                       </h2>
-                      <p class="status-up">
-                        <i class="fas fa-signal" aria-hidden="true"></i>
+                      <div class="text-center mb-2">
                         {% blocktrans trimmed count num_gazettes=year.count %}
                           {{ num_gazettes }} gazette
                         {% plural %}
                           {{ num_gazettes }} gazettes
                         {% endblocktrans %}
-                      </p>
+                      </div>
                     </div>
-                    <div data-year="{{ year.month }}" class="monthly-chart"></div>
+                    {% if locality %}
+                      {% url 'gazettes_by_year' locality.code year.year as url %}
+                    {% else %}
+                      {% url 'gazettes_by_year' year.year as url %}
+                    {% endif %}
+                    {% include 'peachjam/_monthly_column_chart.html' %}
                   </div>
                 {% endfor %}
               </div>

--- a/peachjam/templates/peachjam/gazette_year.html
+++ b/peachjam/templates/peachjam/gazette_year.html
@@ -21,30 +21,52 @@
         </nav>
       {% endblock %}
       {% block page-title %}
-        <h1 class="my-4">{% trans 'Gazettes' %} - {{ year }}</h1>
+        <h1 class="mt-4">{% trans 'Gazettes' %} - {{ year }}</h1>
+      {% endblock %}
+      {% block document-count %}
+        <p class="text-muted mb-4">
+          {% blocktrans trimmed count doc_count=doc_count %}
+            {{ doc_count }} gazette
+          {% plural %}
+            {{ doc_count }} gazettes
+          {% endblocktrans %}
+        </p>
       {% endblock %}
       {% include "peachjam/_years_list.html" %}
       {% include "peachjam/_quick_search.html" %}
     </header>
     <div class="my-4">
       {% block content %}
-        {% for month, items in gazettes %}
-          {% if items %}
-            <h2 class="sans-serif" id="{{ forloop.counter }}">{{ month }} {{ year }}</h2>
-            <ul>
+        <div class="row">
+          <div class="col col-md-4 my-3">{% include 'peachjam/_monthly_column_chart.html' with url='' year=years.0 %}</div>
+        </div>
+        <table class="table table-borderless table-sm">
+          {% for month, items in gazettes %}
+            {% if items %}
+              <tr>
+                <td>
+                  <h2 class="mt-3" id="{{ forloop.counter }}">{{ month }} {{ year }}</h2>
+                </td>
+              </tr>
               {% for gazette in items %}
-                <li>
-                  <a href="{{ gazette.get_absolute_url }}">{{ gazette.title }}</a>
-                  <span class="text-muted m-0">
-                    &nbsp;({{ gazette.source_file.size|filesizeformat }},
-                    <a href="{% url 'document_source_pdf' frbr_uri=gazette.expression_frbr_uri|strip_first_character %}"
-                       target="_blank">PDF</a>)
-                  </span>
-                </li>
+                <tr>
+                  <td>
+                    <a href="{{ gazette.get_absolute_url }}">{{ gazette.title }}</a>
+                  </td>
+                  <td>
+                    <span class="d-none d-lg-block">{{ gazette.sub_publication|default:'' }}</span>
+                  </td>
+                  <td>
+                    <span class="d-none d-lg-block">{{ gazette.number }}</span>
+                  </td>
+                  <td>
+                    <span class="d-none d-lg-block">{{ gazette.date|date:"Y-m-d" }}</span>
+                  </td>
+                </tr>
               {% endfor %}
-            </ul>
-          {% endif %}
-        {% endfor %}
+            {% endif %}
+          {% endfor %}
+        </table>
       {% endblock %}
     </div>
     {% include "peachjam/_years_list.html" %}

--- a/peachjam/templates/peachjam/gazette_year.html
+++ b/peachjam/templates/peachjam/gazette_year.html
@@ -23,17 +23,19 @@
       {% block page-title %}
         <h1 class="mt-4">{% trans 'Gazettes' %} - {{ year }}</h1>
       {% endblock %}
-      {% block document-count %}
-        <p class="text-muted mb-4">
-          {% blocktrans trimmed count doc_count=doc_count %}
-            {{ doc_count }} gazette
-          {% plural %}
-            {{ doc_count }} gazettes
-          {% endblocktrans %}
-        </p>
+      {% block preamble %}
+        {% block document-count %}
+          <p class="text-muted mb-4">
+            {% blocktrans trimmed count doc_count=doc_count %}
+              {{ doc_count }} gazette
+            {% plural %}
+              {{ doc_count }} gazettes
+            {% endblocktrans %}
+          </p>
+        {% endblock %}
+        {% include "peachjam/_years_list.html" %}
+        {% include "peachjam/_quick_search.html" %}
       {% endblock %}
-      {% include "peachjam/_years_list.html" %}
-      {% include "peachjam/_quick_search.html" %}
     </header>
     <div class="my-4">
       {% block content %}

--- a/peachjam/views/gazette.py
+++ b/peachjam/views/gazette.py
@@ -1,5 +1,4 @@
 from itertools import groupby
-from operator import itemgetter
 
 from django.db.models import Count
 from django.db.models.functions import ExtractMonth, ExtractYear
@@ -14,22 +13,49 @@ from peachjam.registry import registry
 from peachjam.views.generic_views import BaseDocumentDetailView, DocumentListView
 
 
-def group_years(years, locality={}):
-    # sort list of years
-    years.sort(key=lambda x: x["year"], reverse=True)
-
+def year_and_month_aggs(queryset, locality=None):
+    """Group and count items by year and month."""
     results = []
-    # group list of years dict by year
-    for key, value in groupby(years, key=itemgetter("year")):
-        year_dict = {
-            "year": key,
-            "count": sum(int(x["count"]) for x in value),
-            "url": reverse(
-                "gazettes_by_year",
-                args=[locality.code, key] if locality else [key],
-            ),
-        }
-        results.append(year_dict)
+
+    items = list(
+        queryset.annotate(
+            year=ExtractYear("date"), month=ExtractMonth("date"), count=Count("pk")
+        ).values("year", "month", "count")
+    )
+
+    # sort by years and months
+    items.sort(key=lambda x: x["year"], reverse=True)
+    for year, year_group in groupby(items, key=lambda x: x["year"]):
+        year_group = list(year_group)
+
+        month_counts = [0] * 12
+        for month, month_group in groupby(
+            sorted(year_group, key=lambda x: x["month"]), key=lambda x: x["month"]
+        ):
+            month_counts[month - 1] = sum(x["count"] for x in month_group)
+
+        months = [
+            {
+                "month": month,
+                "label": MONTHS[month],
+                "count": count,
+            }
+            for month, count in enumerate(month_counts, 1)
+        ]
+
+        results.append(
+            {
+                "year": year,
+                "count": sum(x["count"] for x in year_group),
+                "months": months,
+                "month_max": max(month_counts),
+                "url": reverse(
+                    "gazettes_by_year",
+                    args=[locality.code, year] if locality else [year],
+                ),
+            }
+        )
+
     return results
 
 
@@ -68,19 +94,11 @@ class GazetteListView(TemplateView):
             # counts and years for gazettes at the top-level?
             queryset = queryset.filter(locality=None)
 
-        context["num_gazettes"] = queryset.count()
-        context["years"] = self.get_year_stats(queryset)
+        context["years"] = year_and_month_aggs(queryset, self.locality)
+        context["doc_count"] = queryset.count()
         context["doc_type"] = "Gazette"
 
         return context
-
-    def get_year_stats(self, queryset):
-        years = list(
-            queryset.annotate(
-                year=ExtractYear("date"), month=ExtractMonth("date"), count=Count("pk")
-            ).values("year", "month", "count")
-        )
-        return group_years(years)
 
 
 class GazetteYearView(DocumentListView):
@@ -106,20 +124,12 @@ class GazetteYearView(DocumentListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        years = list(
-            self.get_base_queryset()
-            .annotate(
-                year=ExtractYear("date"),
-                count=Count("pk"),
-            )
-            .values("year", "count")
-        )
-        context["years"] = group_years(years, self.locality)
         context["locality"] = self.locality
-
         context["gazettes"] = self.group_gazettes(list(self.object_list))
         context["year"] = int(self.kwargs["year"])
+        context["years"] = year_and_month_aggs(self.object_list, self.locality)
         context["doc_type"] = "Gazette"
+        context["doc_count"] = len(self.object_list)
 
         return context
 


### PR DESCRIPTION
This improves the gazettes listing views in a few ways:

* charts (inspired by gazettes.africa but implemented in html rather than js)
* gazettes are listed in tables to make the number and date stand out
* charts and improved layout on the jurisdiction page

![image](https://github.com/laws-africa/peachjam/assets/4178542/31eb8497-0546-461e-b35d-a8de49ee2fdb)

![image](https://github.com/laws-africa/peachjam/assets/4178542/873f5db5-f91a-46d4-ab4e-ae91d5de26c4)


![image](https://github.com/laws-africa/peachjam/assets/4178542/587fab18-e09a-4749-9030-12549b49571d)

