### PR TITLE
Change matomo site search tracking to use trackSiteSearch

### DIFF
--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -659,17 +659,16 @@ export default {
 
     trackSearch (params) {
       const keywords = [];
+      const facets = [];
+      const fields = this.facets.map(facet => facet.name).concat(['date__range', 'date__gte', 'date__lte']);
+
       params.forEach((value, key) => {
         if (key.startsWith('search')) {
           const s = key === 'search' ? '' : (key.substring(8) + '=');
-          keywords.push(s + value.strip());
+          keywords.push(s + value.trim());
+        } else if (fields.includes(key)) {
+          facets.push(`${key}=${params.getAll(key).join(',')}`);
         }
-      });
-
-      const facets = [];
-      const fields = this.facets.map(f => f.name).concat('date__range', 'date__gte', 'date__lte');
-      fields.forEach(facet => {
-        if (params.has(facet)) facets.push(`${facet}=` + params.getAll(facet).join(';'));
       });
 
       analytics.trackSiteSearch(keywords.join('; '), facets.join('; '), this.searchInfo.count);

--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -500,7 +500,7 @@ export default {
       // load state from URL
       const params = new URLSearchParams(window.location.search);
       // skip the first event if there's a query, because the page load will already have sent it
-      this.q = (params.get('q') || '').trim();
+      this.q = params.get('q') || '';
       this.page = parseInt(params.get('page')) || this.page;
       this.ordering = params.get('ordering') || this.ordering;
 
@@ -624,13 +624,14 @@ export default {
         try {
           const params = this.generateSearchParams().toString();
           const url = `/search/api/documents/?${params}`;
+          let searchParams;
           if (pushState) {
+            searchParams = this.serialiseState();
             window.history.pushState(
               null,
               '',
-              document.location.pathname + '?' + this.serialiseState()
+              document.location.pathname + '?' + searchParams
             );
-            analytics.trackPageView();
           }
           const response = await fetch(url);
 
@@ -639,6 +640,9 @@ export default {
             if (response.ok) {
               this.error = null;
               this.searchInfo = await response.json();
+              if (searchParams) {
+                analytics.trackSiteSearch(searchParams, this.searchInfo.count);
+              }
               if (this.searchInfo.count === 0) {
                 this.clearAllFilters();
               }

--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -662,11 +662,13 @@ export default {
       const facets = [];
       const fields = this.facets.map(facet => facet.name).concat(['date__range', 'date__gte', 'date__lte']);
 
+      let currentKey = '';
       params.forEach((value, key) => {
         if (key.startsWith('search')) {
           const s = key === 'search' ? '' : (key.substring(8) + '=');
           keywords.push(s + value.trim());
-        } else if (fields.includes(key)) {
+        } else if (fields.includes(key) && key !== currentKey) {
+          currentKey = key;
           facets.push(`${key}=${params.getAll(key).join(',')}`);
         }
       });

--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -662,13 +662,11 @@ export default {
       const facets = [];
       const fields = this.facets.map(facet => facet.name).concat(['date__range', 'date__gte', 'date__lte']);
 
-      let currentKey = '';
-      params.forEach((value, key) => {
+      [...new Set(params.keys())].forEach((key) => {
         if (key.startsWith('search')) {
           const s = key === 'search' ? '' : (key.substring(8) + '=');
-          keywords.push(s + value.trim());
-        } else if (fields.includes(key) && key !== currentKey) {
-          currentKey = key;
+          keywords.push(s + params.get(key).trim());
+        } else if (fields.includes(key)) {
           facets.push(`${key}=${params.getAll(key).join(',')}`);
         }
       });

--- a/peachjam/js/components/analytics.ts
+++ b/peachjam/js/components/analytics.ts
@@ -21,6 +21,11 @@ export class Analytics {
     this.paq.push(['trackPageView']);
     this.gtag('event', 'page_view');
   }
+
+  trackSiteSearch (keyword: string, searchCount: number) {
+    this.paq.push(['trackSiteSearch', keyword, false, searchCount]);
+    this.gtag('event', 'site_search', { keyword, searchCount });
+  }
 }
 
 const analytics = new Analytics();

--- a/peachjam/js/components/analytics.ts
+++ b/peachjam/js/components/analytics.ts
@@ -22,9 +22,9 @@ export class Analytics {
     this.gtag('event', 'page_view');
   }
 
-  trackSiteSearch (keyword: string, searchCount: number) {
-    this.paq.push(['trackSiteSearch', keyword, false, searchCount]);
-    this.gtag('event', 'site_search', { keyword, searchCount });
+  trackSiteSearch (keyword: string, category: string, searchCount: number) {
+    this.paq.push(['trackSiteSearch', keyword, category, searchCount]);
+    this.gtag('event', 'site_search', { keyword, category, searchCount });
   }
 }
 


### PR DESCRIPTION
Since the URL params contain both keywords and facets, I figured the easiest way to track would be to use the entire params as the keyword like this:
` 
      this.paq.push(['trackSiteSearch', keyword, false, searchCount]);
`
If you'd rather I destructure it instead, please let me know.
Closes #1757 