### PR TITLE
Decorators

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -824,7 +824,8 @@ class DocumentAdmin(DocumentAccessMixin, BaseAdmin):
     def apply_labels(self, request, queryset):
         count = queryset.count()
         for doc in queryset.iterator():
-            doc.apply_labels()
+            if doc.decorator:
+                doc.decorator.apply_labels(doc)
         self.message_user(
             request, _("Applying labels for %(count)d documents.") % {"count": count}
         )

--- a/peachjam/decorators.py
+++ b/peachjam/decorators.py
@@ -1,0 +1,76 @@
+class DocumentDecorator:
+    """Decorators are mini plugins that allow you to add extra functionality to your documents."""
+
+    def pre_save(self, document):
+        """Called before a document is saved."""
+        pass
+
+    def post_save(self, document):
+        """Called after a document is saved."""
+        self.apply_labels(document)
+
+    def apply_labels(self, document):
+        pass
+
+
+class JudgmentDecorator(DocumentDecorator):
+    """Judgment decorators are used to add extra functionality to judgments."""
+
+    def apply_labels(self, document):
+        """Apply labels to this judgment based on its properties."""
+        from peachjam.models import Label
+
+        # label showing that a judgment is cited/reported in law reports, hence "more important"
+        label, _ = Label.objects.get_or_create(
+            code="reported",
+            defaults={"name": "Reported", "code": "reported", "level": "success"},
+        )
+
+        labels = list(document.labels.all())
+
+        # if the judgment has alternative_names, apply the "reported" label
+        if document.alternative_names.exists():
+            if label not in labels:
+                document.labels.add(label.pk)
+        # if the judgment has no alternative_names, remove the "reported" label
+        elif label in labels:
+            document.labels.remove(label.pk)
+
+        super().apply_labels(document)
+
+
+class LegislationDecorator(DocumentDecorator):
+    def apply_labels(self, document):
+        from peachjam.models import Label
+
+        labels = list(document.labels.all())
+
+        # label to indicate that this legislation is repealed
+        repealed_label, _ = Label.objects.get_or_create(
+            code="repealed",
+            defaults={"name": "Repealed", "code": "repealed", "level": "danger"},
+        )
+        uncommenced_label, _ = Label.objects.get_or_create(
+            code="uncommenced",
+            defaults={
+                "name": "Uncommenced",
+                "level": "danger",
+            },
+        )
+
+        # apply label if repealed
+        if document.repealed:
+            if repealed_label not in labels:
+                document.labels.add(repealed_label.pk)
+        elif repealed_label in labels:
+            # not repealed, remove label
+            document.labels.remove(repealed_label.pk)
+
+        # apply label if not commenced
+        if not document.commenced:
+            if uncommenced_label not in labels:
+                document.labels.add(uncommenced_label.pk)
+        elif uncommenced_label in labels:
+            document.labels.remove(uncommenced_label.pk)
+
+        super().apply_labels(document)

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -194,15 +194,15 @@
                       {% block document-metadata-content-alternative-names %}
                         {% with document.alternative_names.all as alternative_names %}
                           {% if alternative_names %}
-                            {% if document.doc_type == "judgment" %}
-                              <dt>
-                                {% trans 'Law report citations' %}
-                              </dt>
-                            {% else %}
-                              <dt>
-                                {% trans 'Alternative names' %}
-                              </dt>
-                            {% endif %}
+                            <dt>
+                              {% block document-metadata-alternative-names-label %}
+                                {% if document.doc_type == "judgment" %}
+                                  {% trans 'Law report citations' %}
+                                {% else %}
+                                  {% trans 'Alternative names' %}
+                                {% endif %}
+                              {% endblock %}
+                            </dt>
                             <dd class="text-muted">
                               {% for alternative_name in alternative_names %}
                                 <div>


### PR DESCRIPTION
Decorators moves the site-specific label decoration into a mini plugin class, which can be overridden/changed by other sites.

Also make it possible to override the alternative names label in the document detail page.