### PR TITLE
Track an event for the "What changed" button

### DIFF
--- a/peachjam/js/components/DocDiffs/index.ts
+++ b/peachjam/js/components/DocDiffs/index.ts
@@ -2,6 +2,7 @@ import ProvisionChangedGutterItem from './ProvisionChangedGutterItem.vue';
 import ProvisionDiffInline from './ProvisionDiffInline.vue';
 import { createAndMountApp } from '../../utils/vue-utils';
 import { vueI18n } from '../../i18n';
+import analytics from '../analytics';
 
 class DocDiffsManager {
   private gutter: HTMLElement;
@@ -78,6 +79,7 @@ class DocDiffsManager {
     this.inlineDiff.$el.addEventListener('close', () => {
       this.inlineDiff = null;
     });
+    analytics.trackEvent('Document', 'What changed');
   }
 }
 

--- a/peachjam/js/components/analytics.ts
+++ b/peachjam/js/components/analytics.ts
@@ -26,6 +26,11 @@ export class Analytics {
     this.paq.push(['trackSiteSearch', keyword, category, searchCount]);
     this.gtag('event', 'site_search', { keyword, category, searchCount });
   }
+
+  trackEvent (category: string, action: string, name: string | null = null, value: number | null = null) {
+    this.paq.push(['trackEvent', category, action, name, value]);
+    this.gtag('event', action, { event_category: category, event_name: name, value });
+  }
 }
 
 const analytics = new Analytics();


### PR DESCRIPTION
This is a start of us tracking non-page interactions (see #1619)

Events: https://docs.google.com/spreadsheets/d/1TO0B92dBuheOi_RmenL3Tkh7kSo9G2RyLRcjG8Fn2So/edit?gid=0#gid=0

Docs: https://matomo.org/faq/reports/implement-event-tracking-with-matomo/