### PR TITLE
re-extract citations on weekends, show background tasks

### DIFF
--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -796,7 +796,7 @@ class SourceFile(AttachmentAbstractModel):
         from peachjam.tasks import convert_source_file_to_pdf
 
         if self.mimetype != "application/pdf" and not self.file_as_pdf:
-            convert_source_file_to_pdf(self.id)
+            convert_source_file_to_pdf(self.id, creator=self.document)
 
     def filename_extension(self):
         return os.path.splitext(self.filename)[1][1:]

--- a/peachjam/tasks.py
+++ b/peachjam/tasks.py
@@ -124,7 +124,8 @@ def run_ingestor(ingestor_id):
         log.info("Ingestor not enabled, ignoring.")
 
 
-@background(queue="peachjam", remove_existing_tasks=True)
+# this can be slow and is not urgent, run at a lower priority
+@background(queue="peachjam", remove_existing_tasks=True, schedule={"priority": -1})
 def extract_citations(document_id):
     """Extract citations from a document in the background."""
 


### PR DESCRIPTION
* run re-extract citation tasks on a saturday at a random hour
* associated document background tasks with their document
* show background tasks in the document admin for easier debugging
* run some tasks at a lower priority

![image](https://github.com/laws-africa/peachjam/assets/4178542/157e92b8-a893-44f7-ac14-f484fcbd6b64)
