### PR TITLE
social login improvements

### DIFF
--- a/peachjam/templates/account/login.html
+++ b/peachjam/templates/account/login.html
@@ -69,23 +69,27 @@
         </p>
       </div>
     </form>
-    {{ social_apps }}
     {% get_providers as socialaccount_providers %}
     {% if socialaccount_providers %}
       <hr/>
       {% for provider in socialaccount_providers %}
-        <a class="btn btn-block btn-outline-primary socialaccount_provider {{ provider.id }}"
-           href="{% provider_login_url provider.id process='login' %}">
-          {% if provider.name == "Google" %}
-            <img alt="google-logo"
-                 src="{% static 'images/google-logo.png' %}"
-                 style="height: 16px;
-                        margin-right: 5px"/>
-          {% else %}
-            <i class="bi bi-{{ provider.id }}"></i>
-          {% endif %}
-          {% trans 'Login with ' %}{{ provider.name }}
-        </a>
+        <form method="post"
+              class="mt-4"
+              action="{% provider_login_url provider.id process='login' %}">
+          {% csrf_token %}
+          <button class="btn btn-block btn-outline-primary mb-3 socialaccount_provider {{ provider.id }}"
+                  type="submit">
+            {% if provider.name == "Google" %}
+              <img alt="google-logo"
+                   src="{% static 'images/google-logo.png' %}"
+                   style="height: 16px;
+                          margin-right: 5px"/>
+            {% else %}
+              <i class="bi bi-{{ provider.id }}"></i>
+            {% endif %}
+            {% blocktrans with provider=provider.name %}Log in with {{provider}}{% endblocktrans %}
+          </button>
+        </form>
       {% endfor %}
     {% endif %}
   </div>

--- a/peachjam/templates/admin/login.html
+++ b/peachjam/templates/admin/login.html
@@ -60,19 +60,25 @@
   <div style="margin-top:1rem;">
     <div style="margin-top:1rem;">
       <div class="col-lg-8 mx-auto">
-        {% for app in social_apps %}
-          <a class="btn btn-block btn-outline-primary mb-3 socialaccount_provider {{ app.name }}"
-             href="{% provider_login_url app.provider process='login' %}">
-            {% if app.provider == "google" %}
-              <img src="{% static 'images/google-logo.png' %}"
-                   alt="Google logo"
-                   style="height: 20px;
-                          margin-right: 5px"/>
-            {% else %}
-              <i class="fab fa-fw fa-{{ app.name }}"></i>
-            {% endif %}
-            Log in with {{ app.provider|title }}
-          </a>
+        {% get_providers as socialaccount_providers %}
+        {% for provider in socialaccount_providers %}
+          <form method="post"
+                class="mt-4"
+                action="{% provider_login_url provider.id process='login' %}">
+            {% csrf_token %}
+            <button class="btn btn-block btn-outline-primary mb-3 socialaccount_provider {{ provider.id }}"
+                    type="submit">
+              {% if provider.name == "Google" %}
+                <img alt="google-logo"
+                     src="{% static 'images/google-logo.png' %}"
+                     style="height: 16px;
+                            margin-right: 5px"/>
+              {% else %}
+                <i class="bi bi-{{ provider.id }}"></i>
+              {% endif %}
+              {% blocktrans with provider=provider.name %}Log in with {{provider}}{% endblocktrans %}
+            </button>
+          </form>
         {% endfor %}
       </div>
     </div>

--- a/peachjam/templates/peachjam/_header.html
+++ b/peachjam/templates/peachjam/_header.html
@@ -65,7 +65,8 @@
         {% elif PEACHJAM_SETTINGS.allow_save_documents %}
           <ul class="navbar-nav">
             <li class="nav-item">
-              <a class="btn btn-primary" href="{% url 'account_login' %}">{% trans "Log in" %}</a>
+              <a class="btn btn-primary"
+                 href="{% url 'account_login' %}?next={{ request.get_full_path|urlencode }}">{% trans "Log in" %}</a>
             </li>
           </ul>
         {% endif %}

--- a/peachjam_search/templates/peachjam_search/_saved_search_modal.html
+++ b/peachjam_search/templates/peachjam_search/_saved_search_modal.html
@@ -62,7 +62,8 @@
             </button>
           {% endif %}
         {% else %}
-          <a href="{% url 'account_login' %}" class="btn btn-primary">{% trans 'Login' %}</a>
+          <a href="{% url 'account_login' %}?next={{ request.htmx.current_url_abs_path|urlencode }}"
+             class="btn btn-primary">{% trans 'Login' %}</a>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
* redirect back to original page when logging in - django-allauth handles this correctly if ?next=xxx is passed in
* use POST so that the intermediate "you're about to login with a social provider" page is skipped