### PR TITLE
exclude sort key from saved search pretty filters

### DIFF
--- a/peachjam_search/models.py
+++ b/peachjam_search/models.py
@@ -118,7 +118,11 @@ class SavedSearch(models.Model):
     def pretty_filters(self):
         # get_filters_dict().values() is a list of lists, join the values with commas
         return ", ".join(
-            [", ".join(values) for values in self.get_filters_dict().values()]
+            [
+                ", ".join(values)
+                for key, values in self.get_filters_dict().items()
+                if key != "sort"
+            ]
         )
 
     def get_sorted_filters_string(self):


### PR DESCRIPTION
Avoids email subject lines such as:

```
New matches for your search: EVOLV OUTDOOR (-date)
```