### PR TITLE
Fix bug that skewed legislation document embeddings

### DIFF
--- a/peachjam_ml/admin.py
+++ b/peachjam_ml/admin.py
@@ -1,21 +1,44 @@
 from django.utils.translation import gettext_lazy as _
 
 from peachjam.admin import DocumentAdmin
+from peachjam_ml.models import DocumentEmbedding
 from peachjam_ml.tasks import update_document_embeddings
 
 
-def update_embeddings(self, request, queryset):
+def update_chunk_embeddings(self, request, queryset):
     for document in queryset:
         update_document_embeddings(document.id)
 
     self.message_user(
         request,
-        _("Updating document embeddings in the background."),
+        _("Updating document chunks and embeddings in the background."),
     )
 
 
-update_embeddings.short_description = _("Update document embeddings (background)")
+update_chunk_embeddings.short_description = _(
+    "Update document chunks and embeddings (background)"
+)
 
 
-DocumentAdmin.actions.append("update_embeddings")
-DocumentAdmin.update_embeddings = update_embeddings
+def update_doc_embeddings(self, request, queryset):
+    for doc_embedding in (
+        DocumentEmbedding.objects.filter(document__in=queryset)
+        .defer("text_embedding")
+        .iterator(100)
+    ):
+        doc_embedding.update_embedding()
+        doc_embedding.save()
+
+    self.message_user(
+        request,
+        _("Re-calculated document embeddings."),
+    )
+
+
+update_doc_embeddings.short_description = _("Re-calculate average document embeddings")
+
+
+DocumentAdmin.actions.append("update_chunk_embeddings")
+DocumentAdmin.actions.append("update_doc_embeddings")
+DocumentAdmin.update_doc_embeddings = update_doc_embeddings
+DocumentAdmin.update_chunk_embeddings = update_chunk_embeddings


### PR DESCRIPTION
when we break an AKN document into chunks, we do it recursively. This
gives us good coverage and semantic search across provision boundaries
as well as accuracy when finding provision-level matches.

When we're calculating the average of all a document's chunks to find
the document-level embedding, we don't want to include the repeated
(nested) chunks because it gives them more weight than they should have.
Instead, use the average of the top-level provisions.