### PR TITLE
Copy citation button for floating toolbar

### DIFF
--- a/peachjam/js/components/clipboard.ts
+++ b/peachjam/js/components/clipboard.ts
@@ -1,10 +1,10 @@
 export class CopyToClipboard {
   root: HTMLElement;
-  text: string;
+  buttonHTML: string;
 
   constructor (root: HTMLElement) {
     this.root = root;
-    this.text = root.innerText;
+    this.buttonHTML = root.innerHTML;
     root.addEventListener('click', () => this.copy());
   }
 
@@ -30,13 +30,13 @@ export class CopyToClipboard {
 
         this.root.innerText = this.root.dataset.confirmation || 'Copied!';
         setTimeout(() => {
-          this.root.innerText = this.text;
+          this.root.innerHTML = this.buttonHTML;
         }, 1500);
       }
     } catch {
       this.root.innerText = 'Copy failed!';
       setTimeout(() => {
-        this.root.innerText = this.text;
+        this.root.innerHTML = this.buttonHTML;
       }, 1500);
     }
   }

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -377,6 +377,10 @@
     flex: 0 0 calc(100% - var(--dt-width));
   }
 
+  .btn.copy-to-clipboard {
+    @include button-size(0.125rem, 0.25rem, $btn-font-size-sm, $btn-border-radius-sm);
+    margin-left: map-get($spacers, 2);
+  }
 }
 
 .to-the-top {
@@ -444,6 +448,12 @@ la-akoma-ntoso[frbr-country="na"] .akn-remark {
 
     @include media-breakpoint-down(md) {
       max-width: 5rem;
+    }
+  }
+
+  @include media-breakpoint-down(lg) {
+    .btn.copy-to-clipboard {
+      display: none;
     }
   }
 }

--- a/peachjam/templates/peachjam/_copy_to_clipboard.html
+++ b/peachjam/templates/peachjam/_copy_to_clipboard.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<button type="button"
+        class="btn btn-outline-secondary copy-to-clipboard"
+        title="{% trans "Copy to clipboard" %}"
+        data-component="CopyToClipboard"
+        data-value='{{ value }}'
+        data-value-html='<a href="https://{{ request.site.domain }}{{ document.get_absolute_url }}">{{ value }}</a>'
+        data-confirmation="{% trans "Copied!" %}">
+  {% if verb %}
+    {{ verb }}
+  {% else %}
+    {% trans "Copy" %}
+  {% endif %}
+</button>

--- a/peachjam/templates/peachjam/_document_floating_header.html
+++ b/peachjam/templates/peachjam/_document_floating_header.html
@@ -10,6 +10,8 @@
   </div>
   <h5 class="title px-2 py-0 m-0 align-self-center">{{ document.title }}</h5>
   <div class="ms-auto px-2 align-content-center">
+    {% trans "Copy citation" as verb %}
+    {% include 'peachjam/_copy_to_clipboard.html' with value=document.mnc|default:document.citation verb=verb %}
     {% if show_save_doc_button %}
       <!-- this will be replaced by htmx from the main toolbar's save document button is loaded -->
       <div class="save-document-button"></div>

--- a/peachjam/templates/peachjam/judgment_detail.html
+++ b/peachjam/templates/peachjam/judgment_detail.html
@@ -35,15 +35,7 @@
     </dt>
     <dd class="text-muted">
       {{ document.mnc }}
-      <button type="button"
-              class="btn btn-outline-secondary btn-xs ms-2"
-              title="{% trans "Copy to clipboard" %}"
-              data-component="CopyToClipboard"
-              data-value='{{ document.mnc }}'
-              data-value-html='<a href="https://{{ request.site.domain }}{{ document.get_absolute_url }}">{{ document.mnc }}</a>'
-              data-confirmation="{% trans "Copied!" %}">
-        {% trans "Copy" %}
-      </button>
+      {% include 'peachjam/_copy_to_clipboard.html' with value=document.mnc %}
     </dd>
   {% endif %}
   {% if document.hearing_date %}

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -187,15 +187,7 @@
                           </dt>
                           <dd class="text-muted">
                             {{ document.citation }}
-                            <button type="button"
-                                    class="btn btn-outline-secondary btn-xs ms-2"
-                                    title="{% trans "Copy to clipboard" %}"
-                                    data-component="CopyToClipboard"
-                                    data-value='{{ document.citation }}'
-                                    data-value-html='<a href="https://{{ request.site.domain }}{{ document.get_absolute_url }}">{{ document.citation }}</a>'
-                                    data-confirmation="{% trans "Copied!" %}">
-                              {% trans "Copy" %}
-                            </button>
+                            {% include 'peachjam/_copy_to_clipboard.html' with value=document.citation %}
                           </dd>
                         {% endif %}
                       {% endblock %}
@@ -215,15 +207,7 @@
                               {% for alternative_name in alternative_names %}
                                 <div>
                                   {{ alternative_name.title }}
-                                  <button type="button"
-                                          class="btn btn-outline-secondary btn-xs ms-2"
-                                          title="{% trans "Copy to clipboard" %}"
-                                          data-component="CopyToClipboard"
-                                          data-value='{{ alternative_name.title }}'
-                                          data-value-html='<a href="https://{{ request.site.domain }}{{ document.get_absolute_url }}">{{ alternative_name.title }}</a>'
-                                          data-confirmation="{% trans "Copied!" %}">
-                                    {% trans "Copy" %}
-                                  </button>
+                                  {% include 'peachjam/_copy_to_clipboard.html' with value=alternative_name.title %}
                                 </div>
                               {% endfor %}
                             </dd>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/71da84b9-8ea2-4c83-8479-3a2c7889c3e1)


* the button is only visible on desktop, because there isn't enough room on mobile and the need for copying the citation on mobile is much less