### PR TITLE
Adjust document detail page toolbar and use menu on mobile

### DIFF
--- a/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
+++ b/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
@@ -39,7 +39,7 @@
               target="_blank"
               data-track-event="Document | Social share | X"
               @click="modal.hide()"
-            ><i class="bi bi-twitter twitter-forecolor share-icon" />
+            ><i class="bi bi-twitter-x twitter-x-forecolor share-icon" />
             </a>
             <a
               :href="`https://www.facebook.com/sharer/sharer.php?u=${ encodeURIComponent(url) }`"

--- a/peachjam/js/components/index.ts
+++ b/peachjam/js/components/index.ts
@@ -11,6 +11,7 @@ import { ToggleTab } from './tabs';
 import TaxonomyTree from './taxonomy-tree';
 import TermsOfUse from './terms-of-use';
 import SearchTypeahead from './search-typeahead';
+import ShareMenuItem from './share-menu-item';
 
 import DocumentProblemModal from './DocumentProblemModal.vue';
 import FindDocuments from './FindDocuments/index.vue';
@@ -30,6 +31,7 @@ const components: Record<string, any> = {
   RelationshipEnrichments,
   AnnotationsProvider,
   SearchTypeahead,
+  ShareMenuItem,
   ToggleTab,
   TaxonomyTree,
   TermsOfUse,

--- a/peachjam/js/components/share-menu-item.ts
+++ b/peachjam/js/components/share-menu-item.ts
@@ -1,0 +1,26 @@
+import ShareSelectionModal from './DocumentContent/ShareSelectionModal.vue';
+import { createAndMountApp } from '../utils/vue-utils';
+import { vueI18n } from '../i18n';
+
+export default class ShareMenuItem {
+  private documentTitle: string;
+
+  constructor (root: HTMLElement) {
+    root.addEventListener('click', this.showModal.bind(this));
+    // @ts-ignore
+    this.documentTitle = document.querySelector('.document-content')?.dataset?.title || '';
+  }
+
+  showModal () {
+    // open the share dialog
+    createAndMountApp({
+      component: ShareSelectionModal,
+      props: {
+        url: window.location.toString(),
+        text: this.documentTitle
+      },
+      use: [vueI18n],
+      mountTarget: document.createElement('div')
+    });
+  }
+}

--- a/peachjam/templates/peachjam/_document_detail_toolbar.html
+++ b/peachjam/templates/peachjam/_document_detail_toolbar.html
@@ -77,7 +77,7 @@
     </div>
   {% endblock %}
   <div class="d-md-none dropdown">
-    <button class="btn btn-shrink-sm ms-2"
+    <button class="btn btn-outline-secondary btn-shrink-sm ms-2"
             type="button"
             data-bs-toggle="dropdown"
             aria-expanded="false">

--- a/peachjam/templates/peachjam/_document_detail_toolbar.html
+++ b/peachjam/templates/peachjam/_document_detail_toolbar.html
@@ -1,7 +1,16 @@
 {% load peachjam static i18n %}
-<div class="btn-toolbar justify-content-end mb-3 document-detail-toolbar"
+<div class="btn-toolbar mb-3 document-detail-toolbar"
      role="toolbar"
      aria-label="{% trans "Document toolbar" %}">
+  <div class="me-auto">
+    {% if show_save_doc_button %}
+      <div hx-get="{% url 'saved_document_button' document.id %}"
+           hx-trigger="load"></div>
+      <!-- these will be replaced by htmx -->
+      <div class="save-document-button save-document-button--{{ document.id }}"></div>
+      {% include 'peachjam/saved_document/_modal_placeholder.html' %}
+    {% endif %}
+  </div>
   {% block edit-btn %}
     {% if user.is_staff %}
       {% if document.ingestor_edit_url %}
@@ -26,26 +35,17 @@
     {% endif %}
   {% endblock %}
   {% block download-btn %}
-    <div>
-      {% if show_save_doc_button %}
-        <div hx-get="{% url 'saved_document_button' document.id %}"
-             hx-trigger="load"></div>
-        <!-- these will be replaced by htmx -->
-        <div class="save-document-button save-document-button--{{ document.id }}"></div>
-        {% include 'peachjam/saved_document/_modal_placeholder.html' %}
-      {% endif %}
-    </div>
     {% if document.source_file %}
-      <div class="btn-group dropdown-center ms-2">
+      <div class="btn-group dropdown-center ms-2 d-none d-md-block">
         <a href="{% url 'document_source' document.expression_frbr_uri|strip_first_character %}"
-           class="btn btn-primary btn-shrink-sm"
+           class="btn btn-secondary btn-shrink-sm"
            target="_blank">
           {% trans "Download" %} {{ document.source_file.filename_extension|upper }}
           ({{ document.source_file.size|filesizeformat }})
         </a>
         {% if document.source_file.filename_extension != "pdf" %}
           <button type="button"
-                  class="btn btn-primary btn-shrink-sm dropdown-toggle dropdown-toggle-split"
+                  class="btn btn-secondary btn-shrink-sm dropdown-toggle dropdown-toggle-split"
                   data-bs-toggle="dropdown"
                   aria-expanded="false">
             <span class="visually-hidden">{% trans "Toggle dropdown" %}</span>
@@ -62,21 +62,56 @@
     {% endif %}
   {% endblock %}
   {% block report-problem-btn %}
-    <div>
-      <button type="button"
-              class="btn btn-outline-secondary btn-shrink-sm ms-2"
-              data-bs-toggle="modal"
-              data-bs-target="#documentProblemModal">
-        <span class="d-md-none">{% trans "Report" %}</span>
-        <span class="d-none d-md-inline">{% trans 'Report a problem' %}</span>
-      </button>
-      <div class="modal fade"
-           id="documentProblemModal"
-           tabindex="-1"
-           aria-labelledby="documentProblemModalTitle"
-           aria-hidden="true"
-           data-vue-component="DocumentProblemModal">
-      </div>
+    <button type="button"
+            class="btn btn-outline-secondary btn-shrink-sm ms-2 d-none d-md-block"
+            data-bs-toggle="modal"
+            data-bs-target="#documentProblemModal">
+      {% trans 'Report a problem' %}
+    </button>
+    <div class="modal fade"
+         id="documentProblemModal"
+         tabindex="-1"
+         aria-labelledby="documentProblemModalTitle"
+         aria-hidden="true"
+         data-vue-component="DocumentProblemModal">
     </div>
   {% endblock %}
+  <div class="d-md-none dropdown">
+    <button class="btn btn-shrink-sm ms-2"
+            type="button"
+            data-bs-toggle="dropdown"
+            aria-expanded="false">
+      <i class="bi bi-three-dots"></i>
+    </button>
+    <ul class="dropdown-menu">
+      <li>
+        <button class="dropdown-item" data-component="ShareMenuItem">{% trans "Share" %}</button>
+      </li>
+      {% if document.source_file %}
+        <li>
+          <a href="{% url 'document_source' document.expression_frbr_uri|strip_first_character %}"
+             class="dropdown-item"
+             target="_blank">
+            {% trans "Download" %} {{ document.source_file.filename_extension|upper }}
+            ({{ document.source_file.size|filesizeformat }})
+          </a>
+        </li>
+        {% if document.source_file.filename_extension != "pdf" %}
+          <li>
+            <a class="dropdown-item"
+               href="{% url 'document_source_pdf' document.expression_frbr_uri|strip_first_character %}"
+               target="_blank">{% trans "Download" %} PDF</a>
+          </li>
+        {% endif %}
+      {% endif %}
+      <li>
+        <hr class="dropdown-divider"/>
+      </li>
+      <li>
+        <a class="dropdown-item"
+           href="#documentProblemModal"
+           data-bs-toggle="modal">{% trans "Report a problem" %}</a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -38,7 +38,7 @@
               {% block sub-title %}{% endblock %}
               {% include 'peachjam/_document_labels.html' %}
             </div>
-            <div class="d-flex align-items-center">
+            <div class="d-none d-md-flex align-items-center">
               <a href="https://api.whatsapp.com/send?text={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
                  data-track-event="Document | Social share | WhatsApp"

--- a/peachjam/templates/peachjam/saved_document/_create.html
+++ b/peachjam/templates/peachjam/saved_document/_create.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<button class="btn btn-outline-primary btn-shrink-sm ms-2 save-document-button save-document-button--{{ document.id }}"
+<button class="btn btn-primary btn-shrink-sm save-document-button save-document-button--{{ document.id }}"
         type="button"
         data-bs-toggle="modal"
         data-bs-target="#saveDocumentModal-{{ document.id }}"
@@ -12,7 +12,7 @@
 </button>
 <div hx-swap-oob="true"
      id="saveDocumentModalDialog-{{ document.id }}"
-     class="modal-dialog">
+     class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="modal-header">
       <p class="h5 modal-title">{% trans 'Save document' %}</p>

--- a/peachjam/templates/peachjam/saved_document/_update_button.html
+++ b/peachjam/templates/peachjam/saved_document/_update_button.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<button class="btn btn-outline-primary btn-shrink-sm ms-2 save-document-button save-document-button--{{ saved_document.document.id }}"
+<button class="btn btn-primary btn-shrink-sm save-document-button save-document-button--{{ saved_document.document.id }}"
         type="button"
         data-bs-toggle="modal"
         data-bs-target="#saveDocumentModal-{{ saved_document.document.id }}"


### PR DESCRIPTION
* move Save button to the left and make it primary so it stands out
* make download button secondary
* on mobile, move share, download and report a problem into a dropdown menu to preserve space

## desktop

![image](https://github.com/user-attachments/assets/9d300e9e-db6b-4fb2-983a-09c9b744d0a3)

## mobile

![image](https://github.com/user-attachments/assets/b88f0a85-e39f-4eb2-b4f2-72da1d4562fd)


![image](https://github.com/user-attachments/assets/2c92fc10-3a0f-461d-a5ba-c86623c57685)
