### PR TITLE
Field ordering for legislation listing and search results

### DIFF
--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -307,9 +307,66 @@ export default {
       googleActive: false
     };
     const facets = [
+      // most frequently used facets first, based on user data
       {
         title: this.$t('Document type'),
         name: 'nature',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: this.$t('Court'),
+        name: 'court',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: this.$t('Year'),
+        name: 'year',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: getTitle('registry'),
+        name: 'registry',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: this.$t('Locality'),
+        name: 'locality',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: this.$t('Outcome'),
+        name: 'outcome',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: getTitle('judge'),
+        name: 'judges',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: getTitle('author'),
+        name: 'authors',
+        type: 'checkboxes',
+        value: [],
+        options: []
+      },
+      {
+        title: this.$t('Language'),
+        name: 'language',
         type: 'checkboxes',
         value: [],
         options: []
@@ -323,50 +380,8 @@ export default {
         optionLabels: getLabelOptionLabels(data.documentLabels)
       },
       {
-        title: getTitle('author'),
-        name: 'authors',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
-        title: this.$t('Court'),
-        name: 'court',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
-        title: getTitle('registry'),
-        name: 'registry',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
-        title: getTitle('judge'),
-        name: 'judges',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
         title: this.$t('Attorneys'),
         name: 'attorneys',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
-        title: this.$t('Outcome'),
-        name: 'outcome',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
-        title: this.$t('Locality'),
-        name: 'locality',
         type: 'checkboxes',
         value: [],
         options: []
@@ -377,25 +392,11 @@ export default {
         type: 'checkboxes',
         value: [],
         options: []
-      },
-      {
-        title: this.$t('Language'),
-        name: 'language',
-        type: 'checkboxes',
-        value: [],
-        options: []
-      },
-      {
-        title: this.$t('Year'),
-        name: 'year',
-        type: 'checkboxes',
-        value: [],
-        options: []
       }
     ];
 
     if (this.showJurisdiction) {
-      facets.splice(0, 0, {
+      facets.splice(1, 0, {
         title: this.$t('Jurisdiction'),
         name: 'jurisdiction',
         type: 'checkboxes',

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -21,6 +21,14 @@ class LegislationListView(FilteredDocumentListView):
     extra_context = {"nature": "Act", "help_link": "legislation/"}
     form_defaults = {"sort": "title"}
 
+    def add_facets(self, context):
+        super().add_facets(context)
+        # move the alphabet facet first, it's highly used on the legislation page for some LIIs
+        facets = {"alphabet": context["facet_data"].pop("alphabet")}
+        for k, v in context["facet_data"].items():
+            facets[k] = v
+        context["facet_data"] = facets
+
 
 @registry.register_doc_type("legislation")
 class LegislationDetailView(BaseDocumentDetailView):


### PR DESCRIPTION
* search facet ordering updated to put most commonly used at the top
* legislation facet ordering updated to move alphabet first, since it's heavily use in KE (and more used than other facets in other places)

![image](https://github.com/user-attachments/assets/ece2383d-d3f5-4b9f-bac2-f39743b6e633)


![image](https://github.com/user-attachments/assets/8631fc62-98fb-487b-a059-41a76ef58db3)
