### PR TITLE
clamp pagination at 10 pages

### DIFF
--- a/peachjam/templatetags/peachjam.py
+++ b/peachjam/templatetags/peachjam.py
@@ -2,7 +2,6 @@ import datetime
 import json
 
 from django import template
-from django.core.paginator import Paginator
 from django.http import QueryDict
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -34,8 +33,7 @@ def parse_string_date(date):
 
 
 @register.simple_tag
-def get_proper_elided_page_range(p, number, on_each_side=3, on_ends=2):
-    paginator = Paginator(p.object_list, p.per_page)
+def get_proper_elided_page_range(paginator, number, on_each_side=3, on_ends=2):
     return paginator.get_elided_page_range(
         number=number, on_each_side=on_each_side, on_ends=on_ends
     )


### PR DESCRIPTION
This prevents a major performance issue with very large datasets (> 50,000) where crawlers can page through the entire dataset, hurting PostgreSQL because `OFFSET` pagination in psql is inefficient.

See https://readyset.io/blog/optimizing-sql-pagination-in-postgres


https://www.loom.com/share/973f54014ae94bb4b18bb2bfd5b6266e