### PR TITLE
correctly schedule regular tasks

### DIFF
--- a/peachjam/apps.py
+++ b/peachjam/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
+from django.utils import timezone
 
 
 class PeachJamConfig(AppConfig):
@@ -18,5 +19,15 @@ class PeachJamConfig(AppConfig):
 
             from peachjam.tasks import rank_works, run_ingestors
 
-            run_ingestors(schedule=Task.DAILY, repeat=Task.DAILY)
-            rank_works(schedule=Task.WEEKLY, repeat=Task.WEEKLY)
+            # run tomorrow at 2am and then daily after that
+            run_at = (timezone.now() + timezone.timedelta(days=1)).replace(
+                hour=2, minute=0, second=0
+            )
+            run_ingestors(schedule=run_at, repeat=Task.DAILY)
+
+            # run on sunday at 3am and then weekly after that
+            run_at = timezone.now()
+            run_at = (
+                run_at + timezone.timedelta(days=(6 - run_at.weekday()) % 7)
+            ).replace(hour=3, minute=0, second=0)
+            rank_works(schedule=run_at, repeat=Task.WEEKLY)


### PR DESCRIPTION
Before this change, the daily and weekly tasks were scheduled to run "in 1 day" and "in one week", and then daily/weekly after that.

The problem is that every time we deployed an update, it re-scheduled the tasks. So the weekly task in particular just never got run, because it was continually pushed out.

Instead, we now schedule as "run on this date" and then repeat daily/weekly.