### PR TITLE
Fix locality filters for Lawlibrary

### DIFF
--- a/lawlibrary/urls.py
+++ b/lawlibrary/urls.py
@@ -20,6 +20,21 @@ urlpatterns = [
         name="legislation_list_all",
     ),
     path(
+        "legislation/uncommenced",
+        views.LegislationListView.as_view(variant="uncommenced"),
+        name="legislation_list_uncommenced",
+    ),
+    path(
+        "legislation/subsidiary",
+        views.LegislationListView.as_view(variant="subleg"),
+        name="legislation_list_subsidiary",
+    ),
+    path(
+        "legislation/recent",
+        views.LegislationListView.as_view(variant="recent"),
+        name="legislation_list_recent",
+    ),
+    path(
         "legislation/<str:code>/",
         views.LocalityLegislationListView.as_view(),
         name="locality_legislation_list",


### PR DESCRIPTION
This fixes the base view that is used for the national legislation listing views.
The base view should filter out documents that have localites

closes https://github.com/laws-africa/peachjam/issues/1979