### PR TITLE
bootstrap 5 must not conflict with bootstrap 4 in admin

### DIFF
--- a/peachjam/adapters/indigo.py
+++ b/peachjam/adapters/indigo.py
@@ -201,6 +201,7 @@ class IndigoAdapter(RequestsAdapter):
             document = self.client_get(f"{url}.json").json()
         except requests.HTTPError as error:
             if error.response.status_code == 404:
+                logger.info(f"Document not found: {url}")
                 return
             else:
                 raise error
@@ -209,6 +210,7 @@ class IndigoAdapter(RequestsAdapter):
         if document["stub"]:
             pubdoc = document["publication_document"]
             if not pubdoc or not pubdoc["url"]:
+                logger.info("Skipping stub document without publication document")
                 return
 
         frbr_uri = FrbrUri.parse(document["frbr_uri"])

--- a/peachjam/templates/admin/change_form.html
+++ b/peachjam/templates/admin/change_form.html
@@ -21,6 +21,11 @@
   {% endblock %}
 {% endblock %}
 {% block content %}
+  <script>
+  // app-prod.js uses Bootstrap 5, but jazzmin uses Bootstrap 4. So tell Bootstrap 5 not to integrate with jquery,
+  // so that it doesn't conflict with Bootstrap 4.
+  document.body.setAttribute('data-bs-no-jquery', 'true');
+  </script>
   <script defer src="{% static 'js/app-prod.js' %}"></script>
   {{ block.super }}
   {% if original %}


### PR DESCRIPTION
This makes modals in admin area work again

![image](https://github.com/user-attachments/assets/236439f1-c9f4-44c3-8f0e-addf78b002de)


also extra logging for ingestors