### PR TITLE
Responsible document table and improved legislation listing

### DIFF
--- a/lawlibrary/views/legislation.py
+++ b/lawlibrary/views/legislation.py
@@ -54,6 +54,6 @@ class LocalityLegislationListView(BaseLocalityLegislationListView):
             )
             self.navbar_link = "legislation/municipal"
             context["breadcrumb_link"] = reverse("municipal_legislation")
-            context["legislation_list_show_dates"] = True
+            context["doc_table_citations"] = False
 
         return context

--- a/liiweb/templates/liiweb/legislation_list.html
+++ b/liiweb/templates/liiweb/legislation_list.html
@@ -60,7 +60,7 @@
         <div class="alert alert-danger">{% trans 'You are viewing repealed legislation which is no longer in force.' %}</div>
       {% endif %}
       <div data-vue-component="LegislationTable"
-           {% if legislation_list_show_dates %}data-show-dates="true"{% endif %}>
+           {% if not doc_table_citations %}data-hide-citations="true"{% endif %}>
         {% comment %}
         This ensures that peachjam has links to scrape. This content is replaced when the javacript LegislationTable
         component runs.

--- a/liiweb/templates/liiweb/legislation_list.html
+++ b/liiweb/templates/liiweb/legislation_list.html
@@ -60,6 +60,7 @@
         <div class="alert alert-danger">{% trans 'You are viewing repealed legislation which is no longer in force.' %}</div>
       {% endif %}
       <div data-vue-component="LegislationTable"
+           data-initial-sort="{{ legislation_list_sort }}"
            {% if not doc_table_citations %}data-hide-citations="true"{% endif %}>
         {% comment %}
         This ensures that peachjam has links to scrape. This content is replaced when the javacript LegislationTable

--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -14,7 +14,7 @@ class LegislationListView(TemplateView):
     variant = "current"
     navbar_link = "legislation"
     model = Legislation
-    extra_context = {"doc_table_citations": True}
+    extra_context = {"doc_table_citations": True, "legislation_list_sort": "title"}
 
     def get_queryset(self):
         qs = (

--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -14,6 +14,7 @@ class LegislationListView(TemplateView):
     variant = "current"
     navbar_link = "legislation"
     model = Legislation
+    extra_context = {"doc_table_citations": True}
 
     def get_queryset(self):
         qs = (

--- a/open_by_laws/views/by_laws.py
+++ b/open_by_laws/views/by_laws.py
@@ -3,4 +3,4 @@ from liiweb.views.legislation import LocalityLegislationListView
 
 class MunicipalByLawsView(LocalityLegislationListView):
     template_name = "open_by_laws/municipal_by_laws_list.html"
-    extra_context = {"legislation_list_show_dates": True}
+    extra_context = {"doc_table_citations": False}

--- a/peachjam/js/components/LegislationTable/TableRow.vue
+++ b/peachjam/js/components/LegislationTable/TableRow.vue
@@ -4,7 +4,7 @@
     role="button"
     @click="handleRowClick"
   >
-    <div class="doc-table-cell cell-title">
+    <div class="doc-table-cell cell-toggle">
       <div
         v-if="row.children && row.children.length"
         class="indent"
@@ -14,15 +14,14 @@
         <i class="bi bi-caret-right-fill" />
         <i class="bi bi-caret-down-fill" />
       </div>
-      <div v-else class="indent"/>
-      <div class="title">
-        <a :href="`${row.work_frbr_uri}`">{{ row.title }}</a>
-        <i
-          v-if="row.languages != null && row.languages.length > 1"
-          class="bi bi-translate ps-2"
-          :title="$t('Multiple languages available')"
-        />
-      </div>
+    </div>
+    <div class="doc-table-cell cell-title">
+      <a :href="`${row.work_frbr_uri}`">{{ row.title }}</a>
+      <i
+        v-if="row.languages != null && row.languages.length > 1"
+        class="bi bi-translate ps-2"
+        :title="$t('Multiple languages available')"
+      />
     </div>
     <div class="doc-table-cell cell-subtitle">
       {{ row.citation }}

--- a/peachjam/js/components/LegislationTable/TableRow.vue
+++ b/peachjam/js/components/LegislationTable/TableRow.vue
@@ -22,6 +22,15 @@
         class="bi bi-translate ps-2"
         :title="$t('Multiple languages available')"
       />
+      <div v-if="row.labels.length" class="d-flex align-items-center">
+        <span
+          v-for="(label, index) in row.labels"
+          :key="index"
+          :class="`badge rounded-pill bg-${label.level}`"
+        >
+          {{ label.name }}
+        </span>
+      </div>
     </div>
     <div v-if="!hideCitation" class="doc-table-cell cell-citation">
       {{ row.citation }}

--- a/peachjam/js/components/LegislationTable/TableRow.vue
+++ b/peachjam/js/components/LegislationTable/TableRow.vue
@@ -23,7 +23,7 @@
         :title="$t('Multiple languages available')"
       />
     </div>
-    <div class="doc-table-cell cell-subtitle">
+    <div v-if="!hideCitation" class="doc-table-cell cell-citation">
       {{ row.citation }}
     </div>
     <div class="doc-table-cell cell-date">
@@ -35,7 +35,7 @@
 <script>
 export default {
   name: 'TableRow',
-  props: ['row'],
+  props: ['row', 'hideCitation'],
   emits: ['toggle']
 };
 </script>

--- a/peachjam/js/components/LegislationTable/TableRow.vue
+++ b/peachjam/js/components/LegislationTable/TableRow.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    :class="`doc-table-row ${row.children && row.children.length ? 'has-children' : ''}`"
+    role="button"
+    @click="handleRowClick"
+  >
+    <div class="doc-table-cell cell-title">
+      <div
+        v-if="row.children && row.children.length"
+        class="indent"
+        role="button"
+        @click="$emit('toggle')"
+      >
+        <i class="bi bi-caret-right-fill" />
+        <i class="bi bi-caret-down-fill" />
+      </div>
+      <div v-else class="indent"/>
+      <div class="title">
+        <a :href="`${row.work_frbr_uri}`">{{ row.title }}</a>
+        <i
+          v-if="row.languages != null && row.languages.length > 1"
+          class="bi bi-translate ps-2"
+          :title="$t('Multiple languages available')"
+        />
+      </div>
+    </div>
+    <div class="doc-table-cell cell-subtitle">
+      {{ row.citation }}
+    </div>
+    <div class="doc-table-cell cell-date">
+      {{ row.year }}
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TableRow',
+  props: ['row'],
+  emits: ['toggle']
+};
+</script>

--- a/peachjam/js/components/LegislationTable/TableRow.vue
+++ b/peachjam/js/components/LegislationTable/TableRow.vue
@@ -1,10 +1,10 @@
 <template>
-  <div
-    :class="`doc-table-row ${row.children && row.children.length ? 'has-children' : ''}`"
+  <tr
+    :class="`${row.children && row.children.length ? 'has-children' : ''}`"
     role="button"
     @click="handleRowClick"
   >
-    <div class="doc-table-cell cell-toggle">
+    <td class="cell-toggle">
       <div
         v-if="row.children && row.children.length"
         class="indent"
@@ -14,8 +14,8 @@
         <i class="bi bi-caret-right-fill" />
         <i class="bi bi-caret-down-fill" />
       </div>
-    </div>
-    <div class="doc-table-cell cell-title">
+    </td>
+    <td class="cell-title">
       <a :href="`${row.work_frbr_uri}`">{{ row.title }}</a>
       <i
         v-if="row.languages != null && row.languages.length > 1"
@@ -31,14 +31,14 @@
           {{ label.name }}
         </span>
       </div>
-    </div>
-    <div v-if="!hideCitation" class="doc-table-cell cell-citation">
+    </td>
+    <td v-if="!hideCitation" class="cell-citation">
       {{ row.citation }}
-    </div>
-    <div class="doc-table-cell cell-date">
+    </td>
+    <td class="cell-date">
       {{ row.year }}
-    </div>
-  </div>
+    </td>
+  </tr>
 </template>
 
 <script>

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -55,11 +55,11 @@
           {{ filteredData.length }} of {{ tableData.length }} documents
         </div>
         <div v-if="filteredData.length" class="doc-table doc-table-title-subtitle-date">
-          <div class="doc-table-row doc-table-header">
+          <div class="doc-table-row doc-table-head">
+            <div class="doc-table-cell cell-toggle"></div>
             <div class="doc-table-cell cell-title">
-              <div class="indent" />
               <div
-                class="title align-items-center"
+                class="align-items-center"
                 role="button"
                 @click="updateSort('title')"
               >
@@ -113,6 +113,7 @@
           >
             <template v-if="row.heading != null">
               <div class="doc-table-row">
+                <div class="doc-table-cell cell-toggle" />
                 <div class="doc-table-cell cell-group">
                   {{ row.heading }}
                 </div>
@@ -149,8 +150,8 @@
           >
             {{ $t('Try searching instead') }}
           </a>.
+        </div>
       </div>
-    </div>
     </div>
     <!-- DOM Hack for i18next to parse facet to locale json. i18next skips t functions in script element -->
     <div v-if="false">
@@ -387,85 +388,3 @@ export default {
   }
 };
 </script>
-
-<style scoped>
-.legislation-table__row {
-  padding: 0.25rem;
-  border-bottom: 1px solid var(--bs-gray-200);
-  cursor: default !important;
-  transition: background-color 300ms ease-in-out;
-}
-
-.legislation-table__row.has-children {
-  cursor: pointer !important;
-}
-
-.legislation-table__row.has-children:hover {
-  background-color: var(--bs-light);
-}
-
-.legislation-table__row.headings {
-  border-bottom: 1px solid var(--bs-primary);
-}
-
-.legislation-table__row.headings i {
-  font-size: 18px;
-}
-
-.column-caret {
-  text-align: center;
-}
-
-.legislation-table__row .column-caret .bi-caret-down-fill {
-  display: none;
-}
-
-.legislation-table__row.expanded .column-caret .bi-caret-down-fill {
-  display: block;
-}
-
-.legislation-table__row.expanded .column-caret .bi-caret-right-fill {
-  display: none;
-}
-
-.table-row__content-col {
-  flex: 1;
-}
-
-.table-row {
-  display: flex;
-  width: 100%;
-  flex-wrap: wrap;
-}
-
-.table-row .content {
-  display: grid;
-  grid-gap: 1rem;
-  grid-template-columns: repeat(12, 1fr);
-}
-
-.content__children {
-  grid-column: span 12;
-  margin-top: 10px;
-}
-
-.content__children .content__title {
-  padding-left: 1rem;
-}
-
-.content__title {
-  grid-column: span 8;
-}
-
-.content__secondary {
-  grid-column: span 4;
-}
-
-.legislation-table.with-dates .content__title {
-  grid-column: span 6;
-}
-
-.legislation-table.with-dates .content__secondary {
-  grid-column: span 3;
-}
-</style>

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -160,8 +160,8 @@ export default {
     FilterFacets,
     TableRow
   },
-  props: ['hideCitations'],
-  data: () => ({
+  props: ['hideCitations', 'initialSort'],
+  data: (x) => ({
     offCanvasFacets: null,
     facets: [],
     tableData: [],
@@ -169,8 +169,8 @@ export default {
     rows: [],
     lockAccordion: false,
     q: '',
-    windowWith: window.innerWidth,
-    sort: 'title'
+    sort: x.initialSort || 'title',
+    windowWith: window.innerWidth
   }),
   watch: {
     q () {

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -108,7 +108,7 @@
               v-else
               :id="`row-${index}`"
               :row="row"
-              :hideCitation="hideCitations"
+              :hide-citation="hideCitations"
               @toggle="toggleChildren(index)"
             />
             <template v-if="row.children && row.children.length">
@@ -120,7 +120,7 @@
                   v-for="(child, childIndex) in row.children"
                   :key="childIndex"
                   :row="child"
-                  :hideCitation="hideCitations"
+                  :hide-citation="hideCitations"
                 />
               </tbody>
             </template>

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -64,7 +64,7 @@
         <div class="mb-3">
           {{ filteredData.length }} of {{ tableData.length }} documents
         </div>
-        <div v-if="filteredData.length" class="doc-table doc-table-title-subtitle-date">
+        <div v-if="filteredData.length" :class="`doc-table ${docTableClass}`">
           <div class="doc-table-row doc-table-head">
             <div class="doc-table-cell cell-toggle"/>
             <div class="doc-table-cell cell-title">
@@ -78,7 +78,7 @@
                 <i v-if="sort === '-title'" class="bi bi-sort-down ms-2" />
               </div>
             </div>
-            <div class="doc-table-cell cell-subtitle"/>
+            <div v-if="!hideCitations" class="doc-table-cell cell-citation" />
             <div class="doc-table-cell cell-date">
               <div
                 role="button"
@@ -106,6 +106,7 @@
               v-else
               :id="`row-${index}`"
               :row="row"
+              :hideCitation="hideCitations"
               @toggle="toggleChildren(index)"
             />
             <template v-if="row.children && row.children.length">
@@ -117,6 +118,7 @@
                   v-for="(child, childIndex) in row.children"
                   :key="childIndex"
                   :row="child"
+                  :hideCitation="hideCitations"
                 />
               </div>
             </template>
@@ -156,7 +158,7 @@ export default {
     FilterFacets,
     TableRow
   },
-  props: ['showDates'],
+  props: ['hideCitations'],
   data: () => ({
     offCanvasFacets: null,
     facets: [],
@@ -195,7 +197,11 @@ export default {
     this.filterData();
     this.setFacets();
   },
-
+  computed: {
+    docTableClass () {
+      return this.hideCitations ? 'doc-table-toggle-title-date' : 'doc-table-toggle-title-citation-date';
+    }
+  },
   methods: {
     toggleChildren (index) {
       const row = document.getElementById(`row-${index}`);

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -64,43 +64,45 @@
         <div class="mb-3">
           {{ filteredData.length }} of {{ tableData.length }} documents
         </div>
-        <div v-if="filteredData.length" :class="`doc-table ${docTableClass}`">
-          <div class="doc-table-row doc-table-head">
-            <div class="doc-table-cell cell-toggle"/>
-            <div class="doc-table-cell cell-title">
-              <div
-                class="align-items-center"
-                role="button"
-                @click="updateSort('title')"
-              >
-                {{ $t('Title') }}
-                <i v-if="sort === 'title'" class="bi bi-sort-up ms-2" />
-                <i v-if="sort === '-title'" class="bi bi-sort-down ms-2" />
-              </div>
-            </div>
-            <div v-if="!hideCitations" class="doc-table-cell cell-citation" />
-            <div class="doc-table-cell cell-date">
-              <div
-                role="button"
-                @click="updateSort('year')"
-              >
-                {{ $t('Year') }}
-                <i v-if="sort === 'year'" class="bi bi-sort-up ms-2" />
-                <i v-if="sort === '-year'" class="bi bi-sort-down ms-2" />
-              </div>
-            </div>
-          </div>
+        <table v-if="filteredData.length" class="doc-table doc-table--toggle">
+          <thead>
+            <tr>
+              <th class="cell-toggle" />
+              <th class="cell-title">
+                <div
+                  class="align-items-center"
+                  role="button"
+                  @click="updateSort('title')"
+                >
+                  {{ $t('Title') }}
+                  <i v-if="sort === 'title'" class="bi bi-sort-up ms-2" />
+                  <i v-if="sort === '-title'" class="bi bi-sort-down ms-2" />
+                </div>
+              </th>
+              <th v-if="!hideCitations" class="cell-citation" />
+              <th class="cell-date">
+                <div
+                  role="button"
+                  @click="updateSort('year')"
+                >
+                  {{ $t('Year') }}
+                  <i v-if="sort === 'year'" class="bi bi-sort-up ms-2" />
+                  <i v-if="sort === '-year'" class="bi bi-sort-down ms-2" />
+                </div>
+              </th>
+            </tr>
+          </thead>
           <template
             v-for="(row, index) in rows"
             :key="index"
           >
             <template v-if="row.heading != null">
-              <div class="doc-table-row">
-                <div class="doc-table-cell cell-toggle" />
-                <div class="doc-table-cell cell-group">
+              <tr>
+                <td class="cell-toggle" />
+                <td class="cell-group" :colspan="hideCitations ? 2 : 3">
                   {{ row.heading }}
-                </div>
-              </div>
+                </td>
+              </tr>
             </template>
             <table-row
               v-else
@@ -110,7 +112,7 @@
               @toggle="toggleChildren(index)"
             />
             <template v-if="row.children && row.children.length">
-              <div
+              <tbody
                 :id="`children-${index}`"
                 class="doc-table-children collapse"
               >
@@ -120,10 +122,10 @@
                   :row="child"
                   :hideCitation="hideCitations"
                 />
-              </div>
+              </tbody>
             </template>
           </template>
-        </div>
+        </table>
         <div
           v-else
           class="p-2 text-center"
@@ -196,11 +198,6 @@ export default {
     this.tableData = JSON.parse(tableJsonElement.textContent);
     this.filterData();
     this.setFacets();
-  },
-  computed: {
-    docTableClass () {
-      return this.hideCitations ? 'doc-table-toggle-title-date' : 'doc-table-toggle-title-citation-date';
-    }
   },
   methods: {
     toggleChildren (index) {

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -58,8 +58,6 @@
               <option value="-title">{{ $t('Title') }} (Z - A)</option>
               <option value="year">{{ $t('Year') }} ({{ $t('Oldest first') }})</option>
               <option value="-year">{{ $t('Year') }} ({{ $t('Newest first') }})</option>
-              <option value="citation">{{ $t('Numbered title') }} (A - Z)</option>
-              <option value="-citation">{{ $t('Numbered title') }} (Z - A)</option>
             </select>
           </div>
         </div>
@@ -81,14 +79,6 @@
               </div>
             </div>
             <div class="doc-table-cell cell-subtitle">
-              <div
-                role="button"
-                @click="updateSort('citation')"
-              >
-                {{ $t('Numbered title') }}
-                <i v-if="sort === 'citation'" class="bi bi-sort-up ms-2" />
-                <i v-if="sort === '-citation'" class="bi bi-sort-down ms-2" />
-              </div>
             </div>
             <div class="doc-table-cell cell-date">
               <div

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -311,12 +311,10 @@ export default {
 
       const sortAsc = this.sort[0] !== '-';
       const sortKey = sortAsc ? this.sort : this.sort.substring(1);
-      data.sort((a, b) => {
-        const fa = a[sortKey] ? a[sortKey].toLowerCase() : '';
-        const fb = b[sortKey] ? b[sortKey].toLowerCase() : '';
-        // year is the exception that we want to sort desc by default
-        return fa.localeCompare(fb) * (sortAsc ? 1 : -1) * (sortKey === 'year' ? -1 : 1);
-      });
+      this.sortRows(data, sortKey, sortAsc);
+      for (const item of data) {
+        this.sortRows(item.children, sortKey, sortAsc);
+      }
       this.filteredData = data;
 
       this.rows = [];
@@ -343,6 +341,14 @@ export default {
           });
         }
         this.rows.push(record);
+      });
+    },
+    sortRows (rows, sortKey, sortAsc) {
+      rows.sort((a, b) => {
+        const fa = a[sortKey] ? a[sortKey].toLowerCase() : '';
+        const fb = b[sortKey] ? b[sortKey].toLowerCase() : '';
+        // year is the exception that we want to sort desc by default
+        return fa.localeCompare(fb) * (sortAsc ? 1 : -1) * (sortKey === 'year' ? -1 : 1);
       });
     }
   }

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -43,154 +43,114 @@
             Filters
           </button>
         </div>
-        <div :class="`card legislation-table ${showDates ? 'with-dates' : ''}`">
-          <div class="card-header">
-            <input
-              v-model="q"
-              type="text"
-              class="form-control"
-              placeholder="Filter legislation"
-            >
-          </div>
-          <div class="table-row legislation-table__row">
-            <div class="indent" />
-            <div>
-              {{ filteredData.length }} of {{ tableData.length }} documents
-            </div>
-          </div>
-          <div class="table-row legislation-table__row headings">
-            <div class="indent" />
-            <div class="table-row__content-col">
-              <div class="content">
-                <div
-                  class="content__title align-items-center"
-                  role="button"
-                  @click="updateSort('title')"
-                >
-                  <strong>{{ $t('Title') }}</strong>
-                  <i
-                    v-if="sortableFields.title === 'asc'"
-                    class="bi bi-sort-up ms-2"
-                  />
-                  <i
-                    v-if="sortableFields.title === 'desc'"
-                    class="bi bi-sort-down ms-2"
-                  />
-                </div>
-                <div
-                  v-if="!showDates"
-                  class="content__secondary"
-                  role="button"
-                  @click="updateSort('citation')"
-                >
-                  <strong>{{ $t('Numbered title') }}</strong>
-                  <i
-                    v-if="sortableFields.citation === 'asc'"
-                    class="bi bi-sort-up ms-2"
-                  />
-                  <i
-                    v-if="sortableFields.citation === 'desc'"
-                    class="bi bi-sort-down ms-2"
-                  />
-                </div>
-                <div
-                  v-if="showDates"
-                  class="content__secondary"
-                  role="button"
-                  @click="updateSort('date')"
-                >
-                  <strong>{{ $t('Date') }}</strong>
-                  <i
-                    v-if="sortableFields.date === 'asc'"
-                    class="bi bi-sort-up ms-2"
-                  />
-                  <i
-                    v-if="sortableFields.date === 'desc'"
-                    class="bi bi-sort-down ms-2"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <template v-if="filteredData.length">
-            <div
-              v-for="(row, index) in filteredData"
-              :key="index"
-              :class="`table-row legislation-table__row ${
-                row.children.length ? 'has-children' : ''
-              }`"
-              role="button"
-              @click="handleRowClick"
-            >
-              <div
-                v-if="row.children.length"
-                class="column-caret indent"
-              >
-                <i class="bi bi-caret-right-fill" />
-                <i class="bi bi-caret-down-fill" />
-              </div>
-              <div
-                v-else
-                class="indent"
-              />
-              <div class="table-row__content-col">
-                <div class="content">
-                  <div class="content__title">
-                    <a :href="`${row.work_frbr_uri}`">{{ row.title }}</a>
-                    <i
-                      v-if="row.languages.length > 1"
-                      class="bi bi-translate ps-2"
-                      :title="$t('Multiple languages available')"
-                    />
-                  </div>
-                  <div v-if="showDates" class="content__secondary">
-                    {{ row.date }}
-                  </div>
-                  <div v-else class="content__secondary">
-                    {{ row.citation }}
-                  </div>
-                  <div
-                    v-if="row.children.length"
-                    :id="`row-accordion-${index}`"
-                    class="accordion-collapse collapse accordion content__children"
-                    data-bs-parent=".legislation-table__row"
-                  >
-                    <div class="accordion-body p-0">
-                      <div
-                        v-for="(subleg, subleg_index) in row.children"
-                        :key="subleg_index"
-                        class="content mb-3"
-                      >
-                        <div class="content__title">
-                          <a :href="`${subleg.work_frbr_uri}`">{{ subleg.title }}</a>
-                        </div>
-                        <div v-if="showDates" class="content__secondary">
-                          {{ subleg.date }}
-                        </div>
-                        <div v-else class="content__secondary">
-                          {{ subleg.citation }}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </template>
-          <div
-            v-else
-            class="p-2 text-center"
+        <div class="mb-2">
+          <input
+            v-model="q"
+            type="text"
+            class="form-control"
+            :placeholder="$t('Filter legislation')"
           >
-            {{ $t('No legislation found.') }}
-            <a
-              :href="`/search/?q=${encodeURIComponent(q)}`"
-              target="_blank"
-            >
-              {{ $t('Try searching instead') }}
-            </a>.
-          </div>
         </div>
+        <div class="mb-3">
+          {{ filteredData.length }} of {{ tableData.length }} documents
+        </div>
+        <div v-if="filteredData.length" class="doc-table doc-table-title-subtitle-date">
+          <div class="doc-table-row doc-table-header">
+            <div class="doc-table-cell cell-title">
+              <div class="indent" />
+              <div
+                class="title align-items-center"
+                role="button"
+                @click="updateSort('title')"
+              >
+                {{ $t('Title') }}
+                <i
+                  v-if="sortableFields.title === 'asc'"
+                  class="bi bi-sort-up ms-2"
+                />
+                <i
+                  v-if="sortableFields.title === 'desc'"
+                  class="bi bi-sort-down ms-2"
+                />
+              </div>
+            </div>
+            <div class="doc-table-cell cell-subtitle">
+              <div
+                role="button"
+                @click="updateSort('citation')"
+              >
+                {{ $t('Numbered title') }}
+                <i
+                  v-if="sortableFields.citation === 'asc'"
+                  class="bi bi-sort-up ms-2"
+                />
+                <i
+                  v-if="sortableFields.citation === 'desc'"
+                  class="bi bi-sort-down ms-2"
+                />
+              </div>
+            </div>
+            <div class="doc-table-cell cell-date">
+              <div
+                role="button"
+                @click="updateSort('year')"
+              >
+                {{ $t('Year') }}
+                <i
+                  v-if="sortableFields.year === 'asc'"
+                  class="bi bi-sort-up ms-2"
+                />
+                <i
+                  v-if="sortableFields.year === 'desc'"
+                  class="bi bi-sort-down ms-2"
+                />
+              </div>
+            </div>
+          </div>
+          <template
+            v-for="(row, index) in rows"
+            :key="index"
+          >
+            <template v-if="row.heading != null">
+              <div class="doc-table-row">
+                <div class="doc-table-cell cell-group">
+                  {{ row.heading }}
+                </div>
+              </div>
+            </template>
+            <table-row
+              v-else
+              :id="`row-${index}`"
+              :row="row"
+              @toggle="toggleChildren(index)"
+            />
+            <template v-if="row.children && row.children.length">
+              <div
+                :id="`children-${index}`"
+                class="doc-table-children collapse"
+              >
+                <table-row
+                  v-for="(child, childIndex) in row.children"
+                  :key="childIndex"
+                  :row="child"
+                />
+              </div>
+            </template>
+          </template>
+        </div>
+        <div
+          v-else
+          class="p-2 text-center"
+        >
+          {{ $t('No legislation found.') }}
+          <a
+            :href="`/search/?q=${encodeURIComponent(q)}`"
+            target="_blank"
+          >
+            {{ $t('Try searching instead') }}
+          </a>.
       </div>
+    </div>
     </div>
     <!-- DOM Hack for i18next to parse facet to locale json. i18next skips t functions in script element -->
     <div v-if="false">
@@ -203,12 +163,14 @@
 
 <script>
 import FilterFacets from '../FilterFacets/index.vue';
+import TableRow from './TableRow.vue';
 import debounce from 'lodash/debounce';
 
 export default {
   name: 'LegislationTable',
   components: {
-    FilterFacets
+    FilterFacets,
+    TableRow
   },
   props: ['showDates'],
   data: () => ({
@@ -216,13 +178,14 @@ export default {
     facets: [],
     tableData: [],
     filteredData: [],
+    rows: [],
     lockAccordion: false,
     q: '',
     windowWith: window.innerWidth,
     sortableFields: {
       title: 'asc',
       citation: '',
-      date: ''
+      year: ''
     }
   }),
   watch: {
@@ -255,26 +218,13 @@ export default {
   },
 
   methods: {
-    handleRowClick (e) {
-      const parentRow = e.target.closest('.legislation-table__row');
-      if (!parentRow.classList.contains('has-children')) return;
-      if (
-        Array.from(parentRow.querySelectorAll('a')).some(
-          (a) => e.target === a || a.contains(e.target)
-        )
-      ) { return; }
-      if (this.lockAccordion) return;
-      const collapseElement = parentRow.querySelector('.collapse');
-      collapseElement.addEventListener('shown.bs.collapse', () => {
-        this.lockAccordion = false;
-      });
-      collapseElement.addEventListener('hidden.bs.collapse', () => {
-        this.lockAccordion = false;
-      });
-      this.lockAccordion = true;
-      // Async action
-      parentRow.classList.toggle('expanded');
-      return new window.bootstrap.Collapse(collapseElement);
+    toggleChildren (index) {
+      const row = document.getElementById(`row-${index}`);
+      const groupEl = document.getElementById(`children-${index}`);
+      if (row && groupEl) {
+        row.classList.toggle('expanded');
+        return new window.bootstrap.Collapse(groupEl, { toggle: true });
+      }
     },
     setWindowWidth: debounce(function () {
       this.windowWith = window.innerWidth;
@@ -352,7 +302,7 @@ export default {
         ...{
           title: '',
           citation: '',
-          date: ''
+          year: ''
         },
         [field]: newSortValue
       };
@@ -391,8 +341,10 @@ export default {
         });
       });
 
+      let sortKey = null;
       Object.keys(this.sortableFields).forEach((key) => {
         if (this.sortableFields[key]) {
+          sortKey = key;
           data.sort((a, b) => {
             const fa = a[key] ? a[key].toLowerCase() : '';
             const fb = b[key] ? b[key].toLowerCase() : '';
@@ -405,6 +357,32 @@ export default {
         }
       });
       this.filteredData = data;
+
+      this.rows = [];
+      // group rows for headings
+      function groupKey (record) {
+        const val = record[sortKey] || '';
+        if (sortKey === 'year') {
+          // return year
+          return val.substring(0, 4);
+        } else {
+          // letter
+          return (val && val.length) ? val[0].toUpperCase() : '';
+        }
+      }
+
+      let currentGroup = '';
+      this.filteredData.forEach((record) => {
+        const group = groupKey(record);
+        if (group !== currentGroup) {
+          currentGroup = group;
+          this.rows.push({
+            heading: group,
+            children: []
+          });
+        }
+        this.rows.push(record);
+      });
     }
   }
 };
@@ -450,10 +428,6 @@ export default {
   display: none;
 }
 
-.indent {
-  flex: 0 0 30px;
-}
-
 .table-row__content-col {
   flex: 1;
 }
@@ -488,7 +462,7 @@ export default {
 }
 
 .legislation-table.with-dates .content__title {
-  grid-column: span 9;
+  grid-column: span 6;
 }
 
 .legislation-table.with-dates .content__secondary {

--- a/peachjam/js/components/LegislationTable/index.vue
+++ b/peachjam/js/components/LegislationTable/index.vue
@@ -56,8 +56,8 @@
             <select class="form-control" v-model="sort">
               <option value="title">{{ $t('Title') }} (A - Z)</option>
               <option value="-title">{{ $t('Title') }} (Z - A)</option>
-              <option value="year">{{ $t('Year') }} ({{ $t('Oldest first') }})</option>
-              <option value="-year">{{ $t('Year') }} ({{ $t('Newest first') }})</option>
+              <option value="year">{{ $t('Year') }} ({{ $t('Newest first') }})</option>
+              <option value="-year">{{ $t('Year') }} ({{ $t('Oldest first') }})</option>
             </select>
           </div>
         </div>
@@ -66,7 +66,7 @@
         </div>
         <div v-if="filteredData.length" class="doc-table doc-table-title-subtitle-date">
           <div class="doc-table-row doc-table-head">
-            <div class="doc-table-cell cell-toggle"></div>
+            <div class="doc-table-cell cell-toggle"/>
             <div class="doc-table-cell cell-title">
               <div
                 class="align-items-center"
@@ -78,8 +78,7 @@
                 <i v-if="sort === '-title'" class="bi bi-sort-down ms-2" />
               </div>
             </div>
-            <div class="doc-table-cell cell-subtitle">
-            </div>
+            <div class="doc-table-cell cell-subtitle"/>
             <div class="doc-table-cell cell-date">
               <div
                 role="button"
@@ -315,7 +314,8 @@ export default {
       data.sort((a, b) => {
         const fa = a[sortKey] ? a[sortKey].toLowerCase() : '';
         const fb = b[sortKey] ? b[sortKey].toLowerCase() : '';
-        return fa.localeCompare(fb) * (sortAsc ? 1 : -1);
+        // year is the exception that we want to sort desc by default
+        return fa.localeCompare(fb) * (sortAsc ? 1 : -1) * (sortKey === 'year' ? -1 : 1);
       });
       this.filteredData = data;
 

--- a/peachjam/static/stylesheets/components/_index.scss
+++ b/peachjam/static/stylesheets/components/_index.scss
@@ -9,6 +9,7 @@
 @import "letter-radiobox";
 @import "loaders";
 @import "navs";
+@import "tables";
 @import "terms-of-use";
 @import "text";
 @import "timeline";

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -1,0 +1,75 @@
+.doc-table {
+  .doc-table-row {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 0rem 1rem;
+
+    border-bottom-style: solid;
+    border-bottom-color: var(--bs-border-color);
+    border-bottom-width: var(--bs-border-width);
+
+    &.has-children .bi-caret-down-fill { display: none; }
+    &.has-children.expanded {
+      .bi-caret-right-fill { display: none; }
+      .bi-caret-down-fill { display: inline; }
+    }
+  }
+
+  .doc-table-cell {
+    padding: 0.5rem;
+  }
+
+  .doc-table-header {
+    font-weight: bold;
+  }
+
+  .cell-group {
+    grid-column: span 3;
+    font-weight: bold;
+    margin-left: 20px;
+  }
+
+  .cell-title {
+    display: flex;
+
+    .indent {
+      flex: 0 0 20px;
+    }
+
+    .title {
+      flex-grow: 1;
+    }
+  }
+
+  .doc-table-children {
+    .cell-title .title {
+      padding-left: 20px;
+    }
+  }
+
+  // sizing for different groups of columns
+
+  &.doc-table-title-subtitle-date {
+    .cell-title {
+      grid-column: span 7;
+    }
+
+    .cell-subtitle {
+      grid-column: span 3;
+    }
+
+    .cell-date {
+      grid-column: span 2;
+    }
+  }
+
+}
+
+@include media-breakpoint-up(md) {
+  .doc-table {
+    //grid-template-columns: repeat(3, 1fr);
+
+    .doc-table-row {
+    }
+  }
+}

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -1,49 +1,43 @@
 .doc-table {
   .doc-table-row {
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    gap: 0rem 1rem;
+    grid-template-columns: 15px repeat(12, 1fr);
+    gap: 0rem 0.5rem;
+    padding: 0.5rem 0;
 
     border-bottom-style: solid;
     border-bottom-color: var(--bs-border-color);
     border-bottom-width: var(--bs-border-width);
 
-    &.has-children .bi-caret-down-fill { display: none; }
+    &.has-children .bi-caret-down-fill {
+      display: none;
+    }
+
     &.has-children.expanded {
-      .bi-caret-right-fill { display: none; }
-      .bi-caret-down-fill { display: inline; }
+      .bi-caret-right-fill {
+        display: none;
+      }
+
+      .bi-caret-down-fill {
+        display: inline;
+      }
     }
   }
 
-  .doc-table-cell {
-    padding: 0.5rem;
-  }
-
-  .doc-table-header {
+  .doc-table-head {
     font-weight: bold;
+    border-bottom-color: $primary;
   }
 
   .cell-group {
-    grid-column: span 3;
+    grid-column: span 12;
     font-weight: bold;
-    margin-left: 20px;
-  }
-
-  .cell-title {
-    display: flex;
-
-    .indent {
-      flex: 0 0 20px;
-    }
-
-    .title {
-      flex-grow: 1;
-    }
   }
 
   .doc-table-children {
-    .cell-title .title {
-      padding-left: 20px;
+    .doc-table-row {
+      // extra initial padding for child rows
+      grid-template-columns: 30px repeat(12, 1fr);
     }
   }
 
@@ -61,15 +55,30 @@
     .cell-date {
       grid-column: span 2;
     }
-  }
 
-}
+    @include media-breakpoint-down(md) {
+      .doc-table-head {
+        .cell-subtitle,
+        .cell-date {
+          display: none;
+        }
+      }
 
-@include media-breakpoint-up(md) {
-  .doc-table {
-    //grid-template-columns: repeat(3, 1fr);
+      .cell-toggle {
+        grid-row: span 2;
+      }
 
-    .doc-table-row {
+      .cell-title {
+        grid-column: span 12;
+      }
+
+      .cell-subtitle {
+        grid-column: span 10;
+      }
+
+      .cell-date {
+        grid-column: span 2;
+      }
     }
   }
 }

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -49,6 +49,8 @@ table.doc-table {
   }
 
   .doc-table-children {
+    background-color: $gray-100;
+
     .cell-title {
       padding-left: 20px;
     }
@@ -64,8 +66,8 @@ table.doc-table {
     tr {
       display: grid;
       grid-template-columns: repeat(12, 1fr);
-      gap: 0 $table-cell-padding-x;
-      padding: $table-cell-padding-x;
+      gap: 0 $table-cell-padding-x-sm;
+      padding: $table-cell-padding-x 0;
       // the row is moved to the tr, rather than the cells
       border-bottom: 1px solid $table-border-color;
     }
@@ -126,7 +128,7 @@ table.doc-table.doc-table--toggle {
 
   @include media-breakpoint-down(md) {
     tr {
-      // extra 25px for the toggle column
+      // extra space for the toggle column
       grid-template-columns: 20px repeat(12, 1fr);
     }
 

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -35,9 +35,8 @@
   }
 
   .doc-table-children {
-    .doc-table-row {
-      // extra initial padding for child rows
-      grid-template-columns: 30px repeat(12, 1fr);
+    .cell-title {
+      padding-left: 20px;
     }
   }
 
@@ -55,8 +54,21 @@
     .cell-date {
       grid-column: span 2;
     }
+  }
 
-    @include media-breakpoint-down(md) {
+  @include media-breakpoint-down(md) {
+    .doc-table-children {
+      .cell-title {
+        padding-left: 0px;
+      }
+
+      .doc-table-row {
+        // extra initial padding for child rows
+        grid-template-columns: 30px repeat(12, 1fr);
+      }
+    }
+
+    &.doc-table-title-subtitle-date {
       .doc-table-head {
         .cell-subtitle,
         .cell-date {

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -1,39 +1,51 @@
-.doc-table {
+/**
+ * This table is used for document lists and defines behavior that allows it to collapse into rows on mobile. The
+ * table acts as usual on desktop, but on mobile, each row is converted into a grid.
+ */
+table.doc-table {
+  width: 100%;
+  border-collapse: collapse;
   margin-bottom: $spacer;
 
-  .doc-table-row {
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    gap: 0rem 0.5rem;
-    padding: 0.5rem 0;
-
-    border-bottom-style: solid;
-    border-bottom-color: var(--bs-border-color);
-    border-bottom-width: var(--bs-border-width);
-
-    &.has-children .bi-caret-down-fill {
-      display: none;
-    }
-
-    &.has-children.expanded {
-      .bi-caret-right-fill {
-        display: none;
-      }
-
-      .bi-caret-down-fill {
-        display: inline;
-      }
-    }
+  th, td {
+    padding: $table-cell-padding-x 0;
   }
 
-  .doc-table-head {
+  td {
+    border-bottom: 1px solid $table-border-color;
+  }
+
+  th {
+    border-bottom: 1px solid $primary;
     font-weight: bold;
-    border-bottom-color: $primary;
+  }
+
+  // specific cell behaviour
+  .cell-title {
+    width: 60%;
+  }
+
+  .cell-date {
+    text-align: right;
   }
 
   .cell-group {
-    grid-column: span 12;
     font-weight: bold;
+  }
+
+  // "child" rows for legislation subleg
+  .has-children .bi-caret-down-fill {
+    display: none;
+  }
+
+  .has-children.expanded {
+    .bi-caret-right-fill {
+      display: none;
+    }
+
+    .bi-caret-down-fill {
+      display: inline;
+    }
   }
 
   .doc-table-children {
@@ -42,126 +54,100 @@
     }
   }
 
-  .cell-date {
-    text-align: right;
+  @include media-breakpoint-down(md) {
+    /**
+     * On mobile, the table is converted into a grid. Each row is a grid with 12 columns.
+     * The title column takes up the full width, while the others take up half.
+     */
+    display: block;
+
+    tr {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: 0 $table-cell-padding-x;
+      padding: $table-cell-padding-x;
+      // the row is moved to the tr, rather than the cells
+      border-bottom: 1px solid $table-border-color;
+    }
+
+    td {
+      grid-column: span 6;
+      width: unset;
+      border-bottom: 0;
+    }
+
+    // padding moves to the rows, so that when cols wrap, there isn't extra spacing
+    th, td {
+      padding: 0 0;
+    }
+
+    thead {
+      display: contents;
+
+      // the thead border is moved to the tr, rather than the cells
+      td, th {
+        border-bottom-width: 0;
+      }
+
+      tr {
+        border-bottom: 1px solid $primary;
+      }
+
+      // hide most headings
+      th {
+        display: none;
+        width: unset;
+
+        &.cell-title {
+          display: block;
+        }
+      }
+    }
+
+    // column-specific styling
+    .cell-title,
+    .cell-group {
+      grid-column: span 12;
+      width: unset;
+    }
+
+    // when the date comes right after the title, give the date full width
+    .cell-title + .cell-date {
+      grid-column: span 12;
+    }
+  }
+}
+
+// variants
+table.doc-table.doc-table--toggle {
+  .cell-toggle {
+    width: 25px;
   }
 
   @include media-breakpoint-down(md) {
-    .doc-table-head {
-      .cell-citation,
-      .cell-date {
-        display: none;
-      }
+    tr {
+      // extra 25px for the toggle column
+      grid-template-columns: 20px repeat(12, 1fr);
     }
 
-    .doc-table-children {
-      .cell-title {
-        padding-left: 0px;
-      }
+    .cell-toggle {
+      width: unset;
+      display: block;
+    }
 
-      .doc-table-row {
-        // extra initial padding for child rows
+    .cell-toggle {
+      grid-row: span 10;
+      grid-column: span 1;
+    }
+
+    // extra initial padding for child rows
+    .doc-table-children {
+      tr {
         grid-template-columns: 30px repeat(12, 1fr);
       }
-    }
-  }
 
-  // sizing for different groups of columns
-
-  // toggle, title, citation, date
-  &.doc-table-toggle-title-citation-date {
-    .doc-table-row {
-      // extra space for toggle
-      grid-template-columns: 15px repeat(12, 1fr);
-    }
-    .cell-title {
-      grid-column: span 7;
-    }
-    .cell-citation {
-      grid-column: span 3;
-    }
-    .cell-date {
-      grid-column: span 2;
-    }
-
-    @include media-breakpoint-down(md) {
-      .doc-table-children {
-        .doc-table-row {
-          // extra space for toggle
-          grid-template-columns: 30px repeat(12, 1fr);
-        }
-      }
-
-      .cell-toggle {
-        grid-row: span 2;
-      }
       .cell-title {
-        grid-column: span 12;
-      }
-      .cell-citation {
-        grid-column: span 10;
-      }
-      .cell-date {
-        grid-column: span 2;
-      }
-
-      .doc-table-head {
-        .cell-citation,
-        .cell-date {
-          display: none;
-        }
-      }
-    }
-  }
-
-  // toggle, title, date
-  &.doc-table-toggle-title-date {
-    .doc-table-row {
-      // extra space for toggle
-      grid-template-columns: 15px repeat(12, 1fr);
-    }
-    .cell-title {
-      grid-column: span 10;
-    }
-    .cell-date {
-      grid-column: span 2;
-    }
-
-    @include media-breakpoint-down(md) {
-      .doc-table-children {
-        .doc-table-row {
-          // extra space for toggle
-          grid-template-columns: 30px repeat(12, 1fr);
-        }
-      }
-
-      .cell-toggle {
-        grid-row: span 2;
-      }
-      .cell-title {
-        grid-column: span 10;
-      }
-      .cell-date {
-        grid-column: span 2;
-      }
-    }
-  }
-
-  // title, date
-  &.doc-table-title-date {
-    .cell-title {
-      grid-column: span 10;
-    }
-    .cell-date {
-      grid-column: span 2;
-    }
-
-    @include media-breakpoint-down(md) {
-      .cell-title {
-        grid-column: span 12;
-      }
-      .cell-date {
-        grid-column: span 12;
+        padding-left: 0;
       }
     }
   }

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -1,7 +1,7 @@
 .doc-table {
   .doc-table-row {
     display: grid;
-    grid-template-columns: 15px repeat(12, 1fr);
+    grid-template-columns: repeat(12, 1fr);
     gap: 0rem 0.5rem;
     padding: 0.5rem 0;
 
@@ -40,23 +40,14 @@
     }
   }
 
-  // sizing for different groups of columns
-
-  &.doc-table-title-subtitle-date {
-    .cell-title {
-      grid-column: span 7;
-    }
-
-    .cell-subtitle {
-      grid-column: span 3;
-    }
-
-    .cell-date {
-      grid-column: span 2;
-    }
-  }
-
   @include media-breakpoint-down(md) {
+    .doc-table-head {
+      .cell-citation,
+      .cell-date {
+        display: none;
+      }
+    }
+
     .doc-table-children {
       .cell-title {
         padding-left: 0px;
@@ -67,27 +58,83 @@
         grid-template-columns: 30px repeat(12, 1fr);
       }
     }
+  }
 
-    &.doc-table-title-subtitle-date {
-      .doc-table-head {
-        .cell-subtitle,
-        .cell-date {
-          display: none;
+  // sizing for different groups of columns
+
+  // toggle, title, citation, date
+  &.doc-table-toggle-title-citation-date {
+    .doc-table-row {
+      // extra space for toggle
+      grid-template-columns: 15px repeat(12, 1fr);
+    }
+    .cell-title {
+      grid-column: span 7;
+    }
+    .cell-citation {
+      grid-column: span 3;
+    }
+    .cell-date {
+      grid-column: span 2;
+    }
+
+    @include media-breakpoint-down(md) {
+      .doc-table-children {
+        .doc-table-row {
+          // extra space for toggle
+          grid-template-columns: 30px repeat(12, 1fr);
         }
       }
 
       .cell-toggle {
         grid-row: span 2;
       }
-
       .cell-title {
         grid-column: span 12;
       }
-
-      .cell-subtitle {
+      .cell-citation {
         grid-column: span 10;
       }
+      .cell-date {
+        grid-column: span 2;
+      }
 
+      .doc-table-head {
+        .cell-citation,
+        .cell-date {
+          display: none;
+        }
+      }
+    }
+  }
+
+  // toggle, title, date
+  &.doc-table-toggle-title-date {
+    .doc-table-row {
+      // extra space for toggle
+      grid-template-columns: 15px repeat(12, 1fr);
+    }
+    .cell-title {
+      grid-column: span 10;
+    }
+    .cell-date {
+      grid-column: span 2;
+    }
+
+    @include media-breakpoint-down(md) {
+      .doc-table-children {
+        .doc-table-row {
+          // extra space for toggle
+          grid-template-columns: 30px repeat(12, 1fr);
+        }
+      }
+
+      .cell-toggle {
+        grid-row: span 2;
+      }
+      .cell-title {
+        grid-column: span 10;
+      }
       .cell-date {
         grid-column: span 2;
       }

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -1,4 +1,6 @@
 .doc-table {
+  margin-bottom: $spacer;
+
   .doc-table-row {
     display: grid;
     grid-template-columns: repeat(12, 1fr);
@@ -38,6 +40,10 @@
     .cell-title {
       padding-left: 20px;
     }
+  }
+
+  .cell-date {
+    text-align: right;
   }
 
   @include media-breakpoint-down(md) {
@@ -137,6 +143,25 @@
       }
       .cell-date {
         grid-column: span 2;
+      }
+    }
+  }
+
+  // title, date
+  &.doc-table-title-date {
+    .cell-title {
+      grid-column: span 10;
+    }
+    .cell-date {
+      grid-column: span 2;
+    }
+
+    @include media-breakpoint-down(md) {
+      .cell-title {
+        grid-column: span 12;
+      }
+      .cell-date {
+        grid-column: span 12;
       }
     }
   }

--- a/peachjam/templates/peachjam/_document_table.html
+++ b/peachjam/templates/peachjam/_document_table.html
@@ -1,22 +1,22 @@
 {% load i18n peachjam %}
 <div class="table-responsive">
-  <table class="table">
+  <table class="doc-table">
     <thead>
       <tr>
-        <th scope="col" style="width: 70%">{% trans 'Title' %}</th>
+        <th scope="col" class="cell-title">{% trans 'Title' %}</th>
         {% if MULTIPLE_JURISDICTIONS or MULTIPLE_LOCALITIES %}
           <th scope="col">{% trans 'Jurisdiction' %}</th>
         {% endif %}
         {% if doc_table_show_author %}<th scope="col"></th>{% endif %}
         {% if doc_table_show_court %}<th scope="col"></th>{% endif %}
         {% if doc_table_show_doc_type %}<th scope="col"></th>{% endif %}
-        <th scope="col">{% trans 'Date' %}</th>
+        <th scope="col" class="cell-date">{% trans 'Date' %}</th>
       </tr>
     </thead>
     <tbody>
       {% for document in documents %}
         <tr>
-          <td>
+          <td class="cell-title">
             <a href="{{ document.get_absolute_url }}">{{ document.title }}</a>
           </td>
           {% if MULTIPLE_JURISDICTIONS %}
@@ -30,7 +30,7 @@
           {% if doc_table_show_author %}<td>{{ document.author|default_if_none:'' }}</td>{% endif %}
           {% if doc_table_show_court %}<td>{{ document.court|default_if_none:'' }}</td>{% endif %}
           {% if doc_table_show_doc_type %}<td style="white-space: nowrap;">{{ document.get_doc_type_display }}</td>{% endif %}
-          <td style="white-space: nowrap;">{{ document.date }}</td>
+          <td style="white-space: nowrap;" class="cell-date">{{ document.date }}</td>
           <td style="white-space: nowrap;">
             {% if document.work.languages|length > 1 %}
               <span class="d-inline-block"

--- a/peachjam/templates/peachjam/_grouped_judgments_table.html
+++ b/peachjam/templates/peachjam/_grouped_judgments_table.html
@@ -1,19 +1,21 @@
 {% extends 'peachjam/_judgment_table.html' %}
 {% block table-body %}
-  {% for item in grouped_documents %}
-    {% if item.judgments %}
-      <tr>
-        <td class="cell-group">{{ item.key }}</td>
-      </tr>
-      {% for judgment in item.judgments %}
+  <tbody>
+    {% for item in grouped_documents %}
+      {% if item.judgments %}
         <tr>
-          <td class="cell-title">
-            <a href="{{ judgment.get_absolute_url }}">{{ judgment.title }}</a>
-            {% include 'peachjam/_labels.html' with labels=judgment.labels.all %}
-          </td>
-          <td class="cell-date" style="white-space: nowrap;">{{ judgment.date }}</td>
+          <td class="cell-group">{{ item.key }}</td>
         </tr>
-      {% endfor %}
-    {% endif %}
-  {% endfor %}
+        {% for judgment in item.judgments %}
+          <tr>
+            <td class="cell-title">
+              <a href="{{ judgment.get_absolute_url }}">{{ judgment.title }}</a>
+              {% include 'peachjam/_labels.html' with labels=judgment.labels.all %}
+            </td>
+            <td class="cell-date" style="white-space: nowrap;">{{ judgment.date }}</td>
+          </tr>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </tbody>
 {% endblock %}

--- a/peachjam/templates/peachjam/_grouped_judgments_table.html
+++ b/peachjam/templates/peachjam/_grouped_judgments_table.html
@@ -1,21 +1,19 @@
 {% extends 'peachjam/_judgment_table.html' %}
 {% block table-body %}
-  <tbody>
-    {% for item in grouped_documents %}
-      {% if item.judgments %}
-        <tr>
-          <th colspan="2" scope="row">{{ item.key }}</th>
-        </tr>
-        <tr>
-          {% for judgment in item.judgments %}
-            <td>
-              <a href="{{ judgment.get_absolute_url }}">{{ judgment.title }}</a>
-              {% include 'peachjam/_labels.html' with labels=judgment.labels.all %}
-            </td>
-            <td style="white-space: nowrap;">{{ judgment.date }}</td>
-          </tr>
-        {% endfor %}
-      {% endif %}
-    {% endfor %}
-  </tbody>
+  {% for item in grouped_documents %}
+    {% if item.judgments %}
+      <div class="doc-table-row">
+        <div class="doc-table-cell cell-group">{{ item.key }}</div>
+      </div>
+      {% for judgment in item.judgments %}
+        <div class="doc-table-row">
+          <div class="doc-table-cell cell-title">
+            <a href="{{ judgment.get_absolute_url }}">{{ judgment.title }}</a>
+            {% include 'peachjam/_labels.html' with labels=judgment.labels.all %}
+          </div>
+          <div class="doc-table-cell cell-date" style="white-space: nowrap;">{{ judgment.date }}</div>
+        </div>
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
 {% endblock %}

--- a/peachjam/templates/peachjam/_grouped_judgments_table.html
+++ b/peachjam/templates/peachjam/_grouped_judgments_table.html
@@ -2,17 +2,17 @@
 {% block table-body %}
   {% for item in grouped_documents %}
     {% if item.judgments %}
-      <div class="doc-table-row">
-        <div class="doc-table-cell cell-group">{{ item.key }}</div>
-      </div>
+      <tr>
+        <td class="cell-group">{{ item.key }}</td>
+      </tr>
       {% for judgment in item.judgments %}
-        <div class="doc-table-row">
-          <div class="doc-table-cell cell-title">
+        <tr>
+          <td class="cell-title">
             <a href="{{ judgment.get_absolute_url }}">{{ judgment.title }}</a>
             {% include 'peachjam/_labels.html' with labels=judgment.labels.all %}
-          </div>
-          <div class="doc-table-cell cell-date" style="white-space: nowrap;">{{ judgment.date }}</div>
-        </div>
+          </td>
+          <td class="cell-date" style="white-space: nowrap;">{{ judgment.date }}</td>
+        </tr>
       {% endfor %}
     {% endif %}
   {% endfor %}

--- a/peachjam/templates/peachjam/_judgment_table.html
+++ b/peachjam/templates/peachjam/_judgment_table.html
@@ -1,24 +1,18 @@
 {% load i18n %}
-<div class="table-responsive">
-  <table class="table">
-    <thead>
-      <tr>
-        <th scope="col" style="width: 70%">{% trans 'Title' %}</th>
-        <th scope="col">{% trans 'Date' %}</th>
-      </tr>
-    </thead>
-    {% block table-body %}
-      <tbody>
-        {% for document in documents %}
-          <tr>
-            <td>
-              <a href="{{ document.get_absolute_url }}">{{ document.title }}</a>
-              {% include 'peachjam/_labels.html' with labels=document.labels.all %}
-            </td>
-            <td style="white-space: nowrap;">{{ document.date }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    {% endblock %}
-  </table>
+<div class="doc-table doc-table-title-date">
+  <div class="doc-table-row doc-table-head">
+    <div class="doc-table-cell cell-title">{% trans 'Title' %}</div>
+    <div class="doc-table-cell cell-date">{% trans 'Date' %}</div>
+  </div>
+  {% block table-body %}
+    {% for document in documents %}
+      <div class="doc-table-row">
+        <div class="doc-table-cell cell-title">
+          <a href="{{ document.get_absolute_url }}">{{ document.title }}</a>
+          {% include 'peachjam/_labels.html' with labels=document.labels.all %}
+        </div>
+        <div class="doc-tabl-cell cell-date" style="white-space: nowrap;">{{ document.date }}</div>
+      </div>
+    {% endfor %}
+  {% endblock %}
 </div>

--- a/peachjam/templates/peachjam/_judgment_table.html
+++ b/peachjam/templates/peachjam/_judgment_table.html
@@ -1,18 +1,22 @@
 {% load i18n %}
-<div class="doc-table doc-table-title-date">
-  <div class="doc-table-row doc-table-head">
-    <div class="doc-table-cell cell-title">{% trans 'Title' %}</div>
-    <div class="doc-table-cell cell-date">{% trans 'Date' %}</div>
-  </div>
+<table class="doc-table">
+  <thead>
+    <tr>
+      <th class="cell-title">{% trans 'Title' %}</th>
+      <th class="cell-date">{% trans 'Date' %}</th>
+    </tr>
+  </thead>
   {% block table-body %}
-    {% for document in documents %}
-      <div class="doc-table-row">
-        <div class="doc-table-cell cell-title">
-          <a href="{{ document.get_absolute_url }}">{{ document.title }}</a>
-          {% include 'peachjam/_labels.html' with labels=document.labels.all %}
-        </div>
-        <div class="doc-tabl-cell cell-date" style="white-space: nowrap;">{{ document.date }}</div>
-      </div>
-    {% endfor %}
+    <tbody>
+      {% for document in documents %}
+        <tr>
+          <td class="cell-title">
+            <a href="{{ document.get_absolute_url }}">{{ document.title }}</a>
+            {% include 'peachjam/_labels.html' with labels=document.labels.all %}
+          </td>
+          <td class="cell-date" style="white-space: nowrap;">{{ document.date }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
   {% endblock %}
-</div>
+</table>

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -18,6 +18,7 @@ class LegislationListView(FilteredDocumentListView):
     template_name = "peachjam/legislation_list.html"
     navbar_link = "legislation"
     queryset = Legislation.objects.prefetch_related("work")
+    extra_context = {"legislation_list_sort": "title"}
 
 
 @registry.register_doc_type("legislation")

--- a/peachjam_api/serializers.py
+++ b/peachjam_api/serializers.py
@@ -73,12 +73,19 @@ class CitationLinkSerializer(serializers.ModelSerializer):
         fields = ("id", "document", "text", "url", "target_id", "target_selectors")
 
 
+class LabelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Label
+        fields = ("name", "level")
+
+
 class ChildLegislationSerializer(serializers.ModelSerializer):
     year = serializers.SerializerMethodField("get_year")
+    labels = LabelSerializer(many=True, read_only=True)
 
     class Meta:
         model = Legislation
-        fields = ("title", "citation", "work_frbr_uri", "repealed", "year")
+        fields = ("title", "citation", "work_frbr_uri", "repealed", "year", "labels")
 
     def get_year(self, instance):
         """Use the FRBR work uri, rather than the document year."""
@@ -90,6 +97,7 @@ class LegislationSerializer(serializers.ModelSerializer):
     year = serializers.SerializerMethodField("get_year")
     children = ChildLegislationSerializer(many=True, read_only=True)
     languages = serializers.SerializerMethodField("get_languages")
+    labels = LabelSerializer(many=True, read_only=True)
 
     class Meta:
         model = Legislation
@@ -102,6 +110,7 @@ class LegislationSerializer(serializers.ModelSerializer):
             "year",
             "taxonomies",
             "languages",
+            "labels",
         )
 
     def get_taxonomies(self, instance):

--- a/peachjam_api/serializers.py
+++ b/peachjam_api/serializers.py
@@ -74,9 +74,15 @@ class CitationLinkSerializer(serializers.ModelSerializer):
 
 
 class ChildLegislationSerializer(serializers.ModelSerializer):
+    year = serializers.SerializerMethodField("get_year")
+
     class Meta:
         model = Legislation
-        fields = ("title", "citation", "work_frbr_uri", "repealed", "date")
+        fields = ("title", "citation", "work_frbr_uri", "repealed", "year")
+
+    def get_year(self, instance):
+        """Use the FRBR work uri, rather than the document year."""
+        return instance.frbr_uri_date.split("-")[0]
 
 
 class LegislationSerializer(serializers.ModelSerializer):
@@ -91,7 +97,6 @@ class LegislationSerializer(serializers.ModelSerializer):
             "title",
             "children",
             "citation",
-            "date",
             "work_frbr_uri",
             "repealed",
             "year",


### PR DESCRIPTION
* replace tables with responsive document tables that collapse on mobile
* legislation listing uses FRBR year, rather than date, and always has this column
* legislation listing shows group headings based on sort key
* legislation listing includes labels
* document tables make better use of whitespace, particularly on mobile, to show more data with less padding
* legislation table now looks the same as the other document tables

https://www.loom.com/share/aae4f89d15b74fe5b1bbc1756f545952

## desktop

![image](https://github.com/laws-africa/peachjam/assets/4178542/5d937493-2ebb-4e40-a115-26b612180bd4)


![image](https://github.com/laws-africa/peachjam/assets/4178542/a40572c7-7020-4e97-9229-2c77e9ce5ade)


![image](https://github.com/laws-africa/peachjam/assets/4178542/6c97c6a0-3683-4205-929a-42afa24d6c8a)


## mobile

![image](https://github.com/laws-africa/peachjam/assets/4178542/b9e51185-fbdc-4001-b88f-709f1d77cba6)

![image](https://github.com/laws-africa/peachjam/assets/4178542/01ce0a53-3321-4dc0-bde6-8ad79a648000)


