### PR TITLE
show taxonomies in document popup

### DIFF
--- a/peachjam/templates/peachjam/_document_table_row.html
+++ b/peachjam/templates/peachjam/_document_table_row.html
@@ -30,7 +30,7 @@
       {% endif %}
       {% include 'peachjam/_document_labels.html' with labels=document.labels.all %}
       {% if document.listing_taxonomies %}
-        <div class="d-none d-md-block">
+        <div class="d-none d-md-block ms-3">
           {% include 'peachjam/_document_taxonomies.html' with taxonomies=document.listing_taxonomies %}
         </div>
       {% endif %}
@@ -54,7 +54,7 @@
   {% if doc_table_show_doc_type %}<td style="white-space: nowrap;">{{ document.get_doc_type_display }}</td>{% endif %}
   {% if doc_table_show_date %}<td class="cell-date text-nowrap">{{ document.date|default_if_none:'' }}</td>{% endif %}
   {% if document.listing_taxonomies %}
-    <td class="cell-taxonomies">
+    <td class="cell-taxonomies ms-3">
       {% include 'peachjam/_document_taxonomies.html' with taxonomies=document.listing_taxonomies %}
     </td>
   {% endif %}

--- a/peachjam/templates/peachjam/_document_taxonomies.html
+++ b/peachjam/templates/peachjam/_document_taxonomies.html
@@ -1,5 +1,5 @@
 {% if taxonomies %}
-  <div class="ms-3 text-muted fs-sm fst-italic">
+  <div class="text-muted fs-sm fst-italic">
     {% for taxonomy in taxonomies %}
       {% if not forloop.first %}·{% endif %}
       {{ taxonomy.topic.path_name }}

--- a/peachjam/templates/peachjam/document_popup.html
+++ b/peachjam/templates/peachjam/document_popup.html
@@ -24,6 +24,9 @@
         {% endif %}
       {% endblock %}
       {% block date %}<div>{{ document.date }}</div>{% endblock %}
+      {% if document.listing_taxonomies %}
+        <div class="mt-2">{% include 'peachjam/_document_taxonomies.html' with taxonomies=document.listing_taxonomies %}</div>
+      {% endif %}
     </div>
     {% block offsite_request %}
       {% if offsite_request %}


### PR DESCRIPTION
fixes #2263

![image](https://github.com/user-attachments/assets/dd293a99-9701-4560-ac8c-fda3d31e5df1)

(the "lawlibrary" won't be shown in production)