### PR TITLE
background colour for remarks, except na

### DIFF
--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -393,3 +393,13 @@
   bottom: 10px;
   z-index: 10;
 }
+
+// give remarks a background colour
+la-akoma-ntoso .akn-remark {
+  background-color: var(--bs-primary-bg-subtle);
+}
+
+// except in jurisdictions where they are already styled differently
+la-akoma-ntoso[frbr-country="na"] .akn-remark {
+  background-color: inherit;
+}


### PR DESCRIPTION
this makes editorial remarks stand out a bit more

![image](https://github.com/user-attachments/assets/557548d2-70f4-4edc-888e-c544478a64c9)
