### PR TITLE
Fix sublegislation dropdown

### DIFF
--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -26,8 +26,8 @@ class LegislationListView(FilteredDocumentListView):
             self.form_defaults = {"sort": "-date"}
         return super().get_form()
 
-    def get_queryset(self):
-        qs = super().get_queryset()
+    def get_base_queryset(self, *args, **kwargs):
+        qs = super().get_base_queryset(*args, *kwargs)
         qs = self.get_variant_queryset(qs)
         return qs
 
@@ -87,7 +87,7 @@ class LegislationListView(FilteredDocumentListView):
         )
 
         children = defaultdict(list)
-        children_qs = self.get_base_queryset().filter(
+        children_qs = Legislation.objects.filter(
             parent_work_id__in=parents, repealed=False, metadata_json__principal=True
         )
         # group children by parent

--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
-from peachjam.helpers import chunks
+from peachjam.helpers import chunks, get_language
 from peachjam.models import JurisdictionProfile, Legislation, Locality, pj_settings
 from peachjam.views import FilteredDocumentListView
 
@@ -27,7 +27,7 @@ class LegislationListView(FilteredDocumentListView):
         return super().get_form()
 
     def get_base_queryset(self, *args, **kwargs):
-        qs = super().get_base_queryset(*args, *kwargs)
+        qs = super().get_base_queryset(*args, **kwargs)
         qs = self.get_variant_queryset(qs)
         return qs
 
@@ -90,6 +90,7 @@ class LegislationListView(FilteredDocumentListView):
         children_qs = Legislation.objects.filter(
             parent_work_id__in=parents, repealed=False, metadata_json__principal=True
         )
+        children_qs = children_qs.preferred_language(get_language(self.request))
         # group children by parent
         for child in children_qs:
             children[child.parent_work_id].append(child)

--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -26,8 +26,8 @@ class LegislationListView(FilteredDocumentListView):
             self.form_defaults = {"sort": "-date"}
         return super().get_form()
 
-    def get_base_queryset(self, *args, **kwargs):
-        qs = super().get_base_queryset(*args, **kwargs)
+    def get_queryset(self):
+        qs = super().get_queryset()
         qs = self.get_variant_queryset(qs)
         return qs
 


### PR DESCRIPTION
The children are not present on the qs when we do the variant filter on the get_base_queryset method. This moves the variant filter to the get queryset method leaving the base_queryset intact so we can fetch the children.

closes https://github.com/laws-africa/peachjam/issues/1971