### PR TITLE
disable atomic requests

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -208,7 +208,6 @@ default_db_config = dj_database_url.config(default=default_db_url)
 gazette_db_config = dj_database_url.config(
     default=gazette_db_url, env="GAZETTES_DATABASE_URL"
 )
-default_db_config["ATOMIC_REQUESTS"] = True
 
 DATABASES = {
     "default": default_db_config,


### PR DESCRIPTION
the reasoning is that 99% of our requests are GETs which don't require atomic, and this is placing load on pgbouncer and psql.