### PR TITLE
Fix sublegislation ordering

### DIFF
--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -22,7 +22,7 @@ class LegislationListView(FilteredDocumentListView):
 
     def get_form(self):
         self.form_defaults = {"sort": "title"}
-        if self.variant == "recent":
+        if self.variant in ["recent", "subleg"]:
             self.form_defaults = {"sort": "-date"}
         return super().get_form()
 
@@ -89,7 +89,7 @@ class LegislationListView(FilteredDocumentListView):
         children = defaultdict(list)
         children_qs = Legislation.objects.filter(
             parent_work_id__in=parents, repealed=False, metadata_json__principal=True
-        )
+        ).order_by("-date")
         children_qs = children_qs.preferred_language(get_language(self.request))
         # group children by parent
         for child in children_qs:


### PR DESCRIPTION
This fixes sublegislation ordering, on both the drop down and the listing page

![image](https://github.com/user-attachments/assets/18d5c7cb-ed50-4613-93fc-4964c35c94e1)
closes https://github.com/laws-africa/kenyalaw-pj/issues/201