### PR TITLE
use outcomes__name not outcomes__code

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -203,7 +203,7 @@ class BaseDocumentFilterForm(forms.Form):
             queryset = queryset.filter(attorneys__name__in=attorneys).distinct()
 
         if outcomes and exclude != "outcomes":
-            queryset = queryset.filter(outcomes__code__in=outcomes).distinct()
+            queryset = queryset.filter(outcomes__name__in=outcomes).distinct()
 
         if taxonomies and exclude != "taxonomies":
             queryset = queryset.filter(taxonomies__topic__slug__in=taxonomies)


### PR DESCRIPTION
later we must give outcomes a slug/code so that we support translations

fixes https://lawsafrica.sentry.io/issues/5804276287/


![image](https://github.com/user-attachments/assets/84c14718-5857-42df-87d4-15dda6662cdd)
