### PR TITLE
merge highlights for provisions/pages .exact field with main field

### DIFF
--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -55,7 +55,7 @@ class MainSearchBackend(BaseSearchFilterBackend):
     pages_inner_hits = {
         "_source": ["pages.page_num"],
         "highlight": {
-            "fields": {"pages.body": {}},
+            "fields": {"pages.body": {}, "pages.body.exact": {}},
             "pre_tags": ["<mark>"],
             "post_tags": ["</mark>"],
             "fragment_size": 80,
@@ -71,7 +71,7 @@ class MainSearchBackend(BaseSearchFilterBackend):
             "provisions.parent_ids",
         ],
         "highlight": {
-            "fields": {"provisions.body": {}},
+            "fields": {"provisions.body": {}, "provisions.body.exact": {}},
             "pre_tags": ["<mark>"],
             "post_tags": ["</mark>"],
             "fragment_size": 80,


### PR DESCRIPTION
for some searches, particularly advanced searches, the match is on the .exact field. If we don't highlight that field, we don't get highlights. To make the client's work easier, we merge highlights from pages.body.exact into pages.body (for example), if a highlight doesn't already exist.