### PR TITLE
optimise object lookup

### DIFF
--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -291,7 +291,7 @@ class CoreDocumentQuerySet(PolymorphicQuerySet):
             return obj, True
 
         # try looking based on the work URI instead, and use the latest expression
-        qs = CoreDocument.objects.filter(work_frbr_uri=frbr_uri)
+        qs = CoreDocument.objects.filter(work__frbr_uri=frbr_uri)
 
         # first, look for one in the user's preferred language
         if lang:

--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -286,8 +286,8 @@ class CoreDocumentQuerySet(PolymorphicQuerySet):
         """Get the best object for this FRBR URI, which could be an expression or a work URI.
         Returns an (object, exact) tuple, where exact is a boolean indicating if the match was an exact one,
         or a guess."""
-        obj = self.filter(expression_frbr_uri=frbr_uri).first()
-        if obj:
+        if "@" in frbr_uri:
+            obj = self.filter(expression_frbr_uri=frbr_uri).first()
             return obj, True
 
         # try looking based on the work URI instead, and use the latest expression
@@ -295,11 +295,9 @@ class CoreDocumentQuerySet(PolymorphicQuerySet):
 
         # first, look for one in the user's preferred language
         if lang:
-            lang = Language.objects.filter(pk=lang).first()
-            if lang:
-                obj = qs.filter(language=lang).latest_expression().first()
-                if obj:
-                    return obj, False
+            obj = qs.filter(language__pk=lang).latest_expression().first()
+            if obj:
+                return obj, False
 
         # try the default site language
         lang = pj_settings().default_document_language

--- a/peachjam/templates/peachjam/document_popup.html
+++ b/peachjam/templates/peachjam/document_popup.html
@@ -12,9 +12,7 @@
         {% block title %}
           <b>{{ document.title }}</b>
           {% block title-badges %}
-            {% if document.metadata_json.repealed %}
-              <span class="badge bg-danger">{% trans 'repealed' %}</span>
-            {% endif %}
+            {% include 'peachjam/_document_labels.html' with labels=document.labels.all %}
           {% endblock %}
         {% endblock %}
       </div>

--- a/peachjam/views/widgets.py
+++ b/peachjam/views/widgets.py
@@ -83,7 +83,9 @@ class DocumentPopupView(DetailView):
         else:
             uri = self.frbr_uri.work_uri()
 
-        obj = self.model.objects.best_for_frbr_uri(uri, get_language())[0]
+        obj = self.model.objects.prefetch_related("labels").best_for_frbr_uri(
+            uri, get_language()
+        )[0]
         if not obj:
             raise Http404()
         return obj


### PR DESCRIPTION
this potentially saves two unnecessary trips to the db, and uses the work__frbr_uri unique index

before:

![image](https://github.com/user-attachments/assets/db7ba817-6e00-4fc9-9db6-043a7b94e723)



after:

![image](https://github.com/user-attachments/assets/c0c32adc-d5ee-463a-b462-a1f167b8f7aa)
