### PR TITLE
pin whitenose 6.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "python-magic>=0.4.25",
     "requests>=2.27.1",
     "sentry-sdk>=1.16.0",
-    "whitenoise==5.3.0",
+    "whitenoise==6.0.0",
 ]
 
 [tool.setuptools.data-files]


### PR DESCRIPTION
testing to see if 6.0.0 is also broken
whitenose 5.3.0 fixes our db issues!