### PR TITLE
Add taxonomies to court listings

### DIFF
--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -38,18 +38,14 @@ class FilteredJudgmentView(FilteredDocumentListView):
 
         context["doc_type"] = "Judgment"
         context["page_title"] = self.page_title()
-        context["labels"].update({"judge": Judge.model_label_plural})
         context["doc_table_show_jurisdiction"] = False
 
         self.populate_years(context)
-        self.populate_facets(context)
-        self.show_facet_clear_all(context)
-
         context["documents"] = self.group_documents(context["documents"])
 
         return context
 
-    def populate_facets(self, context):
+    def add_facets(self, context):
         context["facet_data"] = {}
         if "judges" not in self.exclude_facets:
             judges = list(
@@ -63,7 +59,7 @@ class FilteredJudgmentView(FilteredDocumentListView):
                 if judge
             )
             context["facet_data"]["judges"] = {
-                "label": _("Judges"),
+                "label": Judge.model_label_plural,
                 "type": "checkbox",
                 "options": judges,
                 "values": self.request.GET.getlist("judges"),
@@ -103,6 +99,24 @@ class FilteredJudgmentView(FilteredDocumentListView):
                 "type": "checkbox",
                 "options": attorneys,
                 "values": self.request.GET.getlist("attorneys"),
+            }
+
+        if "taxonomy" not in self.exclude_facets:
+            taxonomies = list(
+                self.form.filter_queryset(
+                    self.get_base_queryset(), exclude="taxonomies"
+                )
+                .filter(taxonomies__topic__isnull=False)
+                .order_by()
+                .values_list("taxonomies__topic__name", flat=True)
+                .distinct()
+            )
+
+            context["facet_data"]["taxonomies"] = {
+                "label": _("Topics"),
+                "type": "checkbox",
+                "options": taxonomies,
+                "values": self.request.GET.getlist("taxonomies"),
             }
 
         if "alphabet" not in self.exclude_facets:

--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -107,7 +107,7 @@ class FilteredJudgmentView(FilteredDocumentListView):
                     self.get_base_queryset(), exclude="taxonomies"
                 )
                 .filter(taxonomies__topic__isnull=False)
-                .order_by()
+                .order_by("taxonomies__topic__name")
                 .values_list("taxonomies__topic__name", flat=True)
                 .distinct()
             )

--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -173,7 +173,7 @@ class FilteredDocumentListView(DocumentListView):
         taxonomies = list(
             self.form.filter_queryset(self.get_base_queryset(), exclude="taxonomies")
             .filter(taxonomies__topic__isnull=False)
-            .order_by()
+            .order_by("taxonomies__topic__name")
             .values_list("taxonomies__topic__name", flat=True)
             .distinct()
         )

--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -136,7 +136,6 @@ class FilteredDocumentListView(DocumentListView):
         self.add_facets(context)
         self.show_facet_clear_all(context)
         context["doc_count"] = context["paginator"].count
-        context["labels"] = {"author": Author.model_label}
 
         return context
 
@@ -189,7 +188,7 @@ class FilteredDocumentListView(DocumentListView):
                 "values": self.request.GET.getlist("years"),
             },
             "authors": {
-                "label": _("Authors"),
+                "label": Author.model_label_plural,
                 "type": "checkbox",
                 "options": authors,
                 "values": self.request.GET.getlist("authors"),


### PR DESCRIPTION
This adds taxonomies to the court listing pages
Also some small refactors to eliminate some repitition in the facets code.

![image](https://github.com/user-attachments/assets/f9276a35-2a9e-40c7-b33a-567449f64889)



closes https://github.com/laws-africa/kenyalaw-pj/issues/132