### PR TITLE
Add a notice for future points in time

### DIFF
--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -270,6 +270,17 @@ class LegislationDetailView(BaseDocumentDetailView):
                     }
                 )
 
+        if self.object.date > datetime.now().date():
+            notices.append(
+                {
+                    "type": messages.WARNING,
+                    "html": _(
+                        "This version will be applied on %(current_object_date)s."
+                    )
+                    % {"current_object_date": current_object_date},
+                }
+            )
+
         return notices
 
     def get_repeal_info(self):


### PR DESCRIPTION
![Screenshot 2025-05-05 at 12 15 38](https://github.com/user-attachments/assets/00a1822c-c8fa-4bc9-be5a-8dd11115c533)
Closes #2220 

Kindly let me know if there are other types of docs with versions that may be applied at a future date