### PR TITLE
lazy reference to paq and gtag

### DIFF
--- a/peachjam/js/components/analytics.ts
+++ b/peachjam/js/components/analytics.ts
@@ -4,31 +4,38 @@
 export class Analytics {
   isGAEnabled: boolean;
   isMatomoEnabled: boolean;
-  gtag: any;
-  paq: any[];
 
   constructor () {
     this.isGAEnabled = 'gtag' in window;
     this.isMatomoEnabled = '_paq' in window;
+  }
 
-    // @ts-ignore
-    this.gtag = this.isGAEnabled ? window.gtag : () => {};
-    // @ts-ignore
-    this.paq = this.isMatomoEnabled ? window._paq : [];
+  matomo (x: any) {
+    if (this.isMatomoEnabled) {
+      // @ts-ignore
+      window._paq.push(x);
+    }
+  }
+
+  gtag (...x: any[]) {
+    if (this.isGAEnabled) {
+      // @ts-ignore
+      window.gtag(...x);
+    }
   }
 
   trackPageView () {
-    this.paq.push(['trackPageView']);
+    this.matomo(['trackPageView']);
     this.gtag('event', 'page_view');
   }
 
   trackSiteSearch (keyword: string, category: string, searchCount: number) {
-    this.paq.push(['trackSiteSearch', keyword, category, searchCount]);
+    this.matomo(['trackSiteSearch', keyword, category, searchCount]);
     this.gtag('event', 'site_search', { keyword, category, searchCount });
   }
 
   trackEvent (category: string, action: string, name?: string, value?: number) {
-    this.paq.push(['trackEvent', category, action, name, value]);
+    this.matomo(['trackEvent', category, action, name, value]);
     this.gtag('event', action, { event_category: category, event_name: name, value });
   }
 

--- a/peachjam/js/peachjam.ts
+++ b/peachjam/js/peachjam.ts
@@ -14,7 +14,7 @@ import '@lawsafrica/law-widgets/dist/components/la-decorate-terms';
 // @ts-ignore
 import htmx from 'htmx.org';
 import { csrfToken } from './api';
-import analytics from './components/analytics';
+import analytics, { Analytics } from './components/analytics';
 
 export interface PeachJamConfig {
   appName: string;
@@ -28,6 +28,7 @@ export interface PeachJamConfig {
 
 class PeachJam {
   private components: any[];
+  public analytics: Analytics;
   public config: PeachJamConfig = {
     appName: 'Peach Jam',
     pdfWorker: '/static/js/pdf.worker-prod.js',
@@ -40,6 +41,7 @@ class PeachJam {
 
   constructor () {
     this.components = [];
+    this.analytics = analytics;
   }
 
   setup () {
@@ -68,7 +70,7 @@ class PeachJam {
   }
 
   setupAnalytics () {
-    analytics.trackButtonEvents();
+    this.analytics.trackButtonEvents();
   }
 
   setupHtmx () {


### PR DESCRIPTION
otherwise, our local ref is an array but when matomo loads it replaces window._paq with a function, our local ref won't have it