### PR TITLE
Order subsidiary legislation by frbr_uri number 

### DIFF
--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -20,7 +20,7 @@ class LegislationListView(BaseLegislationListView):
     def get_form(self):
         self.form_defaults = {"sort": "title"}
         if self.variant in ["recent", "subleg"]:
-            self.form_defaults = {"sort": "-date"}
+            self.form_defaults = {"sort": "-date", "secondary_sort": "-frbr_uri_number"}
         return super().get_form()
 
     def get_base_queryset(self, *args, **kwargs):

--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -216,6 +216,10 @@ class BaseDocumentFilterForm(forms.Form):
 
     def order_queryset(self, queryset, exclude=None):
         sort = self.cleaned_data.get("sort") or "-date"
+        if sort == "-date" and "frbr_uri_number" in self.secondary_sort:
+            self.secondary_sort = "-frbr_uri_number"
+        elif sort == "date" and "frbr_uri_number" in self.secondary_sort:
+            self.secondary_sort = "frbr_uri_number"
         queryset = queryset.order_by(sort, self.secondary_sort)
         return queryset
 


### PR DESCRIPTION
- This adds the frbr uri number as a secondary sort parameter for subleg
- The ordering needs to be reversed if the order date sorting is reversed

![image](https://github.com/user-attachments/assets/78f65042-8e98-49d7-bcc1-01b09fb899a3)

closes https://github.com/laws-africa/kenyalaw-pj/issues/115
