### PR TITLE
Citations speed

### DIFF
--- a/peachjam/models/citations.py
+++ b/peachjam/models/citations.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 from random import randint
 
 from django.db import models
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -111,6 +113,53 @@ class ExtractedCitation(models.Model):
         work.n_cited_works = cls.for_citing_works(work).count()
         work.n_citing_works = cls.for_target_works(work).count()
         work.save(update_fields=["n_cited_works", "n_citing_works"])
+
+    @classmethod
+    def fetch_grouped_citation_docs(
+        self, works, language, n_per_group=10, offset=0, nature=None
+    ):
+        """Fetch documents for the given works, grouped by nature and ordered by the most incoming citations.
+        Returns a list of documents ordered by nature, -citing works, title."""
+        from .core_document_model import CoreDocument
+
+        # get the best documents for these works
+        docs = (
+            CoreDocument.objects.filter(work__in=works)
+            .distinct("work_frbr_uri")
+            # we're fetching documents, so we want the most recent one for each work
+            .order_by("work_frbr_uri", "-date")
+            .preferred_language(language)
+        )
+
+        qs = (
+            CoreDocument.objects.prefetch_related("work")
+            .select_related("nature")
+            .filter(pk__in=docs)
+        )
+
+        truncated = False
+        # get the top n_per_group documents for each nature, ordering by the number of incoming citations
+        if nature:
+            # just one group, don't need a window function
+            qs = qs.filter(nature=nature).order_by("-work__n_citing_works", "title")
+            truncated = qs.count() > offset + n_per_group
+            qs = qs[offset : offset + n_per_group]
+        else:
+            # use a window function to apply a row number within each nature group, ordering by number of citations
+            # offset is not supported
+            assert offset == 0
+            qs = qs.annotate(
+                row_number=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("nature__name")],
+                    order_by=[F("work__n_citing_works").desc(), F("title")],
+                )
+            ).filter(row_number__lte=n_per_group)
+
+        return (
+            sorted(qs, key=lambda d: [d.nature.name, -d.work.n_citing_works, d.title]),
+            truncated,
+        )
 
 
 class CitationProcessing(SingletonModel):

--- a/peachjam/models/core_document_model.py
+++ b/peachjam/models/core_document_model.py
@@ -765,10 +765,8 @@ class CoreDocument(PolymorphicModel):
         return 0.0000001
 
     def get_doc_type_display(self):
-        """Human-friendly type of this document."""
-        if self.nature:
-            return self.nature.name
-        return super().get_doc_type_display()
+        """Human-friendly type of this document, which is always the nature, since that cannot be null."""
+        return self.nature.name
 
 
 def file_location(instance, filename):

--- a/peachjam/templates/peachjam/_citations.html
+++ b/peachjam/templates/peachjam/_citations.html
@@ -6,13 +6,13 @@
         <i class="bi bi-pj pj-citations"></i>
         {% translate 'Cited documents' %} <span class="badge bg-secondary">{{ document.work.n_cited_works }}</span>
       </h4>
-      {% include 'peachjam/_citations_list.html' with citations=cited_documents group="outgoing" %}
+      {% include 'peachjam/_citations_list.html' with citations=cited_documents direction="outgoing" %}
     </div>
     <div class="col-lg">
       <h4 class="mb-3">
         {% translate 'Documents citing this one' %} <span class="badge bg-secondary">{{ document.work.n_citing_works }}</span>
       </h4>
-      {% include 'peachjam/_citations_list.html' with citations=documents_citing_current_doc group="incoming" %}
+      {% include 'peachjam/_citations_list.html' with citations=documents_citing_current_doc direction="incoming" %}
     </div>
   </div>
 </div>

--- a/peachjam/templates/peachjam/_citations_list.html
+++ b/peachjam/templates/peachjam/_citations_list.html
@@ -1,7 +1,7 @@
 {% load peachjam i18n %}
-{% for item in citations %}
+{% for citation_group in citations %}
   <h5 class="mt-4">
-    {{ item.doc_type }} <span class="badge bg-secondary">{{ item.docs|length }}</span>
+    {{ citation_group.nature.name }} <span class="badge bg-secondary">{{ citation_group.n_docs }}</span>
   </h5>
   <table class="table table-striped table-borderless table-sm mb-0">
     <colgroup>
@@ -9,23 +9,11 @@
       <col style="width: 100%"/>
       <col />
     </colgroup>
-    <tbody>
-      {% include 'peachjam/_citations_list_items.html' with start=0 docs=item.docs|slice:":10" %}
+    <tbody id="citation-tbody-{{ direction }}-{{ citation_group.nature.pk }}">
+      {% include 'peachjam/_citations_list_items.html' with start=0 docs=citation_group.docs %}
     </tbody>
-    {% if item.docs|length > 10 %}
-      <tbody class="collapse {{ group }}-{{ forloop.counter }}">
-        {% include 'peachjam/_citations_list_items.html' with start=10 docs=item.docs|slice:"10:" %}
-      </tbody>
-    {% endif %}
   </table>
-  {% if item.docs|length > 10 %}
-    <button class="btn btn-link"
-            data-bs-toggle="collapse"
-            data-bs-target=".{{ group }}-{{ forloop.counter }}"
-            role="button"
-            aria-expanded="false"
-            aria-controls="{{ item.doc_type }}">
-      {% trans 'Show/Hide all' %}
-    </button>
+  {% if citation_group.docs|length < citation_group.n_docs %}
+    {% include 'peachjam/_citations_list_more_button.html' with nature=citation_group.nature offset=0 %}
   {% endif %}
 {% endfor %}

--- a/peachjam/templates/peachjam/_citations_list_items.html
+++ b/peachjam/templates/peachjam/_citations_list_items.html
@@ -3,7 +3,7 @@
   <tr>
     <td>{{ start|add:forloop.counter }}.</td>
     <td>
-      <a href="{% url 'document_detail' frbr_uri=doc.work.frbr_uri|strip_first_character %}">{{ doc.title }}</a>
+      <a href="{% url 'document_detail' frbr_uri=doc.expression_frbr_uri|strip_first_character %}">{{ doc.title }}</a>
     </td>
     <td class="text-nowrap">
       {% if doc.work.n_citing_works %}
@@ -16,3 +16,11 @@
     </td>
   </tr>
 {% endfor %}
+{% if request.htmx %}
+  {% if truncated %}
+    {% include 'peachjam/_citations_list_more_button.html' %}
+  {% else %}
+    <span id="citation-button-{{ direction }}-{{ nature.pk }}"
+          hx-swap-oob="true"></span>
+  {% endif %}
+{% endif %}

--- a/peachjam/templates/peachjam/_citations_list_more_button.html
+++ b/peachjam/templates/peachjam/_citations_list_more_button.html
@@ -1,0 +1,9 @@
+{% load peachjam i18n %}
+<button class="btn btn-link"
+        id="citation-button-{{ direction }}-{{ nature.pk }}"
+        hx-get="{% url 'document_citations' document.expression_frbr_uri|strip_first_character %}?direction={{ direction }}&nature={{ nature.pk }}&offset={{ citation_group.docs|length|add:offset }}"
+        hx-target="#citation-tbody-{{ direction }}-{{ nature.pk }}"
+        hx-swap="beforeend"
+        hx-swap-oob="true">
+  {% trans "More..." %}
+</button>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -24,7 +24,7 @@
       <div class="container">
         {% block breadcrumbs %}{% endblock %}
         {% block document-title %}
-          <div class="d-md-flex justify-content-md-between py-4">
+          <div class="d-md-flex justify-content-md-between py-3">
             <div>
               <h1>{{ document.title }}</h1>
               {% block sub-title %}{% endblock %}

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -45,6 +45,7 @@ from peachjam.views import (
     CourtRegistryMonthView,
     CourtRegistryYearView,
     CourtYearView,
+    DocumentCitationsView,
     DocumentDetailViewResolver,
     DocumentListView,
     DocumentMediaView,
@@ -207,6 +208,11 @@ urlpatterns = [
         r"^(?P<frbr_uri>akn/.*)/media/(?P<filename>.+)$",
         cache_page(CACHE_DURATION)(DocumentMediaView.as_view()),
         name="document_media",
+    ),
+    re_path(
+        r"^(?P<frbr_uri>akn/.*)/citations$",
+        cache_page(CACHE_DURATION)(DocumentCitationsView.as_view()),
+        name="document_citations",
     ),
     re_path(
         r"^(?P<frbr_uri>akn/?.*)$",

--- a/peachjam/views/documents.py
+++ b/peachjam/views/documents.py
@@ -200,7 +200,7 @@ class DocumentCitationsView(DetailView):
             raise Http404
 
         try:
-            offset = int(self.request.GET.get("offset", 0))
+            offset = max(0, int(self.request.GET.get("offset", 0)))
         except ValueError:
             raise Http404
 


### PR DESCRIPTION
https://www.loom.com/share/5584208b940e476b9662234b5af9a8b7

![image](https://github.com/user-attachments/assets/625cc46e-945c-4d46-965f-5a926a168014)

This changes how we render citation lists, so that documents that are heavily cited don't have very long page load times.

* only show the first 10 of each group
* use htmx to load the next ten, etc.

Also changes to link to the cited works using the full expression FRBR URI, not the work uri.

Also reduces py-4 to py-3 since our base font size is a  bit bigger.