### PR TITLE
always rewrite images in document content

### DIFF
--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -19,6 +19,7 @@ from peachjam.models import (
     Predicate,
     Relationship,
 )
+from peachjam.xmlutils import parse_html_str
 from peachjam_api.serializers import (
     CitationLinkSerializer,
     PredicateSerializer,
@@ -280,8 +281,7 @@ class BaseDocumentDetailView(DetailView):
             context["display_type"] = (
                 "akn" if context["document"].content_html_is_akn else "html"
             )
-            if not context["document"].content_html_is_akn:
-                self.prefix_images(context["document"])
+            self.prefix_images(context["document"])
         elif hasattr(context["document"], "source_file"):
             context["display_type"] = "pdf"
         else:
@@ -408,14 +408,14 @@ class BaseDocumentDetailView(DetailView):
 
     def prefix_images(self, document):
         """Rewrite image URLs so that we can serve them correctly."""
-        root = html.fromstring(document.content_html)
+        root = parse_html_str(document.content_html)
 
         for img in root.xpath(".//img[@src]"):
             src = img.attrib["src"]
             if not src.startswith("/") and not src.startswith("data:"):
-                img.attrib["src"] = (
-                    document.expression_frbr_uri + "/media/" + img.attrib["src"]
-                )
+                if not src.startswith("media/"):
+                    src = "media/" + src
+                img.attrib["src"] = document.expression_frbr_uri + "/" + src
 
         document.content_html = html.tostring(root, encoding="unicode")
 


### PR DESCRIPTION
this ensures that all images, even in AKN HTML, have the correct URL including the document's full expression FRBR URI.

Otherwise, for a document URL such as  `http://localhost:8001/akn/za/act/1996/constitution/eng@2013-08-23` the image url `media/foo.png` becomes `http://localhost:8001/akn/za/act/1996/constitution/media/foo.png` which is not correct.