### PR TITLE
Floating titlebar above document

### DIFF
--- a/peachjam/js/components/floating-header.ts
+++ b/peachjam/js/components/floating-header.ts
@@ -11,7 +11,7 @@ export default class FloatingHeader {
   }
 
   init () {
-    window.addEventListener('scroll', debounce(this.onScroll.bind(this), 200));
+    window.addEventListener('scroll', debounce(this.onScroll.bind(this), 50));
   }
 
   onScroll () {

--- a/peachjam/js/components/floating-header.ts
+++ b/peachjam/js/components/floating-header.ts
@@ -1,0 +1,25 @@
+import debounce from 'lodash/debounce';
+
+export default class FloatingHeader {
+  public root: HTMLElement;
+  public documentContent: HTMLElement;
+
+  constructor(root: HTMLElement) {
+    this.root = root;
+    this.documentContent = document.querySelector('.document-detail-toolbar') as HTMLElement;
+    this.init();
+  }
+
+  init () {
+    window.addEventListener('scroll', debounce(this.onScroll.bind(this), 200));
+  }
+
+  onScroll () {
+    const contentTop = this.documentContent.getBoundingClientRect().top;
+    if (contentTop <= -10) {
+      this.root.classList.add('visible');
+    } else {
+      this.root.classList.remove('visible');
+    }
+  }
+}

--- a/peachjam/js/components/index.ts
+++ b/peachjam/js/components/index.ts
@@ -3,6 +3,7 @@ import { RelationshipEnrichments } from './RelationshipEnrichment';
 import DocumentFilterForm from './document-filter-form';
 import DocumentTable from './document-table';
 import DocumentContent from './DocumentContent/index';
+import FloatingHeader from './floating-header';
 import NavigationSelect from './navigation-select';
 import { ToggleTab } from './tabs';
 import TaxonomyTree from './taxonomy-tree';
@@ -21,6 +22,7 @@ const components: Record<string, any> = {
   DocumentContent,
   DocumentFilterForm,
   DocumentTable,
+  FloatingHeader,
   NavigationSelect,
   RelationshipEnrichments,
   SearchTypeahead,

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -32,3 +32,4 @@ $visited-link: #1A77F2 !default;
 $breadcrumb-margin-bottom: 1rem !default;
 
 $floating-header-height: 3rem !default;
+$floating-header-height-md: 2.5rem !default;

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -30,3 +30,5 @@ $visited-link: #1A77F2 !default;
 }
 
 $breadcrumb-margin-bottom: 1rem !default;
+
+$floating-header-height: 3em !default;

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -31,4 +31,4 @@ $visited-link: #1A77F2 !default;
 
 $breadcrumb-margin-bottom: 1rem !default;
 
-$floating-header-height: 3em !default;
+$floating-header-height: 3rem !default;

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -117,6 +117,7 @@
     display: flex;
     height: 100%;
     flex-direction: column;
+    margin-top: $floating-header-height;
 
     nav {
       padding-top: 1rem;
@@ -405,4 +406,26 @@ la-akoma-ntoso .akn-remark {
 // except in jurisdictions where they are already styled differently
 la-akoma-ntoso[frbr-country="na"] .akn-remark {
   background-color: inherit;
+}
+
+.document-floating-header {
+  position: fixed;
+  top: 0px;
+  right: 0px;
+  left: 0px;
+  height: $floating-header-height;
+  display: none;
+  box-shadow: 0 4px 4px rgb(0, 0, 0, 0.2);
+  background: white;
+  z-index: 100;
+
+  &.visible {
+    display: flex;
+  }
+
+  h5 {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 }

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -81,20 +81,9 @@
     }
   }
 
-  .document-content__toggle {
-    @extend .mb-4;
-    position: sticky;
-    top: 0;
-    left: 0;
-    z-index: 99;
-    @include media-breakpoint-up(lg) {
-      display: none;
-    }
-  }
-
   .navigation {
     position: sticky;
-    top: 0;
+    top: $floating-header-height;
     left: 0;
     height: 100vh;
     border-right: 1px solid $gray-200;
@@ -117,7 +106,6 @@
     display: flex;
     height: 100%;
     flex-direction: column;
-    margin-top: $floating-header-height;
 
     nav {
       padding-top: 1rem;
@@ -340,10 +328,6 @@
     .pdf-content {
       display: none;
     }
-
-    .document-content__toggle {
-      display: none;
-    }
   }
 
   &[data-pdf-standby] {
@@ -416,16 +400,37 @@ la-akoma-ntoso[frbr-country="na"] .akn-remark {
   height: $floating-header-height;
   display: none;
   box-shadow: 0 4px 4px rgb(0, 0, 0, 0.2);
-  background: white;
   z-index: 100;
 
   &.visible {
     display: flex;
   }
 
-  h5 {
+  .menu-toggle {
+    display: block;
+    background-color: $primary;
+    width: $floating-header-height;
+    min-width: $floating-header-height;
+    text-align: center;
+    align-content: center;
+    font-size: 1.5rem;
+  }
+
+  .title {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    @include media-breakpoint-down(lg) {
+      @include font-size($h6-font-size);
+    }
   }
+
+  button {
+    white-space: nowrap;
+  }
+}
+
+.offcanvas .navigation__inner {
+  margin-top: 0px;
 }

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -397,11 +397,17 @@ la-akoma-ntoso[frbr-country="na"] .akn-remark {
 }
 
 .document-floating-header {
+  --floating-header-height: #{$floating-header-height};
+
+  @include media-breakpoint-down(md) {
+    --floating-header-height: #{$floating-header-height-md};
+  }
+
   position: fixed;
   top: 0px;
   right: 0px;
   left: 0px;
-  height: $floating-header-height;
+  height: var(--floating-header-height);
   display: none;
   box-shadow: 0 4px 4px rgb(0, 0, 0, 0.2);
   z-index: 100;
@@ -413,8 +419,9 @@ la-akoma-ntoso[frbr-country="na"] .akn-remark {
   .menu-toggle {
     display: block;
     background-color: $primary;
-    width: $floating-header-height;
-    min-width: $floating-header-height;
+    color: color-contrast($primary);
+    width: var(--floating-header-height);
+    min-width: var(--floating-header-height);
     text-align: center;
     align-content: center;
     font-size: 1.5rem;

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -432,6 +432,12 @@ la-akoma-ntoso[frbr-country="na"] .akn-remark {
 
   button {
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    @include media-breakpoint-down(md) {
+      max-width: 5rem;
+    }
   }
 }
 

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -142,6 +142,10 @@
     margin-left: auto;
     margin-right: auto;
 
+    * {
+      scroll-margin-top: $floating-header-height + 1rem;
+    }
+
     &.la-akoma-ntoso-with-gutter {
       .content {
         flex: 80%;

--- a/peachjam/templates/peachjam/_document_content_sidebar.html
+++ b/peachjam/templates/peachjam/_document_content_sidebar.html
@@ -72,15 +72,6 @@ and #navigation-column for desktop screensize.
     </div>
   </div>
 </div>
-<div class="document-content__toggle">
-  <button class="btn btn-primary"
-          type="button"
-          data-bs-toggle="offcanvas"
-          data-bs-target="#navigation-offcanvas"
-          aria-controls="navigation-offcanvas">
-    {% trans "Navigate document" %}
-  </button>
-</div>
 <div class="offcanvas offcanvas-start document-content__offcanvas"
      tabindex="-1"
      id="navigation-offcanvas"

--- a/peachjam/templates/peachjam/_document_detail_toolbar.html
+++ b/peachjam/templates/peachjam/_document_detail_toolbar.html
@@ -28,6 +28,8 @@
   {% block download-btn %}
     <div>
       {% if show_save_doc_button %}
+        <!-- this will be replaced by htmx -->
+        <div class="save-document-button"></div>
         <div hx-get="{% url 'saved_document_button' document.id %}"
              hx-trigger="load"></div>
         <div id="saveDocumentModal"
@@ -70,8 +72,8 @@
               class="btn btn-outline-secondary btn-shrink-sm ms-2"
               data-bs-toggle="modal"
               data-bs-target="#documentProblemModal">
-        <span class="d-inline d-sm-none">{% trans "Report" %}</span>
-        <span class="d-none d-sm-inline">{% trans 'Report a problem' %}</span>
+        <span class="d-md-none">{% trans "Report" %}</span>
+        <span class="d-none d-md-inline">{% trans 'Report a problem' %}</span>
       </button>
       <div class="modal fade"
            id="documentProblemModal"

--- a/peachjam/templates/peachjam/_document_detail_toolbar.html
+++ b/peachjam/templates/peachjam/_document_detail_toolbar.html
@@ -1,5 +1,5 @@
 {% load peachjam static i18n %}
-<div class="btn-toolbar justify-content-end mb-3"
+<div class="btn-toolbar justify-content-end mb-3 document-detail-toolbar"
      role="toolbar"
      aria-label="{% trans "Document toolbar" %}">
   {% block edit-btn %}
@@ -48,7 +48,7 @@
         </a>
         {% if document.source_file.filename_extension != "pdf" %}
           <button type="button"
-                  class="btn btn-primary dropdown-toggle dropdown-toggle-split"
+                  class="btn btn-primary btn-shrink-sm dropdown-toggle dropdown-toggle-split"
                   data-bs-toggle="dropdown"
                   aria-expanded="false">
             <span class="visually-hidden">{% trans "Toggle dropdown" %}</span>

--- a/peachjam/templates/peachjam/_document_floating_header.html
+++ b/peachjam/templates/peachjam/_document_floating_header.html
@@ -1,0 +1,3 @@
+<div class="document-floating-header p-2" data-component="FloatingHeader">
+  <h5 class="m-0 align-self-center">{{ document.title }}</h5>
+</div>

--- a/peachjam/templates/peachjam/_document_floating_header.html
+++ b/peachjam/templates/peachjam/_document_floating_header.html
@@ -8,5 +8,11 @@
     <i class="bi bi-menu-button-wide"
        title="{% trans "Navigate document" %}"></i>
   </div>
-  <h5 class="title p-2 m-0 align-self-center">{{ document.title }}</h5>
+  <h5 class="title px-2 py-0 m-0 align-self-center">{{ document.title }}</h5>
+  <div class="ms-auto px-2 align-content-center">
+    {% if show_save_doc_button %}
+      <!-- this will be replaced by htmx from the main toolbar's save document button is loaded -->
+      <div class="save-document-button"></div>
+    {% endif %}
+  </div>
 </div>

--- a/peachjam/templates/peachjam/_document_floating_header.html
+++ b/peachjam/templates/peachjam/_document_floating_header.html
@@ -1,3 +1,12 @@
-<div class="document-floating-header p-2" data-component="FloatingHeader">
-  <h5 class="m-0 align-self-center">{{ document.title }}</h5>
+{% load i18n %}
+<div class="document-floating-header bg-light"
+     data-component="FloatingHeader">
+  <div class="btn-primary menu-toggle d-lg-none"
+       data-bs-toggle="offcanvas"
+       data-bs-target="#navigation-offcanvas"
+       aria-controls="navigation-offcanvas">
+    <i class="bi bi-menu-button-wide"
+       title="{% trans "Navigate document" %}"></i>
+  </div>
+  <h5 class="title p-2 m-0 align-self-center">{{ document.title }}</h5>
 </div>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -63,6 +63,7 @@
         {% endblock %}
         {% include 'peachjam/_notices.html' with messages=notices %}
         {% include "peachjam/_document_detail_toolbar.html" %}
+        {% include 'peachjam/_document_floating_header.html' %}
         <ul class="nav nav-tabs border-bottom scroll-xs" role="tablist">
           {% block document-tabs %}
             <li class="nav-item" role="presentation">

--- a/peachjam/templates/peachjam/saved_document_create.html
+++ b/peachjam/templates/peachjam/saved_document_create.html
@@ -1,27 +1,25 @@
 {% load i18n %}
-<div id="saveDocumentWrapper">
-  <button id="saveDocumentButton"
-          class="btn btn-outline-primary btn-shrink-sm ms-2"
-          type="button"
-          data-bs-toggle="modal"
-          data-bs-target="#saveDocumentModal"
-          aria-expanded="false"
-          hx-post="{% url 'saved_document_create' %}?doc_id={{ form.document.value }}"
-          hx-target="#saveDocumentWrapper">
-    <span class="d-sm-none">{% trans 'Save' %}</span>
-    <span class="d-none d-sm-inline">{% trans 'Save document' %}</span>
-  </button>
-  <div hx-swap-oob="true" id="saveDocumentModalDialog" class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <p class="h5 modal-title">{% trans 'Save document' %}</p>
-        <button type="button"
-                class="btn-close"
-                data-bs-dismiss="modal"
-                aria-label="Close"></button>
-      </div>
-      <div class="modal-body">{% trans 'Saving...' %}</div>
-      <div class="modal-footer d-flex"></div>
+<button class="btn btn-outline-primary btn-shrink-sm ms-2 save-document-button"
+        type="button"
+        data-bs-toggle="modal"
+        data-bs-target="#saveDocumentModal"
+        aria-expanded="false"
+        hx-swap-oob="outerHTML:.save-document-button"
+        hx-post="{% url 'saved_document_create' %}?doc_id={{ form.document.value }}">
+  <i class="bi bi-star"></i>
+  <span class="d-md-none">{% trans 'Save' %}</span>
+  <span class="d-none d-md-inline">{% trans 'Save document' %}</span>
+</button>
+<div hx-swap-oob="true" id="saveDocumentModalDialog" class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <p class="h5 modal-title">{% trans 'Save document' %}</p>
+      <button type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"></button>
     </div>
+    <div class="modal-body">{% trans 'Saving...' %}</div>
+    <div class="modal-footer d-flex"></div>
   </div>
 </div>

--- a/peachjam/templates/peachjam/saved_document_login.html
+++ b/peachjam/templates/peachjam/saved_document_login.html
@@ -1,34 +1,33 @@
 {% load i18n %}
-<div id="saveDocumentWrapper">
-  <button class="btn btn-outline-primary ms-2"
-          id="saveDocumentButton"
-          data-bs-toggle="modal"
-          type="button"
-          aria-expanded="false"
-          data-bs-target="#saveDocumentModal">
-    <span class="d-sm-none">{% trans 'Save' %}</span>
-    <span class="d-none d-sm-inline">{% trans 'Save document' %}</span>
-  </button>
-  <div hx-swap-oob="true" id="saveDocumentModalDialog" class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">{% trans 'Login' %}</h5>
-        <button type="button"
-                class="btn-close"
-                data-bs-dismiss="modal"
-                aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p>
-          <strong>{% trans 'You are not logged in' %}.</strong>
-        </p>
-        <p>{% trans 'To save a document you need to be logged in' %}.</p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Close' %}</button>
-        <a href="{% url 'account_login' %}?next={{ document.get_absolute_url }}"
-           class="btn btn-primary">{% trans 'Login' %}</a>
-      </div>
+<button class="btn btn-outline-primary ms-2 save-document-button"
+        type="button"
+        data-bs-toggle="modal"
+        data-bs-target="#saveDocumentModal"
+        aria-expanded="false"
+        hx-swap-oob="outerHTML:.save-document-button">
+  <i class="bi bi-star"></i>
+  <span class="d-md-none">{% trans 'Save' %}</span>
+  <span class="d-none d-md-inline">{% trans 'Save document' %}</span>
+</button>
+<div hx-swap-oob="true" id="saveDocumentModalDialog" class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title">{% trans 'Login' %}</h5>
+      <button type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"></button>
+    </div>
+    <div class="modal-body">
+      <p>
+        <strong>{% trans 'You are not logged in' %}.</strong>
+      </p>
+      <p>{% trans 'To save a document you need to be logged in' %}.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Close' %}</button>
+      <a href="{% url 'account_login' %}?next={{ document.get_absolute_url }}"
+         class="btn btn-primary">{% trans 'Login' %}</a>
     </div>
   </div>
 </div>

--- a/peachjam/templates/peachjam/saved_document_update.html
+++ b/peachjam/templates/peachjam/saved_document_update.html
@@ -1,87 +1,83 @@
 {% load i18n %}
-<div id="saveDocumentWrapper">
-  <button id="saveDocumentButton"
-          class="btn btn-outline-primary btn-shrink-sm ms-2"
-          type="button"
-          data-bs-toggle="modal"
-          data-bs-target="#saveDocumentModal"
-          aria-expanded="false">
-    <i class="bi bi-star-fill"></i>
-    {% if saved_document.folder %}
-      {% trans 'Saved to' %} {{ saved_document.folder }}
-    {% else %}
-      {% trans 'Saved' %}
-    {% endif %}
-  </button>
-  <div hx-swap-oob="true" id="saveDocumentModalDialog" class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <p class="h5 modal-title">{% trans 'Document saved' %}</p>
+<button class="btn btn-outline-primary btn-shrink-sm ms-2 saved-document-button"
+        type="button"
+        data-bs-toggle="modal"
+        data-bs-target="#saveDocumentModal"
+        aria-expanded="false"
+        hx-swap-oob="outerHTML:.save-document-button">
+  <i class="bi bi-star-fill"></i>
+  {% if saved_document.folder %}
+    {% trans 'Saved to' %} {{ saved_document.folder }}
+  {% else %}
+    {% trans 'Saved' %}
+  {% endif %}
+</button>
+<div hx-swap-oob="true" id="saveDocumentModalDialog" class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <p class="h5 modal-title">{% trans 'Document saved' %}</p>
+      <button type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"></button>
+    </div>
+    <div class="modal-body">
+      <form id="save-document-form"
+            hx-post="{% url 'saved_document_update' saved_document.id %}">
+        {{ form.document }}
+        <p class="h5">{{ saved_document.document }}</p>
+        <label class="form-label" for="{{ form.folder.id_for_label }}">{{ form.folder.label }}</label>
+        <select id="{{ form.folder.id_for_label }}"
+                class="form-select"
+                name="{{ form.folder.name }}">
+          {% for value, name in form.fields.folder.choices %}
+            <option value="{{ value }}"
+                    {% if form.folder.value == value %} selected{% endif %}>
+              {{ name }}
+            </option>
+          {% endfor %}
+        </select>
         <button type="button"
-                class="btn-close"
-                data-bs-dismiss="modal"
-                aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <form id="save-document-form"
-              hx-post="{% url 'saved_document_update' saved_document.id %}"
-              hx-target="#saveDocumentWrapper">
-          {{ form.document }}
-          <p class="h5">{{ saved_document.document }}</p>
-          <label class="form-label" for="{{ form.folder.id_for_label }}">{{ form.folder.label }}</label>
-          <select id="{{ form.folder.id_for_label }}"
-                  class="form-select"
-                  name="{{ form.folder.name }}">
-            {% for value, name in form.fields.folder.choices %}
-              <option value="{{ value }}"
-                      {% if form.folder.value == value %} selected{% endif %}>
-                {{ name }}
-              </option>
-            {% endfor %}
-          </select>
-          <button type="button"
-                  class="btn btn-link link-underline link-underline-opacity-0 ps-0"
-                  data-bs-toggle="collapse"
-                  data-bs-target="#addFolder"
-                  aria-expanded="false"
-                  aria-controls="addFolder">
-            {% trans 'New folder...' %}
-          </button>
-          <div class="collapse" id="addFolder">
-            <label class="form-label" for="{{ form.new_folder.id_for_label }}">{% trans 'New folder name' %}</label>
-            <input class="form-control"
-                   id="{{ form.new_folder.id_for_label }}"
-                   name="{{ form.new_folder.name }}"
-                   type="text"/>
-          </div>
-          <div class="mt-3">
-            <a href="{% url 'folder_list' %}">{% trans 'All saved documents' %}</a>
-          </div>
-        </form>
-      </div>
-      <div class="modal-footer d-flex justify-content-between">
-        <button class="btn btn-danger"
-                type="button"
-                data-bs-dismiss="modal"
-                hx-target="#saveDocumentWrapper"
-                hx-include="#save-document-form"
-                hx-post="{% url 'saved_document_delete' saved_document.id %}"
-                hx-confirm="{% trans "Are you sure?" %}">
-          {% trans 'Unsave' %}
+                class="btn btn-link link-underline link-underline-opacity-0 ps-0"
+                data-bs-toggle="collapse"
+                data-bs-target="#addFolder"
+                aria-expanded="false"
+                aria-controls="addFolder">
+          {% trans 'New folder...' %}
         </button>
-        <div>
-          <button type="button"
-                  class="btn btn-outline-secondary btn-shrink-sm ms-2"
-                  data-bs-dismiss="modal">
-            {% trans 'Close' %}
-          </button>
-          <button class="btn btn-primary ms-1"
-                  type="submit"
-                  form="save-document-form"
-                  data-bs-dismiss="modal">
-            {% trans 'Save' %}
-          </button>
+        <div class="collapse" id="addFolder">
+          <label class="form-label" for="{{ form.new_folder.id_for_label }}">{% trans 'New folder name' %}</label>
+          <input class="form-control"
+                 id="{{ form.new_folder.id_for_label }}"
+                 name="{{ form.new_folder.name }}"
+                 type="text"/>
         </div>
+        <div class="mt-3">
+          <a href="{% url 'folder_list' %}">{% trans 'All saved documents' %}</a>
+        </div>
+      </form>
+    </div>
+    <div class="modal-footer d-flex justify-content-between">
+      <button class="btn btn-danger"
+              type="button"
+              data-bs-dismiss="modal"
+              hx-include="#save-document-form"
+              hx-post="{% url 'saved_document_delete' saved_document.id %}"
+              hx-confirm="{% trans "Are you sure?" %}">
+        {% trans 'Unsave' %}
+      </button>
+      <div>
+        <button type="button"
+                class="btn btn-outline-secondary btn-shrink-sm ms-2"
+                data-bs-dismiss="modal">
+          {% trans 'Close' %}
+        </button>
+        <button class="btn btn-primary ms-1"
+                type="submit"
+                form="save-document-form"
+                data-bs-dismiss="modal">
+          {% trans 'Save' %}
+        </button>
       </div>
     </div>
   </div>

--- a/peachjam/templates/peachjam/saved_document_update.html
+++ b/peachjam/templates/peachjam/saved_document_update.html
@@ -68,10 +68,8 @@
       </button>
       <div>
         <button type="button"
-                class="btn btn-outline-secondary btn-shrink-sm ms-2"
-                data-bs-dismiss="modal">
-          {% trans 'Close' %}
-        </button>
+                class="btn btn-outline-secondary ms-2"
+                data-bs-dismiss="modal">{% trans 'Close' %}</button>
         <button class="btn btn-primary ms-1"
                 type="submit"
                 form="save-document-form"

--- a/peachjam/templates/peachjam/saved_document_update.html
+++ b/peachjam/templates/peachjam/saved_document_update.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<button class="btn btn-outline-primary btn-shrink-sm ms-2 saved-document-button"
+<button class="btn btn-outline-primary btn-shrink-sm ms-2 save-document-button"
         type="button"
         data-bs-toggle="modal"
         data-bs-target="#saveDocumentModal"
@@ -7,7 +7,7 @@
         hx-swap-oob="outerHTML:.save-document-button">
   <i class="bi bi-star-fill"></i>
   {% if saved_document.folder %}
-    {% trans 'Saved to' %} {{ saved_document.folder }}
+    {{ saved_document.folder }}
   {% else %}
     {% trans 'Saved' %}
   {% endif %}


### PR DESCRIPTION
This adds a floating titlebar at the top of a document that is shown when the user scrolls past the title of the document. This means the title is always visible, and gives us a place to put key action buttons (for now, just "save").

The navigation toggle in mobile moves into the title bar and takes up less room.

The save button is adjust so that it uses htmx's oob-swap functionality to replace all `.save-document-button` instances on the page, not just the one in the main toolbar.

The "save document" button text is adjusted to support smaller widths.

![image](https://github.com/user-attachments/assets/a9aaf910-02f2-4cc5-9239-d2a7f7b12a4f)

![image](https://github.com/user-attachments/assets/d6ecdd18-cff2-4e39-b14b-2210ca51444d)


https://www.loom.com/share/019b164cde2242e7a624ab1bbb6a13cb


