### PR TITLE
use authority to re-rank similar documents and order citations

### DIFF
--- a/peachjam/models/citations.py
+++ b/peachjam/models/citations.py
@@ -142,7 +142,7 @@ class ExtractedCitation(models.Model):
         # get the top n_per_group documents for each nature, ordering by the number of incoming citations
         if nature:
             # just one group, don't need a window function
-            qs = qs.filter(nature=nature).order_by("-work__n_citing_works", "title")
+            qs = qs.filter(nature=nature).order_by("-work__authority_score", "title")
             truncated = qs.count() > offset + n_per_group
             qs = qs[offset : offset + n_per_group]
         else:
@@ -153,11 +153,11 @@ class ExtractedCitation(models.Model):
                 row_number=Window(
                     expression=RowNumber(),
                     partition_by=[F("nature__name")],
-                    order_by=[F("work__n_citing_works").desc(), F("title")],
+                    order_by=[F("work__authority_score").desc(), F("title")],
                 )
             ).filter(row_number__lte=n_per_group)
         return (
-            sorted(qs, key=lambda d: [d.nature.name, -d.work.n_citing_works, d.title]),
+            sorted(qs, key=lambda d: [d.nature.name, -d.work.authority_score, d.title]),
             truncated,
         )
 

--- a/peachjam_ml/views.py
+++ b/peachjam_ml/views.py
@@ -17,7 +17,12 @@ class SimilarDocumentsView(PermissionRequiredMixin, DetailView):
     slug_url_kwarg = "frbr_uri"
     slug_field = "expression_frbr_uri"
     model = CoreDocument
-    similarity_threshold = 0.5
+    similarity_threshold = 0.0
+    weight_similarity = 0.7
+    weight_authority = 0.3
+    # choose the best from this set, after re-ranking
+    top_k = 100
+    n_similar = 10
 
     def get_similar_documents(self):
         embedding = get_object_or_404(DocumentEmbedding, document_id=self.object.pk)
@@ -30,11 +35,23 @@ class SimilarDocumentsView(PermissionRequiredMixin, DetailView):
                 * -1,
                 title=F("document__title"),
                 expression_frbr_uri=F("document__expression_frbr_uri"),
+                authority_score=F("document__work__authority_score"),
             )
             .filter(similarity__gt=self.similarity_threshold)
-            .values("title", "expression_frbr_uri", "similarity")
-            .order_by("-similarity")[:10]
-        )
+            .values("title", "expression_frbr_uri", "similarity", "authority_score")
+            .order_by("-similarity")
+        )[: self.top_k]
+
+        # re-rank based on a weighted average of similarity and authority score, and keep the top 10
+        similar_docs = sorted(
+            similar_docs,
+            key=lambda x: (
+                x["similarity"] * self.weight_similarity
+                + x["authority_score"] * self.weight_authority
+            ),
+            reverse=True,
+        )[: self.n_similar]
+
         return similar_docs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Get the top 100 documents by similarity, then re-rank using authority, and show the top 10.

Motivation for re-ranking, rather than folding the authority into the score during querying:

1.	Semantic similarity is the primary signal — the user expects the results to be on-topic first.
2.	Authority is a tie-breaker — we want to show the most valuable among the relevant.
3.	We avoid accidentally discarding high-similarity docs with lower authority.


Also:

1. sort citation lists by authority, rather than just citations