### PR TITLE
ignore nulls when saving searches

### DIFF
--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -549,12 +549,16 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
                 # ignore badly formed previous search ids
                 pass
 
+        search = self.request.GET.get("search", "")[:2048]
+        # ignore nulls
+        search = search.replace("\00", " ")
+
         # save the search trace
         return SearchTrace.objects.create(
             user=self.request.user if self.request.user.is_authenticated else None,
             config_version=self.config_version,
             request_id=self.request.id if self.request.id != "none" else None,
-            search=self.request.GET.get("search", "")[:2048],
+            search=search,
             field_searches=field_searches,
             n_results=response.data["count"],
             page=self.paginator.page.number,


### PR DESCRIPTION
This was fixed weeks ago but not merged and pushed.