### PR TITLE
Comments in admin area for documents

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "django_htmx",
     "django_recaptcha",
+    "django_comments",
 ]
 
 MIDDLEWARE = [

--- a/peachjam/templates/admin/_comments_form.html
+++ b/peachjam/templates/admin/_comments_form.html
@@ -1,0 +1,16 @@
+{% load comments %}
+{% get_comment_form for object as comment_form %}
+<form action="{% comment_form_target %}"
+      method="post"
+      id="comment-form"
+      hx-post="{% comment_form_target %}"
+      hx-target="#comments-list">
+  {% csrf_token %}
+  <input type="hidden"
+         name="next"
+         value="{% url 'comment_form' app_label model_name object.pk %}"/>
+  {{ comment_form.content_type }}
+  {{ comment_form.object_pk }}
+  {{ comment_form.timestamp }}
+  {{ comment_form.security_hash }}
+</form>

--- a/peachjam/templates/admin/_comments_form_combo.html
+++ b/peachjam/templates/admin/_comments_form_combo.html
@@ -1,0 +1,2 @@
+{% include 'admin/_comments_list.html' %}
+<div hx-swap-oob="comments-form-wrapper">{% include 'admin/_comments_form.html' %}</div>

--- a/peachjam/templates/admin/_comments_list.html
+++ b/peachjam/templates/admin/_comments_list.html
@@ -1,0 +1,19 @@
+{% load comments i18n humanize %}
+<ol class="list-unstyled">
+  {% get_comment_list for object as comment_list %}
+  {% for comment in comment_list %}
+    <li class="mb-3">
+      <div>
+        <b>{{ comment.user }}</b> {{ comment.submit_date|naturaltime }}:
+      </div>
+      <div>{{ comment.comment|linebreaks }}</div>
+    </li>
+  {% endfor %}
+</ol>
+<textarea name="comment"
+          rows="3"
+          maxlength="3000"
+          required
+          class="form-control mt-3 mb-2"
+          form="comment-form"></textarea>
+<button type="submit" class="btn btn-primary" form="comment-form">{% trans "Add comment" %}</button>

--- a/peachjam/templates/admin/change_form.html
+++ b/peachjam/templates/admin/change_form.html
@@ -8,16 +8,20 @@
        class="btn btn-block btn-info">{% trans 'Help' %}</a>
   {% endif %}
   {% block comments %}
-    <hr/>
-    <!-- actual comments, this is updated with hx-swap when a comment is posted -->
-    <div id="comments-list">{% include 'admin/_comments_list.html' with object=original %}</div>
+    {% if original %}
+      <hr/>
+      <!-- actual comments, this is updated with hx-swap when a comment is posted -->
+      <div id="comments-list">{% include 'admin/_comments_list.html' with object=original %}</div>
+    {% endif %}
   {% endblock %}
 {% endblock %}
 {% block content %}
   <script defer src="{% static 'js/app-prod.js' %}"></script>
   {{ block.super }}
-  <!-- actual comment form, outside of main form; this will be updated with hx-oob-swap when a comment is posted -->
-  <div id="comments-form-wrapper">
-    {% include 'admin/_comments_form.html' with object=original app_label=opts.app_label model_name=opts.model_name %}
-  </div>
+  {% if original %}
+    <!-- actual comment form, outside of main form; this will be updated with hx-oob-swap when a comment is posted -->
+    <div id="comments-form-wrapper">
+      {% include 'admin/_comments_form.html' with object=original app_label=opts.app_label model_name=opts.model_name %}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/peachjam/templates/admin/change_form.html
+++ b/peachjam/templates/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n comments humanize %}
+{% load i18n comments humanize static %}
 {% block extra_actions %}
   {{ block.super }}
   {% if PEACHJAM_SETTINGS.editor_help_link and adminform.model_admin.help_topic %}
@@ -9,37 +9,15 @@
   {% endif %}
   {% block comments %}
     <hr/>
-    {% get_comment_list for original as comment_list %}
-    <ol class="list-unstyled">
-      {% for comment in comment_list %}
-        <li class="mb-3">
-          <div>
-            <b>{{ comment.user }}</b> {{ comment.submit_date|naturaltime }}:
-          </div>
-          <div>{{ comment.comment|linebreaks }}</div>
-        </li>
-      {% endfor %}
-    </ol>
-    {% get_comment_form for original as comment_form %}
-    <textarea name="{{ comment_form.comment.html_name }}"
-              rows="3"
-              maxlength="3000"
-              required
-              class="form-control mt-3 mb-2"
-              form="comment-form"></textarea>
-    <button type="submit" class="btn btn-primary" form="comment-form">{% trans "Add comment" %}</button>
+    <!-- actual comments, this is updated with hx-swap when a comment is posted -->
+    <div id="comments-list">{% include 'admin/_comments_list.html' with object=original %}</div>
   {% endblock %}
 {% endblock %}
 {% block content %}
+  <script defer src="{% static 'js/app-prod.js' %}"></script>
   {{ block.super }}
-  <!-- actual comment form, outside of main form -->
-  {% get_comment_form for original as comment_form %}
-  <form action="{% comment_form_target %}" method="post" id="comment-form">
-    {% csrf_token %}
-    <input type="hidden" name="next" value="{{ request.get_full_path }}" />
-    {{ comment_form.content_type }}
-    {{ comment_form.object_pk }}
-    {{ comment_form.timestamp }}
-    {{ comment_form.security_hash }}
-  </form>
+  <!-- actual comment form, outside of main form; this will be updated with hx-oob-swap when a comment is posted -->
+  <div id="comments-form-wrapper">
+    {% include 'admin/_comments_form.html' with object=original app_label=opts.app_label model_name=opts.model_name %}
+  </div>
 {% endblock %}

--- a/peachjam/templates/admin/change_form.html
+++ b/peachjam/templates/admin/change_form.html
@@ -1,9 +1,45 @@
 {% extends "admin/change_form.html" %}
-{% load i18n %}
+{% load i18n comments humanize %}
 {% block extra_actions %}
+  {{ block.super }}
   {% if PEACHJAM_SETTINGS.editor_help_link and adminform.model_admin.help_topic %}
     <a target="_blank"
        href="{{ PEACHJAM_SETTINGS.editor_help_link }}{{ adminform.model_admin.help_topic }}"
        class="btn btn-block btn-info">{% trans 'Help' %}</a>
   {% endif %}
+  {% block comments %}
+    <hr/>
+    {% get_comment_list for original as comment_list %}
+    <ol class="list-unstyled">
+      {% for comment in comment_list %}
+        <li class="mb-3">
+          <div>
+            <b>{{ comment.user }}</b> {{ comment.submit_date|naturaltime }}:
+          </div>
+          <div>{{ comment.comment|linebreaks }}</div>
+        </li>
+      {% endfor %}
+    </ol>
+    {% get_comment_form for original as comment_form %}
+    <textarea name="{{ comment_form.comment.html_name }}"
+              rows="3"
+              maxlength="3000"
+              required
+              class="form-control mt-3 mb-2"
+              form="comment-form"></textarea>
+    <button type="submit" class="btn btn-primary" form="comment-form">{% trans "Add comment" %}</button>
+  {% endblock %}
+{% endblock %}
+{% block content %}
+  {{ block.super }}
+  <!-- actual comment form, outside of main form -->
+  {% get_comment_form for original as comment_form %}
+  <form action="{% comment_form_target %}" method="post" id="comment-form">
+    {% csrf_token %}
+    <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+    {{ comment_form.content_type }}
+    {{ comment_form.object_pk }}
+    {{ comment_form.timestamp }}
+    {{ comment_form.security_hash }}
+  </form>
 {% endblock %}

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -330,6 +330,8 @@ urlpatterns = [
     ),
     # django-markdown-editor
     path("martor/", include("martor.urls")),
+    # comments
+    path("comments/", include("django_comments.urls")),
 ]
 
 if settings.DEBUG:

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -331,12 +331,18 @@ urlpatterns = [
     ),
     # django-markdown-editor
     path("martor/", include("martor.urls")),
-    # comments
-    path("comments/", include("django_comments.urls")),
     path(
-        "comments/form/<str:app_label>/<str:model_name>/<int:pk>",
-        comment_form_view,
-        name="comment_form",
+        "comments/",
+        include(
+            [
+                path("", include("django_comments.urls")),
+                path(
+                    "form/<str:app_label>/<str:model_name>/<int:pk>",
+                    comment_form_view,
+                    name="comment_form",
+                ),
+            ]
+        ),
     ),
 ]
 

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -80,6 +80,7 @@ from peachjam.views import (
     UserProfileDetailView,
     WorkAutocomplete,
 )
+from peachjam.views.comments import comment_form_view
 from peachjam.views.generic_views import CSRFTokenView
 from peachjam.views.metabase_stats import MetabaseStatsView
 
@@ -332,6 +333,11 @@ urlpatterns = [
     path("martor/", include("martor.urls")),
     # comments
     path("comments/", include("django_comments.urls")),
+    path(
+        "comments/form/<str:app_label>/<str:model_name>/<int:pk>",
+        comment_form_view,
+        name="comment_form",
+    ),
 ]
 
 if settings.DEBUG:

--- a/peachjam/views/comments.py
+++ b/peachjam/views/comments.py
@@ -1,0 +1,21 @@
+from django.contrib.contenttypes.models import ContentType
+from django.http import Http404
+from django.shortcuts import get_object_or_404, render
+
+
+def comment_form_view(request, app_label, model_name, pk):
+    """Renders a list of comments for the admin view, refreshed using htmx after posting a comment."""
+    if not request.user.is_authenticated or not request.user.is_staff:
+        raise Http404()
+
+    content_type = get_object_or_404(ContentType, app_label=app_label, model=model_name)
+    obj = get_object_or_404(content_type.model_class(), pk=pk)
+    return render(
+        request,
+        "admin/_comments_form_combo.html",
+        {
+            "object": obj,
+            "model_name": model_name,
+            "app_label": app_label,
+        },
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "django-background-tasks-updated>=1.2.8",
     "django-ckeditor>=6.4.2",
     "django-compressor>=3.1",
+    "django-contrib-comments>=2.2.0",
     "django-cors-headers>=4.3.1",
     "django-countries-plus>=1.3.2",
     "django-debug-toolbar>=4.4",


### PR DESCRIPTION
This adds comments in the admin area for documents (actually, for any object that can be modified in the admin).

* use django-contrib-comments
* users must be staff to be able to make comments - a signal is used to enforce this
* use htmx to submit the form independently of the edit form that covers most of the page
* because the comment box itself, and the comment form itself, must be in separate parts of the page (because HTML doesn't allow nested forms), when the comment list is updated by htmx after a comment is made, we use hx-oob-swap to also update the form at the bottom of the page.

![image](https://github.com/user-attachments/assets/11d60466-9f44-4fb1-bc09-bf28f5565446)

Fixes #1974 

