### PR TITLE
fix default variable value for visited link

### DIFF
--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -18,7 +18,7 @@ $youtube-color: #FF0000 !default;
 $anntn-highlight-color: #a68bdc !default;
 $diff-green-color: #a6f3a6 !default;
 $diff-red-color: #f8cbcb !default;
-$visited-link: $primary !default;
+$visited-link: #1A77F2 !default;
 
 :root {
   --facebook-color: #{$facebook-color};


### PR DESCRIPTION
setting the primary color variable as the default value fails to compile properly. I've harcoded a default value that gets overridden in the other stylesheets