### PR TITLE
helpscout widget, use SUPPORT_EMAIL for lawlibrary.org.za

### DIFF
--- a/lawlibrary/templates/peachjam/about.html
+++ b/lawlibrary/templates/peachjam/about.html
@@ -51,7 +51,11 @@
   <h2 class="mb-4" id="contact">{% trans 'Contact us' %}</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-      Contact us on <a href="mailto:support@laws.africa">support@laws.africa</a> for more information.
+      Contact us on <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a> for more information.
     {% endblocktrans %}
   </p>
+{% endblock %}
+{% block about-bottom-content %}
+  <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script>
+  <script type="text/javascript">window.Beacon('init', '77a4718f-240f-4c7e-ae4c-35ef1940a1a9')</script>
 {% endblock %}

--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -449,7 +449,7 @@ class DocumentProblemForm(forms.Form):
             subject=subject,
             message=plain_txt_msg,
             from_email=None,
-            recipient_list=default_admin_emails + site_admin_emails,
+            recipient_list=site_admin_emails or default_admin_emails,
             html_message=html,
             fail_silently=False,
         )

--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -448,7 +448,7 @@ class DocumentProblemForm(forms.Form):
         send_mail(
             subject=subject,
             message=plain_txt_msg,
-            from_email=None,
+            from_email=self.cleaned_data.get("email_address"),
             recipient_list=site_admin_emails or default_admin_emails,
             html_message=html,
             fail_silently=False,

--- a/peachjam/templates/peachjam/emails/document_problem_email.html
+++ b/peachjam/templates/peachjam/emails/document_problem_email.html
@@ -6,14 +6,19 @@
   </head>
   <body>
     <p>Hello,</p>
-    <p>
-      We have received a report regarding the following document: <a href="{{ document_link }}">{{ document_link }}</a>
-    </p>
-    <p>Problem category: {{ problem_category }}</p>
-    <p>The reported problem is described as follows:</p>
-    <p>{{ problem_description }}</p>
-    <p>
-      This was reported by: <a href="mailto:{{ email_address }}">{{ email_address }}</a>
-    </p>
+    {% if email_address %}
+      <p>
+        The user <a href="mailto:{{ email_address }}">{{ email_address }}</a> reported a problem with a document.
+      </p>
+    {% else %}
+      <p>A user reported a problem with a document.</p>
+    {% endif %}
+    <ul>
+      <li>
+        Document: <a href="{{ document_link }}">{{ document_link }}</a>
+      </li>
+      <li>Problem category: {{ problem_category }}</li>
+      <li>Problem description: {{ problem_description }}</li>
+    </ul>
   </body>
 </html>

--- a/peachjam/templates/peachjam/emails/document_problem_email.txt
+++ b/peachjam/templates/peachjam/emails/document_problem_email.txt
@@ -1,9 +1,11 @@
 Hello,
 
-We have received a report regarding the following document: {{ document_link }}
+{% if email_address %}
+The user {{ email_address }} reported a problem with a document.
+{% else %}
+A user reported a problem with a document.
+{% endif %}
 
-Problem category: {{ problem_category }}
-The reported problem is described as follows:
-{{ problem_description }}
-
-This was reported by: {{ email_address }}
+* Document: {{ document_link }}
+* Problem category: {{ problem_category }}
+* Problem description: {{ problem_description }}


### PR DESCRIPTION
* on lawlibrary, replace the contact form with the helpscout widget
* use SUPPORT_EMAIL as a backup for lawlibrary
* when submitting problem reports, use the user's email as the from address to support direct reply
* tweak problem email templates

# Screenshots

![image](https://github.com/user-attachments/assets/c5d027a2-1b8c-4641-ac1a-287ba5e114a2)
