### PR TITLE
fix document author on listing page

### DIFF
--- a/peachjam/templates/peachjam/_document_table_row.html
+++ b/peachjam/templates/peachjam/_document_table_row.html
@@ -46,7 +46,7 @@
       <td>{{ document.locality|default_if_none:'' }}</td>
     {% endif %}
   {% endif %}
-  {% if doc_table_show_author %}<td>{{ document.author|default_if_none:'' }}</td>{% endif %}
+  {% if doc_table_show_author %}<td>{{ document.author.first|default_if_none:'' }}</td>{% endif %}
   {% if doc_table_show_court %}<td>{{ document.court|default_if_none:'' }}</td>{% endif %}
   {% if doc_table_show_sub_publication %}<td>{{ document.sub_publication|default_if_none:'' }}</td>{% endif %}
   {% if doc_table_show_frbr_uri_number %}<td>{{ document.frbr_uri_number }}</td>{% endif %}


### PR DESCRIPTION
this broke when added multiple authors, we can simply show the first one on the listing page

before:
![image](https://github.com/user-attachments/assets/6a72722b-ea37-4b2a-ada7-58d8316b07aa)

after:
![image](https://github.com/user-attachments/assets/d1490ce0-a548-44a2-996c-24c7fd2090d3)
