### PR TITLE
added email share

### DIFF
--- a/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
+++ b/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
@@ -53,6 +53,13 @@
               @click="modal.hide()"
             ><i class="bi bi-linkedin linkedin-forecolor share-icon" />
             </a>
+            <a
+              :href="`mailto:?subject=${$t('Take a look at this text from') + ' ' + truncatedText}&body=${text}%0A%0ASee more at ${encodeURIComponent(url) }`"
+              class="btn btn-link"
+              target="_blank"
+              @click="modal.hide()"
+            ><i class="bi bi-envelope-at-fill envelope-at-fill-forecolor share-icon" />
+            </a>
           </div>
         </div>
       </div>
@@ -69,6 +76,10 @@ export default {
   computed: {
     combined () {
       return encodeURIComponent(`${this.text} ${this.url}`)
+    },
+    truncatedText () {
+      const title = document.querySelector('.document-content')?.dataset?.title || '';
+      return title.split(' ').splice(0, 8).join(' ') + '...';
     }
   },
 

--- a/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
+++ b/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
@@ -54,7 +54,7 @@
             ><i class="bi bi-linkedin linkedin-forecolor share-icon" />
             </a>
             <a
-              :href="`mailto:?subject=${$t('Take a look at this text from') + ' ' + truncatedText}&body=${text}%0A%0ASee more at ${encodeURIComponent(url) }`"
+              :href="`mailto:?subject=${emailSubject}&body=${combined}`"
               class="btn btn-link"
               target="_blank"
               @click="modal.hide()"
@@ -75,11 +75,14 @@ export default {
 
   computed: {
     combined () {
-      return encodeURIComponent(`${this.text} ${this.url}`)
+      return encodeURIComponent(`${this.text} ${this.url}`);
     },
-    truncatedText () {
-      const title = document.querySelector('.document-content')?.dataset?.title || '';
-      return title.split(' ').splice(0, 8).join(' ') + '...';
+    emailSubject () {
+      const emailShare = document.querySelector('#email-share');
+      if (emailShare) {
+        return emailShare.getAttribute('data-subject');
+      }
+      return '';
     }
   },
 

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -134,6 +134,9 @@ footer {
 .linkedin-forecolor {
   color: $linkedin-color;
 }
+.envelope-at-fill-forecolor {
+  color: $envelope-at-fill-color;
+}
 
 .youtube-forecolor {
   color: $youtube-color;

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -13,6 +13,7 @@ $twitter-color: #2AA1F2 !default;
 $twitter-x-color: #333 !default;
 $whatsapp-color: #25D366 !default;
 $linkedin-color: #0a66c2 !default;
+$envelope-at-fill-color: #6c757d !default;
 $youtube-color: #FF0000 !default;
 $anntn-highlight-color: #a68bdc !default;
 $diff-green-color: #a6f3a6 !default;

--- a/peachjam/templates/peachjam/article_detail.html
+++ b/peachjam/templates/peachjam/article_detail.html
@@ -53,6 +53,11 @@
              target="_blank">
             <i class="bi bi-facebook facebook-forecolor share-icon"></i>
           </a>
+          <a href="mailto:?subject={% trans 'Take a look at this article from' %} {{ APP_NAME }}: {{ article.title|truncatewords:7|escape }}&body={{ request.build_absolute_uri }}"
+             class="btn btn-link share-link"
+             target="_blank">
+            <i class="bi bi-envelope-at-fill envelope-at-fill-forecolor share-icon"></i>
+          </a>
         </div>
       </div>
     </header>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -51,9 +51,11 @@
                  target="_blank">
                 <i class="bi bi-linkedin linkedin-forecolor share-icon"></i>
               </a>
-              <a href="mailto:?subject={% trans 'Take a look at this document from' %} {{ APP_NAME }}: {{ document.title|truncatewords:7|escape }}&body={{ request.build_absolute_uri }}"
+              <a id="email-share"
+                 href="mailto:?subject={% trans 'Take a look at this document from' %} {{ APP_NAME }}: {{ document.title|truncatewords:7|escape }}&body={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
-                 target="_blank">
+                 target="_blank"
+                 data-subject="{% trans 'Take a look at this document from' %} {{ APP_NAME }}: {{ document.title|truncatewords:7|escape }}">
                 <i class="bi bi-envelope-at-fill envelope-at-fill-forecolor share-icon"></i>
               </a>
             </div>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -51,6 +51,11 @@
                  target="_blank">
                 <i class="bi bi-linkedin linkedin-forecolor share-icon"></i>
               </a>
+              <a href="mailto:example@exapmle.com?subject=Check out this document&body={{ request.build_absolute_uri }}"
+                 class="btn btn-link share-link"
+                 target="_blank">
+                <i class="bi bi-envelope-at-fill envelope-at-fill-forecolor share-icon"></i>
+              </a>
             </div>
           </div>
         {% endblock %}

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -51,7 +51,7 @@
                  target="_blank">
                 <i class="bi bi-linkedin linkedin-forecolor share-icon"></i>
               </a>
-              <a href="mailto:example@exapmle.com?subject=Check out this document&body={{ request.build_absolute_uri }}"
+              <a href="mailto:?subject={% trans 'Take a look at this document from' %} {{ APP_NAME }}: {{ document.title|truncatewords:7|escape }}&body={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
                  target="_blank">
                 <i class="bi bi-envelope-at-fill envelope-at-fill-forecolor share-icon"></i>


### PR DESCRIPTION
- Closes #2223 
- This is a draft to show how it currently works. If you'd like to change something, kindly let me know.
- There are also share buttons on the article detail page and share selection modal. Should I add it there as well?
- You can also mention other places you'd like me to add the email share to.

![Screenshot 2025-01-14 at 10 20 13](https://github.com/user-attachments/assets/0afbe48a-6626-4fae-9c5f-6b4845f20ad1)
![Screenshot 2025-01-14 at 10 20 38](https://github.com/user-attachments/assets/5197a14c-9c41-4598-b829-6ed8f1eaf471)
