### PR TITLE
don't lose embedded /akn citations from markdown docs

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -22,7 +22,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from import_export.admin import ImportExportMixin as BaseImportExportMixin
 from languages_plus.models import Language
-from martor.utils import markdownify
 from nonrelated_inlines.admin import NonrelatedTabularInline
 from treebeard.admin import TreeAdmin
 from treebeard.forms import MoveNodeForm, movenodeform_factory
@@ -1024,7 +1023,7 @@ class BookAdmin(DocumentAdmin):
 
     def save_model(self, request, obj, form, change):
         if "content_markdown" in form.changed_data:
-            obj.content_html = markdownify(form.cleaned_data["content_markdown"])
+            obj.convert_content_markdown()
 
         resp = super().save_model(request, obj, form, change)
 

--- a/peachjam/models/journals_books.py
+++ b/peachjam/models/journals_books.py
@@ -1,5 +1,6 @@
 from django.db import models
 from martor.models import MartorField
+from martor.utils import markdownify
 
 from peachjam.models import CoreDocument, DocumentNature
 
@@ -7,6 +8,15 @@ from peachjam.models import CoreDocument, DocumentNature
 class Book(CoreDocument):
     publisher = models.CharField(max_length=2048)
     content_markdown = MartorField(blank=True, null=True)
+
+    def delete_citations(self):
+        super().delete_citations()
+        # reset the HTML back to the original from markdown, because delete_citations()
+        # removes any embedded akn links
+        self.convert_content_markdown()
+
+    def convert_content_markdown(self):
+        self.content_html = markdownify(self.content_markdown)
 
     def pre_save(self):
         self.frbr_uri_doctype = "doc"


### PR DESCRIPTION
when re-extracting citations from markdown docs, we don't want to lose any existing /akn citations that may already be in place.

in time, we probably want to guard against this in all document types, but having /akn refs in non-markdown (and non-AKN) docs is very rare.

This allows our law reader books to have /akn refs baked into them.