### PR TITLE
Synonyms in search

### DIFF
--- a/africanlii/views/taxonomy.py
+++ b/africanlii/views/taxonomy.py
@@ -10,7 +10,7 @@ from africanlii.forms import ESDocumentFilterForm
 from peachjam.helpers import lowercase_alphabet
 from peachjam.models import Taxonomy
 from peachjam.views import TaxonomyDetailView, TaxonomyFirstLevelView
-from peachjam_search.documents import SearchableDocument, get_search_indexes
+from peachjam_search.documents import MultiLanguageIndexManager, SearchableDocument
 from peachjam_search.views import DocumentSearchViewSet
 
 
@@ -89,9 +89,9 @@ class DocIndexDetailView(TaxonomyDetailView):
         return documents
 
     def get_base_queryset(self):
-        index = get_search_indexes(SearchableDocument._index._name)
+        indexes = MultiLanguageIndexManager.get_instance().get_all_search_index_names()
         search = (
-            SearchableDocument.search(index=index)
+            SearchableDocument.search(index=indexes)
             .source(exclude=DocumentSearchViewSet.source["excludes"])
             .filter("term", taxonomies=self.taxonomy.slug)
         )
@@ -106,7 +106,9 @@ class DocIndexDetailView(TaxonomyDetailView):
     def add_facets(self, context):
         """Add a limited set of facets pulled from ES."""
         faceted = FacetedSearch()
-        faceted.index = get_search_indexes(SearchableDocument._index._name)
+        faceted.index = (
+            MultiLanguageIndexManager.get_instance().get_all_search_index_names()
+        )
         faceted.facets = {
             "year": TermsFacet(field="year", size=100),
             "jurisdiction": TermsFacet(field="jurisdiction", size=100),

--- a/peachjam/graph/ranker.py
+++ b/peachjam/graph/ranker.py
@@ -5,7 +5,7 @@ import igraph as ig
 from elasticsearch import helpers
 
 from peachjam.models import CoreDocument, pj_settings
-from peachjam_search.documents import SearchableDocument
+from peachjam_search.documents import MultiLanguageIndexManager, SearchableDocument
 
 from ..models import ExtractedCitation
 
@@ -84,11 +84,10 @@ class GraphRanker:
         log.info(
             f"updating index with {len(docs)} documents",
         )
-        searchable_doc = SearchableDocument()
         actions = (
             {
                 "_op_type": "update",
-                "_index": searchable_doc.get_index_for_language(
+                "_index": MultiLanguageIndexManager.get_instance().get_index_for_language(
                     doc["language__iso_639_2T"]
                 ),
                 "_id": doc["id"],

--- a/peachjam_search/apps.py
+++ b/peachjam_search/apps.py
@@ -10,9 +10,10 @@ class PeachjamSearchConfig(AppConfig):
         from background_task.models import Task
 
         import peachjam_search.signals  # noqa
-        from peachjam_search.documents import setup_language_indexes
+        from peachjam_search.documents import MultiLanguageIndexManager
 
-        setup_language_indexes()
+        manager = MultiLanguageIndexManager.get_instance()
+        manager.register_indexes()
 
         if not settings.DEBUG:
             from peachjam_search.tasks import prune_search_traces

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -5,7 +5,8 @@ from django.conf import settings
 from django.utils.functional import classproperty
 from django_elasticsearch_dsl import Document, Text, fields
 from django_elasticsearch_dsl.registries import registry
-from elasticsearch_dsl import RankFeature
+from elasticsearch_dsl import RankFeature, token_filter
+from elasticsearch_dsl.analysis import CustomAnalyzer
 from elasticsearch_dsl.index import Index
 
 from peachjam.models import (
@@ -357,15 +358,12 @@ class SearchableDocument(Document):
         parts.extend([a.title for a in instance.alternative_names.all()])
         return " ".join(parts)
 
-    def get_index_for_language(self, lang):
-        if lang in ANALYZERS:
-            return f"{self._index._name}_{lang}"
-        return self._index._name
-
     def _prepare_action(self, object_instance, action):
         info = super()._prepare_action(object_instance, action)
         log.info(f"Prepared document #{object_instance.pk} for indexing")
-        info["_index"] = self.get_index_for_language(
+        info[
+            "_index"
+        ] = MultiLanguageIndexManager.get_instance().get_index_for_language(
             object_instance.language.iso_639_2T
         )
         return info
@@ -406,45 +404,129 @@ for field, attr in SearchableDocument.translated_fields:
             make_prepare(field, attr, lang),
         )
 
-# These are the language-specific indexes we create and their associated analyzers for text fields.
-# Documents in other languages are stored in a general index with the "standard" analyzer
-ANALYZERS = {
-    "ara": "arabic",
-    "eng": "english",
-    "fra": "french",
-    "por": "portuguese",
-}
 
+class MultiLanguageIndexManager:
+    """Helper that creates multi-language indexes from the main search index definition.
+    and ensures the text fields use the correct language variant analyzers."""
 
-def get_search_indexes(base_index):
-    return (
-        [base_index]
-        + [f"{base_index}_{lang}" for lang in ANALYZERS.keys()]
-        + [
-            f"{i}_{lang}"
-            for i in settings.PEACHJAM["EXTRA_SEARCH_INDEXES"]
-            for lang in ANALYZERS.keys()
-        ]
-    )
+    # These are the language-specific indexes we create and their associated analyzers for text fields.
+    # Documents in other languages are stored in a general index with the "standard" analyzer
+    ANALYZERS = {
+        "ara": "arabic",
+        "eng": "english",
+        "fra": "french",
+        "por": "portuguese",
+    }
 
+    # analyzer and filters for synonyms
+    SYNONYM_ANALYZERS = {
+        "eng": CustomAnalyzer(
+            "english_synonym",
+            tokenizer="standard",
+            filter=[
+                token_filter(
+                    "english_synonym_filter",
+                    type="synonym_graph",
+                    synonyms=[
+                        # Any occurrence of one of these words will be expanded to all the others.
+                        # All the terms will then go through the normal filters, such as lowercasing and stemming.
+                        # NB: synonyms are case-sensitive
+                        "Anor, Another",
+                        "AU, African Union",
+                        "au, African Union",
+                        "Ors, Others",
+                        "ors, others",
+                        "R, Republic",
+                        "S, State",
+                        "v, vs, versus",
+                        "V, Vs, Versus",
+                    ],
+                ),
+                token_filter(
+                    "english_possessive_stemmer",
+                    type="stemmer",
+                    language="possessive_english",
+                ),
+                "lowercase",
+                token_filter("english_stop", type="stop", stopwords="_english_"),
+                token_filter("english_stemmer", type="stemmer", language="english"),
+            ],
+        )
+    }
 
-def setup_language_indexes():
-    """Setup multi-language indexes."""
-    main_index = SearchableDocument._index
-    mappings = main_index.to_dict()["mappings"]
+    def __init__(self):
+        self.main_index = SearchableDocument._index
+        self.setup_language_indexes()
 
-    def set_analyzer(fields, analyzer):
-        """Recursively set analyzer for text fields."""
+    @classmethod
+    def get_instance(cls):
+        if not hasattr(cls, "_instance"):
+            cls._instance = cls()
+        return cls._instance
+
+    def setup_language_indexes(self):
+        """Setup multi-language indexes."""
+        self.language_indexes = []
+        mappings = self.main_index.to_dict()["mappings"]
+
+        for lang, analyzer in self.ANALYZERS.items():
+            index = Index(name=f"{self.main_index._name}_{lang}")
+            index._settings = copy.deepcopy(self.main_index._settings)
+
+            search_analyzer = None
+            if lang in self.SYNONYM_ANALYZERS:
+                # setup synonyms
+                index.analyzer(self.SYNONYM_ANALYZERS[lang])
+                search_analyzer = self.SYNONYM_ANALYZERS[lang]._name
+
+            # update and store mappings
+            new_mappings = copy.deepcopy(mappings)
+            self.set_text_field_analyzer(
+                new_mappings["properties"].values(), analyzer, search_analyzer
+            )
+            index.get_or_create_mapping()._update_from_dict(new_mappings)
+
+            self.language_indexes.append(index)
+
+    def set_text_field_analyzer(self, fields, analyzer, search_analyzer):
+        """Recursively set analyzers for text fields."""
         for fld in fields:
             if fld["type"] == "text":
                 fld["analyzer"] = analyzer
+                if search_analyzer:
+                    fld["search_analyzer"] = search_analyzer
             elif fld["type"] == "nested":
-                set_analyzer(fld["properties"].values(), analyzer)
+                self.set_text_field_analyzer(
+                    fld["properties"].values(), analyzer, search_analyzer
+                )
 
-    for lang, analyzer in ANALYZERS.items():
-        new_mappings = copy.deepcopy(mappings)
-        set_analyzer(new_mappings["properties"].values(), analyzer)
-        index = Index(name=f"{main_index._name}_{lang}")
-        index.get_or_create_mapping()._update_from_dict(new_mappings)
-        index._settings = main_index._settings
-        registry.register(index, SearchableDocument)
+    def register_indexes(self):
+        for index in self.language_indexes:
+            registry.register(index, SearchableDocument)
+
+    def get_all_search_index_names(self):
+        """The names of all indexes to use for a search."""
+        names = [self.main_index._name] + [ix._name for ix in self.language_indexes]
+        # fold in language variants of the extra search indexes, if any
+        return names + [
+            f"{i}_{lang}"
+            for i in settings.PEACHJAM["EXTRA_SEARCH_INDEXES"]
+            for lang in self.ANALYZERS.keys()
+        ]
+
+    def get_index_for_language(self, lang):
+        if lang in self.ANALYZERS:
+            return f"{self.main_index._name}_{lang}"
+        return self.main_index._name
+
+    def update_index_settings(self):
+        for index in self.language_indexes:
+            log.info(f"Updating index settings for {index._name}")
+            index.close()
+            log.info("Index closed")
+            try:
+                index.save()
+                log.info("Index updated")
+            finally:
+                index.open()
+                log.info("Index re-opened")

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -419,7 +419,9 @@ class MultiLanguageIndexManager:
     }
 
     # analyzer and filters for synonyms
-    SYNONYM_ANALYZERS = {
+    SEARCH_ANALYZERS = {
+        # Re-implement the built-in English analyzer, but include English synonyms
+        # See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/analysis-lang-analyzer.html#english-analyzer
         "eng": CustomAnalyzer(
             "english_synonym",
             tokenizer="standard",
@@ -482,10 +484,10 @@ class MultiLanguageIndexManager:
 
         for lang, index in self.language_indexes.items():
             search_analyzer = None
-            if lang in self.SYNONYM_ANALYZERS:
+            if lang in self.SEARCH_ANALYZERS:
                 # setup synonyms
-                index.analyzer(self.SYNONYM_ANALYZERS[lang])
-                search_analyzer = self.SYNONYM_ANALYZERS[lang]._name
+                index.analyzer(self.SEARCH_ANALYZERS[lang])
+                search_analyzer = self.SEARCH_ANALYZERS[lang]._name
 
             if index.exists():
                 is_new = False

--- a/peachjam_search/documents.py
+++ b/peachjam_search/documents.py
@@ -436,6 +436,7 @@ class MultiLanguageIndexManager:
                         "Anor, Another",
                         "AU, African Union",
                         "au, African Union",
+                        "delict, tort",
                         "Ors, Others",
                         "ors, others",
                         "R, Republic",

--- a/peachjam_search/management/commands/search_index.py
+++ b/peachjam_search/management/commands/search_index.py
@@ -3,6 +3,7 @@ from django_elasticsearch_dsl.management.commands.search_index import (
 )
 from django_elasticsearch_dsl.registries import registry
 
+from peachjam_search.documents import MultiLanguageIndexManager
 from peachjam_search.tasks import search_model_saved
 
 
@@ -16,6 +17,14 @@ class Command(OriginalCommand):
             default=False,
             dest="background",
             help="Run populate tasks in the background",
+        )
+
+        parser.add_argument(
+            "--update-indexes",
+            action="store_const",
+            dest="action",
+            const="update_indexes",
+            help="Update the index settings in elasticsearch (closes and re-opens the index)",
         )
 
     def _populate(self, models, options):
@@ -33,3 +42,14 @@ class Command(OriginalCommand):
 
             for doc in qs:
                 search_model_saved(doc._meta.label, doc.pk)
+
+    def _update_mappings(self, options):
+        """Updating mappings and settings for indexes."""
+        manager = MultiLanguageIndexManager.get_instance()
+        manager.update_index_settings()
+
+    def handle(self, *args, **options):
+        if options.get("action") == "update_indexes":
+            self._update_mappings(options)
+        else:
+            super().handle(*args, **options)

--- a/peachjam_search/management/commands/search_index.py
+++ b/peachjam_search/management/commands/search_index.py
@@ -46,7 +46,8 @@ class Command(OriginalCommand):
     def _update_mappings(self, options):
         """Updating mappings and settings for indexes."""
         manager = MultiLanguageIndexManager.get_instance()
-        manager.update_index_settings()
+        manager.load_language_index_settings()
+        manager.update_language_index_settings()
 
     def handle(self, *args, **options):
         if options.get("action") == "update_indexes":

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -36,7 +36,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from peachjam.models import Author, CourtRegistry, Judge, Label, pj_settings
 from peachjam_api.serializers import LabelSerializer
-from peachjam_search.documents import SearchableDocument, get_search_indexes
+from peachjam_search.documents import MultiLanguageIndexManager, SearchableDocument
 from peachjam_search.models import SearchTrace
 from peachjam_search.serializers import (
     SearchableDocumentSerializer,
@@ -558,7 +558,9 @@ class DocumentSearchViewSet(BaseDocumentViewSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # search multiple language indexes
-        self.index = get_search_indexes(self.document._index._name)
+        self.index = (
+            MultiLanguageIndexManager.get_instance().get_all_search_index_names()
+        )
         self.search = self.search.index(self.index)
 
     def get_translatable_fields(self, request):


### PR DESCRIPTION
This enables per-language synonyms in elasticsearch. Currently only English synonyms are provided.

* setup a new search-only analyzer for text fields
* a new `search_index` mgmt command option to update the synonym details in elasticsearch.
* this has to take into account that some fields in some indexes have the `standard` analyzer set, and this can't be changed without re-index (unfortunately).

Once deployed, this is set up with `python manage.py search_index --update-indexes`

![image (2)](https://github.com/user-attachments/assets/c6c888e3-377f-484b-987a-b702da38f434)

