### PR TITLE
Bootstrap container is fluid up to container-lg

### DIFF
--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -33,3 +33,13 @@ $breadcrumb-margin-bottom: 1rem !default;
 
 $floating-header-height: 3rem !default;
 $floating-header-height-md: 2.5rem !default;
+
+// Force bootstrap's container to be fluid up to 960px, which covers most phones and tablets in portrait and
+// landscape. This is easier than changing all uses of container to container-lg.
+$container-max-widths: (
+  sm: 960px,
+  md: 960px,
+  lg: 960px,
+  xl: 1140px,
+  xxl: 1320px
+);

--- a/peachjam/templates/peachjam/_document_table_form.html
+++ b/peachjam/templates/peachjam/_document_table_form.html
@@ -6,7 +6,7 @@
       hx-indicator=".htmx-progress"
       hx-target="#filter-form"
       hx-swap="outerHTML">
-  <div class="d-block d-lg-none my-2">
+  <div class="d-block d-md-none my-2">
     <a class="btn btn-primary"
        href="#document-list-filters-offcanvas"
        data-bs-toggle="offcanvas"


### PR DESCRIPTION
It has been bugging me that it doesn't use the full screen width when my phone is in landscape mode. I don't see any reason to limit the width to breakpoints until the page gets as wide as a desktop.

## Before

![image](https://github.com/user-attachments/assets/d7d1f774-dda9-428e-9f91-e141ed179f9d)


## After

![image](https://github.com/user-attachments/assets/676d856f-7b01-4684-b08a-fb9b43df5406)
