### PR TITLE
Styles

### DIFF
--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -63,11 +63,11 @@ mark {
 
 footer {
   .footer-logos {
-    display: block;
+    display: flex;
+    flex-wrap: wrap;
+
     @include media-breakpoint-up(md) {
-      display: flex;
       justify-content: space-around;
-      flex-wrap: wrap;
     }
   }
 
@@ -75,18 +75,23 @@ footer {
     padding: 1rem 0.5rem;
     display: block;
     text-align: center;
+    flex: 0 0 auto;
+    width: 50%;
+
+    @include media-breakpoint-up(md) {
+      width: auto;
+    }
 
     img {
       width: 100%;
+      max-width: 100%;
       height: auto;
+
       @include media-breakpoint-up(md) {
         height: 60px;
         width: auto;
-
       }
-
     }
-
   }
 }
 

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -176,7 +176,7 @@ html[data-user-agent*='pocketlaw'] .pocketlaw-hidden {
   overflow-y: auto;
 }
 
-a:visited:not(.btn) {
+a:visited:not(.btn, .nav-link, .dropdown-item) {
   color: $visited-link;
 }
 


### PR DESCRIPTION
* don't apply `a:visited` to dropdowns and menu items
* fix footer image sizes on mobile to take up 50% of the width


## Screenshots

(previously, some of these links would be green)

![image](https://github.com/user-attachments/assets/bc192888-df5e-4872-ad15-2027e4284dbf)


![image](https://github.com/user-attachments/assets/b0006bb9-deaa-4d61-bfd1-b2caff163280)

![image](https://github.com/user-attachments/assets/e38657da-138d-4cc3-b951-c8f20d3a88de)
