### PR TITLE
add main content type buttons for mobile on lawlibrary

### DIFF
--- a/lawlibrary/templates/liiweb/home.html
+++ b/lawlibrary/templates/liiweb/home.html
@@ -22,6 +22,29 @@
                alt="Law Library logo"/>
         </div>
       </div>
+      <div class="mt-3 d-lg-none row row-cols-2">
+        <div class="col mb-2">
+          <a href="{% url 'judgment_list' %}" class="btn btn-primary d-block">Judgments</a>
+        </div>
+        <div class="col mb-2">
+          <a href="{% url 'legislation_list' %}" class="btn btn-primary d-block">National Legislation</a>
+        </div>
+        <div class="col mb-2">
+          <a href="{% url 'locality_legislation' %}"
+             class="btn btn-primary d-block">Provincial Legislation</a>
+        </div>
+        <div class="col mb-2">
+          <a href="{% url 'municipal_legislation' %}"
+             class="btn btn-primary d-block">Municipal By-laws</a>
+        </div>
+        <div class="col mb-2">
+          <a href="{% url 'gazettes' %}" class="btn btn-primary d-block">Gazettes</a>
+        </div>
+        <div class="col mb-2">
+          <a href="{% url 'first_level_taxonomy_list' 'collections' %}"
+             class="btn btn-primary d-block">Collections</a>
+        </div>
+      </div>
     </div>
   </section>
 {% endblock %}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1d9cd686-80dc-466a-8c83-52453aef16c4)

this makes it easier to jump to the primary content types on mobile, when the menu is collapsed