### PR TITLE
Remove dates from legislation listing views

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.mail import send_mail
 from django.db.models import Q
+from django.db.models.functions.text import Substr
 from django.http import QueryDict
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
@@ -154,6 +155,24 @@ class BaseDocumentFilterForm(forms.Form):
         ],
     )
 
+    # fields for which filters are applied
+    filter_fields = [
+        "years",
+        "alphabet",
+        "authors",
+        "courts",
+        "doc_type",
+        "judges",
+        "natures",
+        "localities",
+        "registries",
+        "divisions",
+        "attorneys",
+        "outcomes",
+        "labels",
+        "taxonomies",
+    ]
+
     def __init__(self, defaults, data, *args, **kwargs):
         self.secondary_sort = "title"
         if defaults is not None:
@@ -166,72 +185,14 @@ class BaseDocumentFilterForm(forms.Form):
         super().__init__(self.params, *args, **kwargs)
 
     def filter_queryset(self, queryset, exclude=None, filter_q=False):
-        years = self.cleaned_data.get("years", [])
-        alphabet = self.cleaned_data.get("alphabet")
-        authors = self.cleaned_data.get("authors", [])
-        courts = self.cleaned_data.get("courts", [])
-        doc_type = self.cleaned_data.get("doc_type", [])
-        judges = self.cleaned_data.get("judges", [])
-        natures = self.cleaned_data.get("natures", [])
-        localities = self.cleaned_data.get("localities", [])
-        registries = self.cleaned_data.get("registries", [])
-        divisions = self.cleaned_data.get("divisions", [])
-        attorneys = self.cleaned_data.get("attorneys", [])
-        outcomes = self.cleaned_data.get("outcomes", [])
-        labels = self.cleaned_data.get("labels", [])
-        taxonomies = self.cleaned_data.get("taxonomies", [])
-        q = self.cleaned_data.get("q")
-
         queryset = self.order_queryset(queryset, exclude)
 
-        if years and exclude != "years":
-            queryset = queryset.filter(date__year__in=years)
+        for field in self.filter_fields:
+            if exclude != field:
+                queryset = getattr(self, f"apply_filter_{field}")(queryset)
 
-        if alphabet and exclude != "alphabet":
-            queryset = queryset.filter(title__istartswith=alphabet)
-
-        if authors and exclude != "authors":
-            queryset = queryset.filter(author__name__in=authors)
-
-        if courts and exclude != "courts":
-            queryset = queryset.filter(court__name__in=courts)
-
-        if doc_type and exclude != "doc_type":
-            queryset = queryset.filter(doc_type__in=doc_type)
-
-        if judges and exclude != "judges":
-            queryset = queryset.filter(judges__name__in=judges).distinct()
-
-        if natures and exclude != "natures":
-            queryset = queryset.filter(nature__code__in=natures)
-
-        if localities and exclude != "localities":
-            queryset = queryset.filter(locality__name__in=localities)
-
-        if registries and exclude != "registries":
-            queryset = queryset.filter(registry__name__in=registries)
-
-        if divisions and exclude != "divisions":
-            queryset = queryset.filter(division__code__in=divisions)
-
-        if attorneys and exclude != "attorneys":
-            queryset = queryset.filter(attorneys__name__in=attorneys).distinct()
-
-        if outcomes and exclude != "outcomes":
-            queryset = queryset.filter(outcomes__name__in=outcomes).distinct()
-
-        if labels and exclude != "labels":
-            queryset = queryset.filter(labels__name__in=labels).distinct()
-
-        if taxonomies and exclude != "taxonomies":
-            queryset = queryset.filter(taxonomies__topic__slug__in=taxonomies)
-
-        if filter_q and q and exclude != "q":
-            terms = q.split()
-            queries = Q()
-            for term in terms:
-                queries &= Q(Q(title__icontains=term) | Q(citation__icontains=term))
-            queryset = queryset.filter(queries)
+        if filter_q and exclude != "q":
+            queryset = self.apply_filter_q(queryset)
 
         return queryset
 
@@ -243,6 +204,106 @@ class BaseDocumentFilterForm(forms.Form):
             self.secondary_sort = "frbr_uri_number"
         queryset = queryset.order_by(sort, self.secondary_sort)
         return queryset
+
+    def apply_filter_years(self, queryset):
+        years = self.cleaned_data.get("years", [])
+        return queryset.filter(date__year__in=years) if years else queryset
+
+    def apply_filter_alphabet(self, queryset):
+        alphabet = self.cleaned_data.get("alphabet")
+        return queryset.filter(title__istartswith=alphabet) if alphabet else queryset
+
+    def apply_filter_authors(self, queryset):
+        authors = self.cleaned_data.get("authors")
+        return queryset.filter(author__name__in=authors) if authors else queryset
+
+    def apply_filter_courts(self, queryset):
+        courts = self.cleaned_data.get("courts", [])
+        return queryset.filter(court__name__in=courts) if courts else queryset
+
+    def apply_filter_doc_type(self, queryset):
+        doc_type = self.cleaned_data.get("doc_type", [])
+        return queryset.filter(doc_type__in=doc_type) if doc_type else queryset
+
+    def apply_filter_judges(self, queryset):
+        judges = self.cleaned_data.get("judges", [])
+        return (
+            queryset.filter(judges__name__in=judges).distinct() if judges else queryset
+        )
+
+    def apply_filter_natures(self, queryset):
+        natures = self.cleaned_data.get("natures", [])
+        return queryset.filter(nature__code__in=natures) if natures else queryset
+
+    def apply_filter_localities(self, queryset):
+        localities = self.cleaned_data.get("localities", [])
+        return (
+            queryset.filter(locality__name__in=localities) if localities else queryset
+        )
+
+    def apply_filter_registries(self, queryset):
+        registries = self.cleaned_data.get("registries", [])
+        return (
+            queryset.filter(registry__name__in=registries) if registries else queryset
+        )
+
+    def apply_filter_divisions(self, queryset):
+        divisions = self.cleaned_data.get("divisions", [])
+        return queryset.filter(division__code__in=divisions) if divisions else queryset
+
+    def apply_filter_attorneys(self, queryset):
+        attorneys = self.cleaned_data.get("attorneys", [])
+        return (
+            queryset.filter(attorneys__name__in=attorneys).distinct()
+            if attorneys
+            else queryset
+        )
+
+    def apply_filter_outcomes(self, queryset):
+        outcomes = self.cleaned_data.get("outcomes", [])
+        return (
+            queryset.filter(outcomes__name__in=outcomes).distinct()
+            if outcomes
+            else queryset
+        )
+
+    def apply_filter_labels(self, queryset):
+        labels = self.cleaned_data.get("labels", [])
+        return (
+            queryset.filter(labels__name__in=labels).distinct() if labels else queryset
+        )
+
+    def apply_filter_taxonomies(self, queryset):
+        taxonomies = self.cleaned_data.get("taxonomies", [])
+        return (
+            queryset.filter(taxonomies__topic__slug__in=taxonomies)
+            if taxonomies
+            else queryset
+        )
+
+    def apply_filter_q(self, queryset):
+        q = self.cleaned_data.get("q")
+        if q:
+            terms = q.split()
+            queries = Q()
+            for term in terms:
+                queries &= Q(Q(title__icontains=term) | Q(citation__icontains=term))
+            queryset = queryset.filter(queries)
+        return queryset
+
+
+class LegislationFilterForm(BaseDocumentFilterForm):
+    def apply_filter_years(self, queryset):
+        years = self.cleaned_data.get("years", [])
+        return (
+            (
+                queryset.annotate(
+                    frbr_uri_date_year=Substr("frbr_uri_date", 1, 4)
+                ).filter(frbr_uri_date_year__in=years)
+            )
+            if years
+            else queryset
+        )
 
 
 class GazetteFilterForm(BaseDocumentFilterForm):

--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -305,6 +305,19 @@ class LegislationFilterForm(BaseDocumentFilterForm):
             else queryset
         )
 
+    def order_queryset(self, queryset, exclude=None):
+        queryset = super().order_queryset(queryset, exclude)
+
+        # change ordering so that date uses frbr_uri_date
+        ordering = list(queryset.query.order_by)
+        for i, order in enumerate(ordering):
+            if order == "date":
+                ordering[i] = "frbr_uri_date"
+            if order == "-date":
+                ordering[i] = "-frbr_uri_date"
+
+        return queryset.order_by(*ordering)
+
 
 class GazetteFilterForm(BaseDocumentFilterForm):
     sub_publications = PermissiveTypedListField(coerce=remove_nulls, required=False)

--- a/peachjam/static/stylesheets/components/_tables.scss
+++ b/peachjam/static/stylesheets/components/_tables.scss
@@ -139,6 +139,12 @@ table.doc-table {
 // variants
 table.doc-table.doc-table--citation {
   .cell-title {
+    width: 70%;
+  }
+}
+
+table.doc-table.doc-table--citation.doc-table--date {
+  .cell-title {
     width: 60%;
   }
 }

--- a/peachjam/templates/peachjam/_document_table.html
+++ b/peachjam/templates/peachjam/_document_table.html
@@ -42,6 +42,7 @@
       {% if document.children %}
         <tbody id="doc-table-children-{{ forloop.counter0 }}"
                class="doc-table-children collapse">
+          {% include 'peachjam/_document_table_row.html' with document=subleg_group_row %}
           {% for d in document.children %}
             {% include 'peachjam/_document_table_row.html' with document=d %}
           {% endfor %}

--- a/peachjam/templates/peachjam/_document_table.html
+++ b/peachjam/templates/peachjam/_document_table.html
@@ -2,7 +2,7 @@
 <div class="table-responsive"
      id="doc-table"
      data-component="DocumentTable">
-  <table class="doc-table {% if doc_table_toggle %}doc-table--toggle{% endif %} {% if doc_table_citations or doc_table_many_cols %}doc-table--citation{% endif %} {{ doc_table_classes }}">
+  <table class="doc-table {% if doc_table_toggle %}doc-table--toggle{% endif %} {% if doc_table_citations or doc_table_many_cols %}doc-table--citation{% endif %} {% if doc_table_show_date %}doc-table--date{% endif %} {{ doc_table_classes }}">
     <thead>
       <tr>
         {% if doc_table_toggle %}<th class="cell-toggle"></th>{% endif %}

--- a/peachjam/templates/peachjam/_document_table.html
+++ b/peachjam/templates/peachjam/_document_table.html
@@ -25,14 +25,16 @@
         {% if doc_table_show_sub_publication %}<th scope="col"></th>{% endif %}
         {% if doc_table_show_frbr_uri_number %}<th scope="col"></th>{% endif %}
         {% if doc_table_show_doc_type %}<th scope="col"></th>{% endif %}
-        <th scope="col" class="cell-date">
-          <div class="align-items-center"
-               role="button"
-               data-sort="{% if form.sort.value == "date" %}-date{% else %}date{% endif %}">
-            {{ doc_table_date_label|default_if_none:"Date" }}
-            <i class="bi ms-2 {% if form.sort.value == "-date" %}bi-sort-down{% endif %} {% if form.sort.value == "date" %}bi-sort-up{% endif %}"></i>
-          </div>
-        </th>
+        {% if doc_table_show_date %}
+          <th scope="col" class="cell-date">
+            <div class="align-items-center"
+                 role="button"
+                 data-sort="{% if form.sort.value == "date" %}-date{% else %}date{% endif %}">
+              {{ doc_table_date_label|default_if_none:"Date" }}
+              <i class="bi ms-2 {% if form.sort.value == "-date" %}bi-sort-down{% endif %} {% if form.sort.value == "date" %}bi-sort-up{% endif %}"></i>
+            </div>
+          </th>
+        {% endif %}
       </tr>
     </thead>
     {% for document in documents %}

--- a/peachjam/templates/peachjam/_document_table_row.html
+++ b/peachjam/templates/peachjam/_document_table_row.html
@@ -5,6 +5,7 @@
       {% if document.children %}
         <button class="btn btn-sm bg-none collapsed"
                 type="button"
+                title="{{ PEACHJAM_SETTINGS.subleg_label }}"
                 data-bs-toggle="collapse"
                 data-bs-target="#doc-table-children-{{ forloop.counter0 }}"
                 aria-expanded="false"

--- a/peachjam/templates/peachjam/_document_table_row.html
+++ b/peachjam/templates/peachjam/_document_table_row.html
@@ -51,7 +51,7 @@
   {% if doc_table_show_sub_publication %}<td>{{ document.sub_publication|default_if_none:'' }}</td>{% endif %}
   {% if doc_table_show_frbr_uri_number %}<td>{{ document.frbr_uri_number }}</td>{% endif %}
   {% if doc_table_show_doc_type %}<td style="white-space: nowrap;">{{ document.get_doc_type_display }}</td>{% endif %}
-  <td style="white-space: nowrap;" class="cell-date">{{ document.date|default_if_none:'' }}</td>
+  {% if doc_table_show_date %}<td class="cell-date text-nowrap">{{ document.date|default_if_none:'' }}</td>{% endif %}
   {% if document.listing_taxonomies %}
     <td class="cell-taxonomies">
       {% include 'peachjam/_document_taxonomies.html' with taxonomies=document.listing_taxonomies %}

--- a/peachjam/tests/test_forms.py
+++ b/peachjam/tests/test_forms.py
@@ -10,7 +10,7 @@ class BaseDocumentFilterFormTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.context["facet_data"]["years"]["options"],
-            [("2020", 2020), ("2010", 2010), ("2005", 2005), ("1969", 1969)],
+            [("2005", "2005"), ("1979", "1979"), ("1969", "1969")],
         )
 
     def test_alphabet_filter(self):

--- a/peachjam/tests/test_views.py
+++ b/peachjam/tests/test_views.py
@@ -143,7 +143,7 @@ class PeachjamViewsTest(TestCase):
             documents,
         )
         self.assertEqual(
-            [("1969", 1969), ("2005", 2005), ("2010", 2010), ("2020", 2020)],
+            [("1969", "1969"), ("1979", "1979"), ("2005", "2005")],
             sorted(response.context["facet_data"]["years"]["options"]),
         )
 

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -24,10 +24,6 @@ class LegislationListView(FilteredDocumentListView):
         "nature": "Act",
         "help_link": "legislation/",
         "doc_table_show_date": False,
-        "subleg_group_row": {
-            "is_group": True,
-            "title": pj_settings().subleg_label,
-        },
     }
     form_defaults = {"sort": "title"}
     form_class = LegislationFilterForm
@@ -63,6 +59,14 @@ class LegislationListView(FilteredDocumentListView):
             # use work year
             return document.frbr_uri_date[:4]
         return super().get_document_group(group_by, document)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["subleg_group_row"] = {
+            "is_group": True,
+            "title": pj_settings().subleg_label,
+        }
+        return context
 
 
 @registry.register_doc_type("legislation")

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -2,10 +2,12 @@ from datetime import datetime, timedelta
 
 from django.contrib import messages
 from django.db.models import CharField, Func, Value
+from django.db.models.functions.text import Substr
 from django.template.defaultfilters import date as format_date
 from django.utils.html import mark_safe
 from django.utils.translation import gettext as _
 
+from peachjam.forms import LegislationFilterForm
 from peachjam.models import Legislation
 from peachjam.registry import registry
 from peachjam.views.generic_views import (
@@ -18,8 +20,13 @@ class LegislationListView(FilteredDocumentListView):
     model = Legislation
     template_name = "peachjam/legislation_list.html"
     navbar_link = "legislation"
-    extra_context = {"nature": "Act", "help_link": "legislation/"}
+    extra_context = {
+        "nature": "Act",
+        "help_link": "legislation/",
+        "doc_table_show_date": False,
+    }
     form_defaults = {"sort": "title"}
+    form_class = LegislationFilterForm
 
     def add_facets(self, context):
         super().add_facets(context)
@@ -28,6 +35,30 @@ class LegislationListView(FilteredDocumentListView):
         for k, v in context["facet_data"].items():
             facets[k] = v
         context["facet_data"] = facets
+
+    def add_years_facet(self, context):
+        # for legislation, use the work year as the years facet
+        if "years" not in self.exclude_facets:
+            years = list(
+                self.form.filter_queryset(self.get_base_queryset(), exclude="years")
+                .order_by()
+                .values_list(Substr("frbr_uri_date", 1, 4), flat=True)
+                .distinct()
+            )
+            if years:
+                context["facet_data"]["years"] = {
+                    "label": _("Years"),
+                    "type": "checkbox",
+                    # these are (value, label) tuples
+                    "options": [(str(y), y) for y in sorted(years, reverse=True)],
+                    "values": self.request.GET.getlist("years"),
+                }
+
+    def get_document_group(self, group_by, document):
+        if group_by == "date":
+            # use work year
+            return document.frbr_uri_date[:4]
+        return super().get_document_group(group_by, document)
 
 
 @registry.register_doc_type("legislation")

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -55,7 +55,7 @@ class LegislationListView(FilteredDocumentListView):
                 }
 
     def get_document_group(self, group_by, document):
-        if group_by == "date":
+        if group_by == "frbr_uri_date":
             # use work year
             return document.frbr_uri_date[:4]
         return super().get_document_group(group_by, document)

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -8,7 +8,7 @@ from django.utils.html import mark_safe
 from django.utils.translation import gettext as _
 
 from peachjam.forms import LegislationFilterForm
-from peachjam.models import Legislation
+from peachjam.models import Legislation, pj_settings
 from peachjam.registry import registry
 from peachjam.views.generic_views import (
     BaseDocumentDetailView,
@@ -24,6 +24,10 @@ class LegislationListView(FilteredDocumentListView):
         "nature": "Act",
         "help_link": "legislation/",
         "doc_table_show_date": False,
+        "subleg_group_row": {
+            "is_group": True,
+            "title": pj_settings().subleg_label,
+        },
     }
     form_defaults = {"sort": "title"}
     form_class = LegislationFilterForm


### PR DESCRIPTION
Where necessary, use the work year for facets and ordering.

https://www.loom.com/share/05b52faa01eb4d95b4ab7472b0bc2e67

* make filtering in the filter form more customisable
* use the year portion of `frbr_uri_date` rather than the `date` field in many legislation listing views
* add overrides for filtering and grouping in legislation list views
* facet by frbr_uri_date
* update `.doc-table` CSS so that it handles lack of a date column (previously this was always assumed to be present)
* bonus: add a tooltip and a group title for "Subsidiary legislation" in the expanded children view

![image](https://github.com/user-attachments/assets/eaaedc47-a931-49a2-9727-a23a35a59145)

![image](https://github.com/user-attachments/assets/2b9c17f2-e5fa-4036-bb66-33453cc385f4)

