### PR TITLE
Include matching text snippet in search alert emails

### DIFF
--- a/peachjam/templatetags/peachjam.py
+++ b/peachjam/templatetags/peachjam.py
@@ -115,3 +115,8 @@ def split(value, sep=None):
 def get_follow_params(obj):
     # this would be better as a model method
     return f"{'_'.join(obj._meta.verbose_name.lower().split())}={obj.pk}"
+
+
+@register.filter
+def get_dotted_key_value(obj, key):
+    return obj.get(key, "")

--- a/peachjam_search/templates/peachjam/emails/search_alert.email
+++ b/peachjam_search/templates/peachjam/emails/search_alert.email
@@ -10,6 +10,7 @@
   <ul>
     {% for doc in hits %}
       <li>
+        <a href="https://{{ site.domain }}{{ doc.expression_frbr_uri }}">{% if doc.highlight.title %} {{ doc.highlight.title|first|safe }} {% else %} {{ doc.title }} {% endif %}</a>
         <div>
           {% if doc.highlight.content %}
             <p>{{ doc.highlight.content|safeseq|join:' ... ' }}</p>
@@ -30,9 +31,8 @@
               </div>
             {% endfor %}
           {% endif %}
-
       </div>
-        <a href="https://{{ site.domain }}{{ doc.expression_frbr_uri }}">{% if doc.highlight.title %} {{ doc.highlight.title|first|safe }} {% else %} {{ doc.title }} {% endif %}</a>
+      <br/>
       </li>
     {% endfor %}
   </ul>

--- a/peachjam_search/templates/peachjam/emails/search_alert.email
+++ b/peachjam_search/templates/peachjam/emails/search_alert.email
@@ -1,5 +1,5 @@
 {% extends 'peachjam/emails/layouts/alert.html' %}
-{% load i18n %}
+{% load peachjam i18n %}
 {% block subject %}{% trans "New matches for your search" %} {{ saved_search.q }}{% endblock %}
 {% block alert-body %}
   <p>{% trans "We have found new documents that match your search alert:" %}</p>
@@ -10,7 +10,29 @@
   <ul>
     {% for doc in hits %}
       <li>
-        <a href="https://{{ site.domain }}{{ doc.expression_frbr_uri }}">{{ doc.title }}</a>
+        <div>
+          {% if doc.highlight.content %}
+            <p>{{ doc.highlight.content|safeseq|join:' ... ' }}</p>
+          {% elif doc.pages|length %}
+            {% for page in doc.pages %}
+              <div>
+                <a href="https://{{ site.domain }}{{doc.expression_frbr_uri}}#page-{{page.page_num}}"
+                >{% trans 'Page' %} {{ page.page_num }}</a>:
+                <span>{{ page.highlight|get_dotted_key_value:'pages.body'|safeseq|join:' ... ' }}</span>
+              </div>
+            {% endfor %}
+          {% elif doc.provisions|length %}
+            {% for provision in doc.provisions %}
+              <div>
+                <a href="https://{{ site.domain }}{{doc.expression_frbr_uri}}#{{provision.id}}"
+                >{{ provision.title }}</a>
+                <span>{{ provision.highlight|get_dotted_key_value:'provisions.body'|safeseq|join:' ... ' }}</span>
+              </div>
+            {% endfor %}
+          {% endif %}
+
+      </div>
+        <a href="https://{{ site.domain }}{{ doc.expression_frbr_uri }}">{% if doc.highlight.title %} {{ doc.highlight.title|first|safe }} {% else %} {{ doc.title }} {% endif %}</a>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Closes #2522
To prevent a hit without highlights, I included cases for pages and provisons
![Screenshot 2025-06-06 at 16 18 20](https://github.com/user-attachments/assets/71b971cf-945f-4e66-8a26-c5611ab20629)
