### PR TITLE
don't allow buttons to wrap in floating toolbar

### DIFF
--- a/peachjam/templates/peachjam/_document_floating_header.html
+++ b/peachjam/templates/peachjam/_document_floating_header.html
@@ -9,7 +9,7 @@
        title="{% trans "Navigate document" %}"></i>
   </div>
   <h5 class="title px-2 py-0 m-0 align-self-center">{{ document.title }}</h5>
-  <div class="ms-auto px-2 align-content-center">
+  <div class="ms-auto px-2 align-content-center text-nowrap">
     {% trans "Copy citation" as verb %}
     {% include 'peachjam/_copy_to_clipboard.html' with value=document.mnc|default:document.citation verb=verb %}
     {% if show_save_doc_button %}


### PR DESCRIPTION
fixes #2316

# before

![image](https://github.com/user-attachments/assets/700e3f74-845f-4927-88f4-91da67b94ff7)


# after

![image](https://github.com/user-attachments/assets/f8df5ed6-0004-4f8a-8029-44ca7efe6e7e)
