### PR TITLE
Allow iframes in ckeditor

### DIFF
--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -488,6 +488,10 @@ class CoreDocument(PolymorphicModel):
         # return None if the HTML doesn't have any content
         try:
             root = parse_html_str(content_html)
+            iframes = root.xpath("//iframe")
+            if iframes:
+                return content_html
+
             text = "".join(root.itertext()).strip()
             text = re.sub(r"\s", "", text)
             if not text:

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -526,7 +526,8 @@ if DEBUG:
 CKEDITOR_CONFIGS = {
     # The rest of this config is defined in ckeditor.configs.DEFAULT_CONFIG
     "default": {
-        "removePlugins": ["image"],
+        "removePlugins": ["image", "iframe"],
+        "extraAllowedContent": "iframe[*];",
         "toolbar_Full": [
             [
                 "Styles",
@@ -543,7 +544,7 @@ CKEDITOR_CONFIGS = {
                 "Redo",
             ],
             ["Link", "Unlink", "Anchor"],
-            ["Image", "Flash", "Table", "HorizontalRule"],
+            ["Image", "Flash", "Table", "HorizontalRule", "Iframe"],
             ["TextColor", "BGColor"],
             ["Smiley", "SpecialChar", "LaAkn"],
             ["Source"],


### PR DESCRIPTION
The problem occurred from two places, the check for removing whitespaces got rid of the iframes, and the ckeditor config also was hiding the iframe content. Now you can paste the iframe into the source and it should work. This also enables the Iframe plugin so you can enter the url and other details manually. 

![image](https://github.com/user-attachments/assets/b351c264-55e4-4c04-9fff-8ec4c612d879)

closes https://github.com/laws-africa/peachjam/issues/1944