### PR TITLE
Visual and layout tweaks

### DIFF
--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -35,6 +35,8 @@ $breadcrumb-margin-bottom: 1rem !default;
 $floating-header-height: 3rem !default;
 $floating-header-height-md: 2.5rem !default;
 
+$alert-padding-y: 0.75rem;
+
 // Force bootstrap's container to be fluid up to 960px, which covers most phones and tablets in portrait and
 // landscape. This is easier than changing all uses of container to container-lg.
 $container-max-widths: (

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -37,6 +37,17 @@ $floating-header-height-md: 2.5rem !default;
 
 $alert-padding-y: 0.75rem;
 
+// add an xxxl breakpoint for wide screens
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1400px,
+  xxxl: 1600px,
+) !default;
+
 // Force bootstrap's container to be fluid up to 960px, which covers most phones and tablets in portrait and
 // landscape. This is easier than changing all uses of container to container-lg.
 $container-max-widths: (
@@ -44,7 +55,9 @@ $container-max-widths: (
   md: 960px,
   lg: 960px,
   xl: 1140px,
-  xxl: 1320px
+  xxl: 1320px,
+  // custom xxxl container
+  xxxl: 1520px
 );
 
 // make navbar toggler simpler

--- a/peachjam/static/stylesheets/components/_header.scss
+++ b/peachjam/static/stylesheets/components/_header.scss
@@ -1,12 +1,6 @@
 .top-bar {
   .top-bar-logo {
-    max-height: 40px;
-  }
-
-  @include media-breakpoint-down(sm) {
-    .top-bar-logo {
-      max-height: 30px;
-    }
+    max-height: 30px;
   }
 }
 

--- a/peachjam/static/stylesheets/components/_text.scss
+++ b/peachjam/static/stylesheets/components/_text.scss
@@ -5,3 +5,7 @@
 .fs-sm {
   font-size: small;
 }
+
+h1.doc-title {
+  font-size: $font-size-base * 1.75; // h3
+}

--- a/peachjam/templates/account/_social_login_buttons.html
+++ b/peachjam/templates/account/_social_login_buttons.html
@@ -1,7 +1,6 @@
 {% load i18n socialaccount static %}
 {% get_providers as socialaccount_providers %}
 {% if PEACHJAM_SETTINGS.allow_social_logins and socialaccount_providers %}
-  <hr/>
   {% for provider in socialaccount_providers %}
     <form method="post"
           class="mt-4"
@@ -21,4 +20,5 @@
       </button>
     </form>
   {% endfor %}
+  <hr/>
 {% endif %}

--- a/peachjam/templates/account/login.html
+++ b/peachjam/templates/account/login.html
@@ -6,6 +6,7 @@
 {% endblock %}
 {% block content %}
   <h2 class="mb-4">{% trans 'Log in' %}</h2>
+  {% include "account/_social_login_buttons.html" %}
   <form method="post" action="{% url 'account_login' %}" id="email-login">
     {% csrf_token %}
     {% if redirect_field_value %}
@@ -60,5 +61,4 @@
       <a class="btn btn-link ms-3" href="{% url 'account_signup' %}">{% trans 'Create an account' %}</a>
     </div>
   </form>
-  {% include "account/_social_login_buttons.html" %}
 {% endblock %}

--- a/peachjam/templates/account/signup.html
+++ b/peachjam/templates/account/signup.html
@@ -6,6 +6,7 @@
 {% endblock %}
 {% block content %}
   <h2 class="mb-4">{% trans 'Sign up' %}</h2>
+  {% include "account/_social_login_buttons.html" %}
   <form method="post">
     {% csrf_token %}
     {% if form.non_field_errors %}
@@ -98,7 +99,6 @@
       <button class="btn btn-primary" type="submit">{% trans 'Sign up' %}</button>
     </div>
   </form>
-  {% include "account/_social_login_buttons.html" %}
   <p class="mt-3">
     {% trans 'Already have an account?' %} <a href="{% url 'account_login' %}">{% trans 'Log in' %}</a>.
   </p>

--- a/peachjam/templates/peachjam/_open_law_africa.html
+++ b/peachjam/templates/peachjam/_open_law_africa.html
@@ -1,5 +1,5 @@
 {% load i18n static %}
-<div class="top-bar bg-dark p-2">
+<div class="top-bar bg-dark p-1">
   <div class="container d-flex">
     <a href="https://www.openlawafrica.org/"
        target="_blank"

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -32,9 +32,9 @@
       <div class="container">
         {% block breadcrumbs %}{% endblock %}
         {% block document-title %}
-          <div class="d-md-flex justify-content-md-between py-3">
+          <div class="d-md-flex justify-content-md-between my-3">
             <div>
-              <h1>{{ document.title }}</h1>
+              <h1 class="doc-title">{{ document.title }}</h1>
               {% block sub-title %}{% endblock %}
               {% include 'peachjam/_document_labels.html' %}
             </div>

--- a/peachjam/templates/peachjam/user_following/_timeline.html
+++ b/peachjam/templates/peachjam/user_following/_timeline.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% for date, groups in following_timeline.items %}
   <li>
-    <div class="sticky-top bg-white text-muted">{{ date }}</div>
+    <div class="bg-white text-muted">{{ date }}</div>
     <ul class="list-unstyled">
       {% for following, docs in groups %}
         <li>


### PR DESCRIPTION
* move social login buttons to top of login and sign up pages, since they are by far the most used login mechanism
* reduce size of OLA header
* reduce padding on alerts to take up less room
* normalise margins on document title and reduce font size
* add an xxxl breakpoint at 1600px for very wide screens to take advantage of the extra width
* drop sticky-top on timeline, it looks weird

# screenshots

## login buttons

![image](https://github.com/user-attachments/assets/b732d18e-a39f-4ca2-bf62-e8f5d62ed6a4)
