### PR TITLE
base legislation list view optionally shows only national legislation

### DIFF
--- a/lawlibrary/tests/test_legislation_views.py
+++ b/lawlibrary/tests/test_legislation_views.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+
+class LegislationViewsTest(TestCase):
+    fixtures = ["tests/countries", "documents/sample_documents"]
+
+    def test_legislation_listing_locality(self):
+        response = self.client.get("/legislation/au/all")
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            [
+                "A",
+                "African Civil Aviation Commission Constitution (AFCAC)",
+                "African Union Non-Aggression and Common Defence Pact",
+            ],
+            [doc.title for doc in response.context.get("documents")],
+        )

--- a/lawlibrary/urls.py
+++ b/lawlibrary/urls.py
@@ -3,36 +3,10 @@ from django.urls import include, path
 from lawlibrary import views
 
 urlpatterns = [
-    path("legislation/", views.LegislationListView.as_view(), name="legislation_list"),
     path(
         "legislation/provincial",
         views.LocalityLegislationView.as_view(variant="provincial"),
         name="locality_legislation",
-    ),
-    path(
-        "legislation/repealed",
-        views.LegislationListView.as_view(variant="repealed"),
-        name="legislation_list_repealed",
-    ),
-    path(
-        "legislation/all",
-        views.LegislationListView.as_view(variant="all"),
-        name="legislation_list_all",
-    ),
-    path(
-        "legislation/uncommenced",
-        views.LegislationListView.as_view(variant="uncommenced"),
-        name="legislation_list_uncommenced",
-    ),
-    path(
-        "legislation/subsidiary",
-        views.LegislationListView.as_view(variant="subleg"),
-        name="legislation_list_subsidiary",
-    ),
-    path(
-        "legislation/recent",
-        views.LegislationListView.as_view(variant="recent"),
-        name="legislation_list_recent",
     ),
     path(
         "legislation/<str:code>/",

--- a/lawlibrary/views/legislation.py
+++ b/lawlibrary/views/legislation.py
@@ -2,16 +2,10 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from lawlibrary.constants import MUNICIPAL_CODES, PROVINCIAL_CODES
-from liiweb.views import LegislationListView as BaseLegislationListView
 from liiweb.views import LocalityLegislationListView as BaseLocalityLegislationListView
 from liiweb.views import LocalityLegislationView as BaseLocalityLegislationView
 from peachjam.helpers import chunks
 from peachjam.models import Locality
-
-
-class LegislationListView(BaseLegislationListView):
-    def get_base_queryset(self):
-        return super().get_base_queryset().filter(locality=None)
 
 
 class LocalityLegislationView(BaseLocalityLegislationView):

--- a/liiweb/tests/test_legislation_views.py
+++ b/liiweb/tests/test_legislation_views.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+
+class LegislationViewsTest(TestCase):
+    fixtures = ["tests/countries", "documents/sample_documents"]
+
+    def test_legislation_listing_national_only(self):
+        response = self.client.get("/legislation/all")
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            ["D", "Divorce Act, 1979"],
+            [doc.title for doc in response.context.get("documents")],
+        )

--- a/liiweb/views/legislation.py
+++ b/liiweb/views/legislation.py
@@ -16,6 +16,7 @@ class LegislationListView(BaseLegislationListView):
     variant = "current"
     latest_expression_only = True
     form_defaults = None
+    national_only = True
 
     def get_form(self):
         self.form_defaults = {"sort": "title"}
@@ -25,6 +26,12 @@ class LegislationListView(BaseLegislationListView):
 
     def get_base_queryset(self, *args, **kwargs):
         qs = super().get_base_queryset(*args, **kwargs)
+        if self.national_only:
+            # only show national legislation, for the default country (if set)
+            qs = qs.filter(locality=None)
+            country = pj_settings().default_document_jurisdiction
+            if country:
+                qs = qs.filter(jurisdiction=country)
         qs = self.get_variant_queryset(qs)
         return qs
 
@@ -106,6 +113,7 @@ class LocalityLegislationView(TemplateView):
 class LocalityLegislationListView(LegislationListView):
     template_name = "liiweb/locality_legislation_list.html"
     navbar_link = "legislation/locality"
+    national_only = False
 
     def get(self, *args, **kwargs):
         self.locality = get_object_or_404(Locality, code=kwargs["code"])


### PR DESCRIPTION
this means that a country lii can have other country's legislation (eg. for treaties from the AU or UN), but not include them in the national legislation lists.