### PR TITLE
Simplify search view (in particular on mobile)

### DIFF
--- a/peachjam/js/components/FilterFacets/index.vue
+++ b/peachjam/js/components/FilterFacets/index.vue
@@ -14,6 +14,20 @@
         {{ $t("Clear all") }}
       </a>
     </li>
+    <li class="list-group-item d-flex d-lg-none">
+      <label class="form-label align-self-center mb-0 me-2">{{ $t('Sort') }}</label>
+      <select :value="ordering" class="ms-auto form-select select-narrow" @change="ordered">
+        <option value="-score">
+          {{ $t('Relevance') }}
+        </option>
+        <option value="date">
+          {{ $t('Date (oldest first)') }}
+        </option>
+        <option value="-date">
+          {{ $t('Date (newest first)') }}
+        </option>
+      </select>
+    </li>
     <template
       v-for="(facet, index) in modelValue"
       :key="index"
@@ -41,9 +55,13 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    ordering: {
+      type: String,
+      default: '-score'
     }
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'ordered'],
   computed: {
     showClearAllFilter () {
       return this.modelValue.some((item) => {
@@ -108,10 +126,11 @@ export default {
         value: getValue()
       };
       this.$emit('update:modelValue', data);
+    },
+
+    ordered (e) {
+      this.$emit('ordered', e.target.value);
     }
   }
 };
 </script>
-
-<style scoped>
-</style>

--- a/peachjam/js/components/FindDocuments/FacetBadges.vue
+++ b/peachjam/js/components/FindDocuments/FacetBadges.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="activeOptions.length" class="mb-3">
+  <div v-if="activeOptions.length" class="mb-3 d-none d-lg-block">
     <button
       v-for="option in activeOptions"
       :key="option.value"

--- a/peachjam/js/components/FindDocuments/MobileSideDrawer.vue
+++ b/peachjam/js/components/FindDocuments/MobileSideDrawer.vue
@@ -49,7 +49,7 @@ export default {
 }
 
 .mobile-side-drawer__mobile-view__content .slot {
-  width: 80%;
+  width: 85%;
   height: 100%;
   transition: transform 300ms ease-in-out;
   transform: translateX(-100%);

--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -77,11 +77,9 @@
                 class="circle-loader--lt"
               />
               <span v-else>
-                <span class="d-none d-md-inline">
-                {{ $t("Search") }}
-                </span>
+                <span class="d-none d-md-inline">{{ $t("Search") }}</span>
                 <span class="d-md-none">
-                  <i class="bi bi-search text-white"></i>
+                  <i class="bi bi-search"></i>
                 </span>
               </span>
             </button>
@@ -91,7 +89,11 @@
               class="btn btn-secondary ms-1 d-lg-none text-nowrap"
               @click="() => drawerOpen = true"
             >
-              {{ $t("Filters") }} <span v-if="selectedFacetsCount">({{ selectedFacetsCount }})</span>
+              <span class="d-none d-md-inline">{{ $t("Filters") }}</span>
+              <span class="d-md-none">
+                <i class="bi bi-filter"></i>
+              </span>
+              <span v-if="selectedFacetsCount" class="badge bg-light text-dark">{{ selectedFacetsCount }}</span>
             </button>
           </form>
           <div class="d-flex my-2">
@@ -174,7 +176,9 @@
               <FilterFacets
                 v-if="searchInfo.count"
                 v-model="facets"
+                :ordering="ordering"
                 :loading="loading"
+                @ordered="setOrdering"
               >
                 <template #header-title>
                   <button
@@ -203,36 +207,29 @@
                 <div id="saved-search-modal-dialog" class="modal-dialog" />
               </div>
               <div v-if="searchInfo.count">
-                <div class="my-3 sort-body row">
-                  <div class="col-md-4 order-md-2 mb-2 sort__inner d-flex align-items-center">
-                    <div style="width: 6em">
-                      {{ $t('Sort by') }}
-                    </div>
-                    <select
-                      v-model="ordering"
-                      class="ms-2 form-select"
-                    >
-                      <option value="-score">
-                        {{ $t('Relevance') }}
-                      </option>
-                      <option value="date">
-                        {{ $t('Date (oldest first)') }}
-                      </option>
-                      <option value="-date">
-                        {{ $t('Date (newest first)') }}
-                      </option>
-                    </select>
+                <div class="my-3 d-flex">
+                  <div class="me-2">
+                    <span v-if="searchInfo.count > 9999">{{ $t('More than 10,000 documents found.') }}</span>
+                    <span v-else>{{ $t('{document_count} documents found', { document_count: searchInfo.count }) }}</span>
+                    <span v-if="searchInfo.can_download">
+                      &nbsp;
+                      <a :href="downloadUrl()" target="_blank">{{ $t('Download to Excel') }}</a>
+                    </span>
                   </div>
-                  <div class="col-md order-md-1 align-self-center">
-                    <div>
-                      <span v-if="searchInfo.count > 9999">{{ $t('More than 10,000 documents found.') }}</span>
-                      <span v-else>{{ $t('{document_count} documents found', { document_count: searchInfo.count }) }}</span>
-                      <span v-if="searchInfo.can_download">
-                        &nbsp;
-                        <a :href="downloadUrl()" target="_blank">{{ $t('Download to Excel') }}</a>
-                      </span>
-                    </div>
-                  </div>
+                  <select
+                    v-model="ordering"
+                    class="form-select ms-auto select-narrow d-none d-lg-block"
+                  >
+                    <option value="-score">
+                      {{ (ordering === "-score" ? ($t("Sort") + ": ") : "") + $t('Relevance') }}
+                    </option>
+                    <option value="date">
+                      {{ (ordering === "date" ? ($t("Sort") + ": ") : "") + $t('Date (oldest first)') }}
+                    </option>
+                    <option value="-date">
+                      {{ (ordering === "-date" ? ($t("Sort") + ": ") : "") + $t('Date (newest first)') }}
+                    </option>
+                  </select>
                 </div>
 
                 <ul class="list-unstyled search-result-list">
@@ -525,6 +522,10 @@ export default {
       this.simpleSearch();
     },
 
+    setOrdering (ordering) {
+      this.ordering = ordering;
+    },
+
     sortBuckets (items, reverse = false, byCount = false) {
       const buckets = [...items];
       function keyFn (a, b) {
@@ -559,14 +560,6 @@ export default {
     submit () {
       this.page = 1;
       this.search();
-    },
-
-    clearAllFilters () {
-      this.facets.forEach((facet) => {
-        if (facet.value.length) {
-          facet.value = [];
-        }
-      });
     },
 
     serialiseState () {
@@ -980,17 +973,6 @@ export default {
   height: 100%;
   background-color: rgba(0, 0, 0, 0.2);
   z-index: 9;
-}
-
-.sort-body {
-  display: flex;
-  justify-content: space-between;
-}
-
-@media screen and (max-width: 400px) {
-  .sort-body {
-    flex-direction: column;
-  }
 }
 
 @media screen and (max-width: 992px) {

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -203,3 +203,7 @@ a:visited:not(.btn, .nav-link, .dropdown-item) {
 .breadcrumb {
   padding-top: 1rem;
 }
+
+select.form-select.select-narrow {
+  width: initial;
+}

--- a/peachjam/static/stylesheets/components/_navs.scss
+++ b/peachjam/static/stylesheets/components/_navs.scss
@@ -44,6 +44,7 @@ $dropdown-box-shadow: $box-shadow-lg;
     border-bottom: 2px solid transparent;
     color: inherit;
     background-color: inherit;
+    white-space: nowrap;
 
     &.active {
       border: none;

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -34,8 +34,8 @@
         {% block document-title %}
           <div class="d-md-flex justify-content-md-between my-3">
             <div>
-              <h1 class="doc-title">
-                {{ document.title }}
+              <h1 class="doc-title d-flex">
+                <span>{{ document.title }}</span>
                 <span id="saved-document-star--{{ document.pk }}"></span>
               </h1>
               {% block sub-title %}{% endblock %}


### PR DESCRIPTION
Reduce clutter on search page, particularly on mobile:

* move sort into filter fly-out
* make sort dropdown take up less space
* move label into the dropdown
* hide faceting buttons in mobile view (they take up too much space, and can be found in the filtering fly-out)


![image](https://github.com/user-attachments/assets/f0be66f7-b9e5-4af3-8cf1-c983d53ace29)

![image](https://github.com/user-attachments/assets/290d6155-2376-4bc5-8417-7703776b472a)

![image](https://github.com/user-attachments/assets/931d4283-a9b9-4dbc-9ef8-f3c5f9c9527a)


Also:

* tweak placement of star in document detail page so that it's to the right of the title, not at the end of a wrapped line

![image](https://github.com/user-attachments/assets/9f3599e8-e3f7-4724-843d-84aaa9e2a227)
