### PR TITLE
When generating a TOC for HTML documents, don't generate entries for headings without text

### DIFF
--- a/peachjam/js/utils/function.ts
+++ b/peachjam/js/utils/function.ts
@@ -55,6 +55,7 @@ export function generateHtmlTocItems (content: HTMLElement): TOCItemType[] {
   const ids = new Map<string, number>();
 
   content.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5').forEach((heading) => {
+    if (!heading.innerText) return;
     if (!heading.id) {
       ids.set(heading.tagName, (ids.get(heading.tagName) || 0) + 1);
       heading.id = heading.tagName + '_' + ids.get(heading.tagName);


### PR DESCRIPTION
Closes #1736 
<img width="319" alt="Screenshot 2024-03-07 at 11 24 59" src="https://github.com/laws-africa/peachjam/assets/52611827/a93aa17c-73fb-4bc3-9803-c6c98776161a">
<img width="304" alt="Screenshot 2024-03-07 at 11 32 46" src="https://github.com/laws-africa/peachjam/assets/52611827/b8e99216-3b3d-46d8-9785-bdef02cc8b14">
