### PR TITLE
move published field to key details

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -623,6 +623,7 @@ class DocumentAdmin(AccessGroupMixin, BaseAdmin):
                     "locality",
                     "date",
                     "language",
+                    "published",
                 ]
             },
         ),
@@ -667,7 +668,6 @@ class DocumentAdmin(AccessGroupMixin, BaseAdmin):
                 "fields": [
                     "content_html_is_akn",
                     "allow_robots",
-                    "published",
                     "restricted",
                     "document_access_link",
                     "toc_json",


### PR DESCRIPTION
Editors cannot republish anonymized documents after anonymisation because they don't have access to the advanced tab. I think its safe to allow editors to have access to this field 