### PR TITLE
use DocumentPublicationView from timeline too

### DIFF
--- a/peachjam/templates/peachjam/_timeline_events.html
+++ b/peachjam/templates/peachjam/_timeline_events.html
@@ -22,8 +22,9 @@
           {% for event in entry.events %}
             <div>
               {% if event.type == "publication" %}
-                {% if event.link_url %}
-                  <a href="{{ event.link_url }}">{{ event.description }}</a>
+                {% if document.publication_file %}
+                  <a href="{% url 'document_publication' document.expression_frbr_uri|strip_first_character %}"
+                     target="_blank">{{ event.description }}</a>
                 {% else %}
                   {{ event.description }}
                 {% endif %}

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -238,18 +238,7 @@ class LegislationDetailView(BaseDocumentDetailView):
 
     def get_timeline(self):
         timeline = self.object.timeline_json
-        publication_url = None
-        work = self.object.metadata_json
         points_in_time = self.get_points_in_time()
-
-        # set publication_url
-        publication_date = work.get("publication_date")
-        if publication_date:
-            api_url = "https://api.laws.africa/v3/"
-            commons_url = "https://commons.laws.africa/"
-            publication_url = (work.get("publication_document") or {}).get("url")
-            if publication_url and api_url in publication_url:
-                publication_url = publication_url.replace(api_url, commons_url)
 
         # prepare for setting contains_unapplied_amendment flag
         point_in_time_dates = [p["date"] for p in points_in_time]
@@ -272,9 +261,6 @@ class LegislationDetailView(BaseDocumentDetailView):
             # add expression_frbr_uri
             for event in entry["events"]:
                 entry["expression_frbr_uri"] = expression_uris.get(entry["date"])
-                # add publication_url to publication event
-                if event["type"] == "publication":
-                    event["link_url"] = publication_url
                 # add contains_unapplied_amendment flag
                 if event["type"] == "amendment":
                     entry["contains_unapplied_amendment"] = (


### PR DESCRIPTION
Currently, we use the 'raw' data for linking to a publication document in the timeline. 
In the cases where the publication document URL includes exactly `https://api.laws.africa/v3/` (when a PDF was uploaded, rather than linked to, on the platform), we point the link to `https://commons.laws.africa/` instead.

However, this assumes both that a peachjam lii always has the same API URL, and that all peachjam lii publication documents are on commons.laws.africa, and neither of these assumptions has been borne out.

We have also in the meantime added a PublicationFile model and a related view, which we use in the document detail view.

This brings the link in the timeline in line with the document detail view by using the same view to link to the publication document.

