### PR TITLE
Better PDF error handling

### DIFF
--- a/peachjam/js/components/DocumentContent/pdf-renderer.ts
+++ b/peachjam/js/components/DocumentContent/pdf-renderer.ts
@@ -171,6 +171,7 @@ class PdfRenderer {
       if (ctx) ctx.clearRect(0, 0, 1, 1);
     } catch (e) {
       console.log(e);
+      this.showError(e);
     }
   }
 
@@ -271,6 +272,15 @@ class PdfRenderer {
 
     if (this.previewPanelsContainer) {
       this.previewPanelsContainer.appendChild(panelPreview);
+    }
+  }
+
+  showError (e: any) {
+    this.root.removeAttribute('data-pdf-loading');
+    this.root.setAttribute('data-pdf-error', '');
+    const err = this.root.querySelector('.pdf-error-message') as HTMLSpanElement;
+    if (err) {
+      err.innerText = e.message;
     }
   }
 }

--- a/peachjam/static/stylesheets/components/_document-content.scss
+++ b/peachjam/static/stylesheets/components/_document-content.scss
@@ -339,11 +339,12 @@
     @extend .mb-4;
   }
 
-  .pdf-loading {
+  .pdf-loading,
+  .pdf-error {
     display: none;
   }
 
-  &[data-pdf-standby], &[data-pdf-loading] {
+  &[data-pdf-standby], &[data-pdf-loading], &[data-pdf-error] {
     .navigation {
       opacity: 0;
     }
@@ -361,6 +362,12 @@
 
   &[data-pdf-loading] {
     .pdf-loading {
+      display: block;
+    }
+  }
+
+  &[data-pdf-error] {
+    .pdf-error {
       display: block;
     }
   }

--- a/peachjam/templates/peachjam/_document_content.html
+++ b/peachjam/templates/peachjam/_document_content.html
@@ -66,6 +66,17 @@
               </p>
               <button class="btn btn-primary" type="button" data-load-doc-button>{% trans 'Load document' %}</button>
             </div>
+            <div class="pdf-error">
+              <h5>{% trans 'Error loading PDF' %}</h5>
+              <div class="mb-3">{% trans "Try reloading the page or downloading the PDF." %}</div>
+              <div class="mb-5">
+                <a href="#" onclick="window.location.reload();" class="me-3">{% trans "Reload page" %}</a>
+                <a href="{% url 'document_source_pdf' document.expression_frbr_uri|strip_first_character %}">{% trans "Download PDF" %}</a>
+              </div>
+              <div class="text-muted">
+                {% trans "Error" %}: <span class="pdf-error-message"></span>
+              </div>
+            </div>
           </div>
         {% endif %}
         <la-gutter akoma-ntoso=".content-and-enrichments .content"></la-gutter>


### PR DESCRIPTION
* show an error when the PDF fails to load, rather than letting the user watch a spinner go nowhere
* load the pdf data using fetch() so that we have visibility into what went wrong
* if the response is a non-200 response, then raise an exception so we get a sentry alert

![image](https://github.com/user-attachments/assets/f9da356a-7c50-4247-a1ad-02eeec78f555)
