### PR TITLE
decorate sentry events AND errors

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -342,6 +342,7 @@ if not DEBUG:
         dsn=PEACHJAM["SENTRY_DSN_KEY"],
         environment=PEACHJAM["SENTRY_ENVIRONMENT"],
         integrations=[DjangoIntegration(), sentry_logging],
+        before_send=before_send,
         before_send_transaction=before_send,
         send_default_pii=True,
         # sample x% of requests for performance metrics


### PR DESCRIPTION
before_send is called for errors
before_send_transaction is called for non-errors

this fixes an issue where app_name is not set on errors sent to sentry.