### PR TITLE
All judgments view, labels facet

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -138,6 +138,7 @@ class BaseDocumentFilterForm(forms.Form):
     attorneys = PermissiveTypedListField(coerce=remove_nulls, required=False)
     outcomes = PermissiveTypedListField(coerce=remove_nulls, required=False)
     taxonomies = PermissiveTypedListField(coerce=remove_nulls, required=False)
+    labels = PermissiveTypedListField(coerce=remove_nulls, required=False)
     q = forms.CharField(required=False)
 
     sort = forms.ChoiceField(
@@ -174,6 +175,7 @@ class BaseDocumentFilterForm(forms.Form):
         divisions = self.cleaned_data.get("divisions", [])
         attorneys = self.cleaned_data.get("attorneys", [])
         outcomes = self.cleaned_data.get("outcomes", [])
+        labels = self.cleaned_data.get("labels", [])
         taxonomies = self.cleaned_data.get("taxonomies", [])
         q = self.cleaned_data.get("q")
 
@@ -214,6 +216,9 @@ class BaseDocumentFilterForm(forms.Form):
 
         if outcomes and exclude != "outcomes":
             queryset = queryset.filter(outcomes__name__in=outcomes).distinct()
+
+        if labels and exclude != "labels":
+            queryset = queryset.filter(labels__name__in=labels).distinct()
 
         if taxonomies and exclude != "taxonomies":
             queryset = queryset.filter(taxonomies__topic__slug__in=taxonomies)

--- a/peachjam/templates/peachjam/_court_list.html
+++ b/peachjam/templates/peachjam/_court_list.html
@@ -7,7 +7,7 @@
           <div class="card-body">
             <h4 class="mb-2">{{ court_class }}</h4>
             {% if court_class.courts.all %}
-              <ul class="list-unstyled">
+              <ul class="list-unstyled mb-0">
                 {% for court in court_class.courts.all %}
                   <li>
                     {% block court_link %}

--- a/peachjam/templates/peachjam/_court_list.html
+++ b/peachjam/templates/peachjam/_court_list.html
@@ -3,27 +3,31 @@
   <div class="flow-columns mb-3">
     {% for court_class in court_classes %}
       <div class="flow-columns-group mb-4">
-        <h4 class="mb-2">{{ court_class }}</h4>
-        {% if court_class.show_listing_page %}
-          <div class="mb-3">
-            {% block court_class_link %}
-              <a href="{% url 'court_class' court_class.slug %}">{% trans 'All judgments' %}</a>
-            {% endblock %}
+        <div class="card">
+          <div class="card-body">
+            <h4 class="mb-2">{{ court_class }}</h4>
+            {% if court_class.courts.all %}
+              <ul class="list-unstyled">
+                {% for court in court_class.courts.all %}
+                  <li>
+                    {% block court_link %}
+                      <a href="{% url 'court' court.code %}">{{ court.name }}</a>
+                    {% endblock %}
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <div>{% trans 'No courts found.' %}</div>
+            {% endif %}
           </div>
-        {% endif %}
-        {% if court_class.courts.all %}
-          <ul class="list-unstyled">
-            {% for court in court_class.courts.all %}
-              <li>
-                {% block court_link %}
-                  <a href="{% url 'court' court.code %}">{{ court.name }}</a>
-                {% endblock %}
-              </li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          <div>{% trans 'No courts found.' %}</div>
-        {% endif %}
+          {% if court_class.show_listing_page %}
+            <div class="card-footer">
+              {% block court_class_link %}
+                <a href="{% url 'court_class' court_class.slug %}">{% blocktrans with court=court_class %}Explore {{ court }}{% endblocktrans %} →</a>
+              {% endblock %}
+            </div>
+          {% endif %}
+        </div>
       </div>
     {% endfor %}
   </div>

--- a/peachjam/templates/peachjam/_quick_search.html
+++ b/peachjam/templates/peachjam/_quick_search.html
@@ -6,7 +6,7 @@
          placeholder="Search {{ court.name }} {{ author.name }} {{ nature.name }} {{ registry.name }} {% if MULTIPLE_JURISDICTIONS and country %}{{ country.name }}{% endif %} {{ locality.name }} {{ year }} "/>
   <input type="submit" class="btn btn-outline-primary ms-2" value="Search"/>
   {% if year %}<input type="hidden" name="year" value="{{ year }}"/>{% endif %}
-  {% if court %}<input type="hidden" name="court" value="{{ court }}"/>{% endif %}
+  {% if court and court.code != "all" %}<input type="hidden" name="court" value="{{ court }}"/>{% endif %}
   {% if author %}<input type="hidden" name="authors" value="{{ author }}"/>{% endif %}
   {% if nature %}<input type="hidden" name="nature" value="{{ nature }}"/>{% endif %}
   {% if registry %}<input type="hidden" name="registry" value="{{ registry }}"/>{% endif %}

--- a/peachjam/templates/peachjam/judgment_list.html
+++ b/peachjam/templates/peachjam/judgment_list.html
@@ -7,8 +7,15 @@
   <h1 class="mt-4">{% trans 'Judgments' %}</h1>
 {% endblock %}
 {% block document-table %}
+  {% block all-courts %}
+    <h4 class="mt-3 mb-2">{% trans "All courts" %}</h4>
+    <div class="mb-4">
+      {% trans "Explore judgments from all courts." %}
+      <a href="{% url 'court' 'all' %}" class="ms-3">{% trans "Explore all courts" %} →</a>
+    </div>
+  {% endblock %}
   {% include 'peachjam/_court_list.html' %}
-  <h4 class="mb-2 mt-4">
+  <h4 class="mb-2 mt-5">
     {% if title %}
       {{ title }}
     {% else %}

--- a/peachjam/tests/test_views.py
+++ b/peachjam/tests/test_views.py
@@ -86,6 +86,38 @@ class PeachjamViewsTest(TestCase):
             self.client.get("/judgments/ECOWASCJ/999999/").status_code, 404
         )
 
+    def test_all_judgments_listing(self):
+        response = self.client.get("/judgments/all/")
+        self.assertEqual(response.status_code, 200)
+
+        documents = [doc.title for doc in response.context.get("documents")]
+        self.assertIn(
+            "Ababacar and Ors vs Senegal [2018] ECOWASCJ 17 (29 June 2018)",
+            documents,
+        )
+        self.assertContains(response, "/judgments/all/2018/")
+        self.assertContains(response, "/judgments/all/2016/")
+        self.assertNotIn("years", response.context["facet_data"], [2016, 2018])
+
+    def test_all_judgments_year_listing(self):
+        response = self.client.get("/judgments/all/2016/")
+        self.assertEqual(response.status_code, 200)
+
+        documents = [doc.title for doc in response.context.get("documents")]
+
+        self.assertIn(
+            "Obi vs Federal Republic of Nigeria [2016] ECOWASCJ 52 (09 November 2016)",
+            documents,
+        )
+        self.assertNotIn(
+            "Ababacar and Ors vs Senegal [2018] ECOWASCJ 17 (29 June 2018)",
+            documents,
+        )
+        self.assertEqual(response.context["year"], 2016)
+        self.assertContains(response, "/judgments/all/2018/")
+        self.assertContains(response, "/judgments/all/2016/")
+        self.assertNotIn("years", response.context["facet_data"], [2016, 2018])
+
     def test_judgment_detail(self):
         response = self.client.get(
             "/akn/aa-au/judgment/ecowascj/2018/17/eng@2018-06-29"

--- a/peachjam/urls.py
+++ b/peachjam/urls.py
@@ -121,51 +121,58 @@ urlpatterns = [
         AuthorDetailView.as_view(),
         name="author",
     ),
-    path("judgments/", JudgmentListView.as_view(), name="judgment_list"),
     path(
-        "judgments/court-class/<str:court_class>/",
-        CourtClassDetailView.as_view(),
-        name="court_class",
-    ),
-    path(
-        "judgments/court-class/<str:court_class>/<int:year>/",
-        CourtClassYearView.as_view(),
-        name="court_class_year",
-    ),
-    path(
-        "judgments/court-class/<str:court_class>/<int:year>/<int:month>/",
-        CourtClassMonthView.as_view(),
-        name="court_class_month",
-    ),
-    path(
-        "judgments/<str:code>/",
-        CourtDetailView.as_view(),
-        name="court",
-    ),
-    path(
-        "judgments/<str:code>/<int:year>/",
-        CourtYearView.as_view(),
-        name="court_year",
-    ),
-    path(
-        "judgments/<str:code>/<int:year>/<int:month>/",
-        CourtMonthView.as_view(),
-        name="court_month",
-    ),
-    path(
-        "judgments/<str:code>/<str:registry_code>/",
-        CourtRegistryDetailView.as_view(),
-        name="court_registry",
-    ),
-    path(
-        "judgments/<str:code>/<str:registry_code>/<int:year>/",
-        CourtRegistryYearView.as_view(),
-        name="court_registry_year",
-    ),
-    path(
-        "judgments/<str:code>/<str:registry_code>/<int:year>/<int:month>/",
-        CourtRegistryMonthView.as_view(),
-        name="court_registry_month",
+        "judgments/",
+        include(
+            [
+                path("", JudgmentListView.as_view(), name="judgment_list"),
+                path(
+                    "court-class/<str:court_class>/",
+                    CourtClassDetailView.as_view(),
+                    name="court_class",
+                ),
+                path(
+                    "court-class/<str:court_class>/<int:year>/",
+                    CourtClassYearView.as_view(),
+                    name="court_class_year",
+                ),
+                path(
+                    "court-class/<str:court_class>/<int:year>/<int:month>/",
+                    CourtClassMonthView.as_view(),
+                    name="court_class_month",
+                ),
+                path(
+                    "<str:code>/",
+                    CourtDetailView.as_view(),
+                    name="court",
+                ),
+                path(
+                    "<str:code>/<int:year>/",
+                    CourtYearView.as_view(),
+                    name="court_year",
+                ),
+                path(
+                    "<str:code>/<int:year>/<int:month>/",
+                    CourtMonthView.as_view(),
+                    name="court_month",
+                ),
+                path(
+                    "<str:code>/<str:registry_code>/",
+                    CourtRegistryDetailView.as_view(),
+                    name="court_registry",
+                ),
+                path(
+                    "<str:code>/<str:registry_code>/<int:year>/",
+                    CourtRegistryYearView.as_view(),
+                    name="court_registry_year",
+                ),
+                path(
+                    "<str:code>/<str:registry_code>/<int:year>/<int:month>/",
+                    CourtRegistryMonthView.as_view(),
+                    name="court_registry_month",
+                ),
+            ]
+        ),
     ),
     path("causelists/", CauseListListView.as_view(), name="causelist_list"),
     path(

--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -79,6 +79,24 @@ class FilteredJudgmentView(FilteredDocumentListView):
                 "values": self.request.GET.getlist("judges"),
             }
 
+        if "labels" not in self.exclude_facets:
+            labels = list(
+                label
+                for label in self.form.filter_queryset(
+                    self.get_base_queryset(), exclude="labels"
+                )
+                .order_by()
+                .values_list("labels__name", flat=True)
+                .distinct()
+                if label
+            )
+            context["facet_data"]["labels"] = {
+                "label": _("Labels"),
+                "type": "checkbox",
+                "options": sorted([(x, x) for x in labels]),
+                "values": self.request.GET.getlist("labels"),
+            }
+
         if "outcomes" not in self.exclude_facets:
             outcomes = Outcome.objects.filter(
                 pk__in=self.form.filter_queryset(

--- a/peachjam/views/courts.py
+++ b/peachjam/views/courts.py
@@ -178,7 +178,7 @@ class CourtDetailView(FilteredJudgmentView):
     @cached_property
     def court(self):
         if self.kwargs.get("code") == "all":
-            return Court(name="All courts", code="all")
+            return Court(name=_("All courts"), code="all")
         return get_object_or_404(Court, code=self.kwargs.get("code"))
 
     def base_view_name(self):


### PR DESCRIPTION
* new view for judgments from all courts
* link to all courts from top of judgments page
* short court groupings as cards -- the big win here is that the "all judgments" link can go into the card footer
* labels faceted, for exploring reported judgments

![image](https://github.com/user-attachments/assets/6d93404a-5291-4925-a3c0-66eb32cf4af8)

![image](https://github.com/user-attachments/assets/db7b2979-8236-4cbf-bea8-b7a9cd92954a)

![image](https://github.com/user-attachments/assets/f329ed69-642f-4f4f-9c0f-3226ecb7faa3)
