### PR TITLE
set line-height for docs with html content

### DIFF
--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -6,8 +6,8 @@
   }
 
   .content.content__html {
-    // reset line height so html documents use their default, rather than bootstrap's adjusted line height
-    line-height: normal;
+    // reset line height to a reasonable default for text documents, rather than bootstrap's adjusted line height
+    line-height: 1.3;
     font-size: 15px;
 
     // style embedded la-akoma-ntoso content


### PR DESCRIPTION
the bootstrap default is 1.5 (too big), but the "normal" default is around 1.2 which is too cramped.

before:

![image](https://github.com/user-attachments/assets/8278e3c8-a15d-4edc-b99d-db5ecb1ac0da)



after:

![image](https://github.com/user-attachments/assets/578d82b8-d37c-4590-862f-fa43674fabf5)
