### PR TITLE
robots.txt must disallow entire work detail

### DIFF
--- a/peachjam/views/robots.py
+++ b/peachjam/views/robots.py
@@ -11,8 +11,11 @@ class RobotsView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         disallowed_content = [
-            "Disallow: " + doc.expression_frbr_uri
-            for doc in CoreDocument.objects.exclude(allow_robots=True)
+            f"Disallow: {frbr_uri}/"
+            for frbr_uri in CoreDocument.objects.filter(allow_robots=False)
+            .values_list("work_frbr_uri", flat=True)
+            .order_by()
+            .distinct()
         ]
         context["disallowed_content"] = "\n".join(disallowed_content)
 


### PR DESCRIPTION
fixes #2006

```
# This content is made available subject to our Terms of Use at /terms-of-use/

User-agent: *
Allow: /
Disallow: /search/
Disallow: /api/
Disallow: /akn/ke/judgment/kehc/2022/13019/
Disallow: /akn/ke/judgment/keelc/2022/14600/
Disallow: /akn/ke/judgment/keca/2022/989/
Disallow: /akn/ke/judgment/keelrc/2022/1728/
Disallow: /akn/ke/judgment/kehc/2018/6377/
Disallow: /akn/ke/judgment/kehc/2021/6429/
Disallow: /akn/ke/judgment/kehc/2019/1049/
Disallow: /akn/ke/judgment/kehc/2017/4559/
Disallow: /akn/ke/judgment/kehc/2022/11441/
```