### PR TITLE
Uncommenced provisions tweaks

### DIFF
--- a/liiweb/templates/liiweb/legislation_list.html
+++ b/liiweb/templates/liiweb/legislation_list.html
@@ -24,13 +24,11 @@
               <a href="{% url "unconstitutional_provision_list" %}">{% trans "Unconstitutional provisions" %}</a>
             </li>
           {% endif %}
-          {% comment %}
           {% if show_uncommenced_provisions %}
             <li>
               <a href="{% url "uncommenced_provision_list" %}">{% trans "Uncommenced provisions" %}</a>
             </li>
           {% endif %}
-          {% endcomment %}
         </ul>
       {% endif %}
     </div>

--- a/peachjam/js/components/ProvisionEnrichments/ProvisionEnrichment.vue
+++ b/peachjam/js/components/ProvisionEnrichments/ProvisionEnrichment.vue
@@ -8,7 +8,7 @@
       @click="activate"
     />
     <!-- TODO: introduce and use a card-alert class -->
-    <div :class="`card gutter-item-card alert ${alertLevel} p-0`">
+    <div :class="`card gutter-item-card ${alertLevel}`">
       <div class="card-body">
         <div class="d-flex">
           <div>
@@ -84,12 +84,12 @@ export default {
     },
     alertLevel () {
       if (this.enrichment.enrichment_type === 'unconstitutional_provision' && !this.enrichment.resolved) {
-        return 'alert-danger';
+        return 'alert alert-danger p-0';
       } else if (this.enrichment.enrichment_type === 'uncommenced_provision') {
-        return 'alert-warning';
+        return 'alert alert-warning p-0';
       }
-      // for resolved unconstitutional provisions / the default
-      return 'alert-primary';
+      // for resolved unconstitutional provisions / the default, just use a normal card
+      return null;
     }
   },
   mounted () {

--- a/peachjam/js/components/ProvisionEnrichments/ProvisionEnrichment.vue
+++ b/peachjam/js/components/ProvisionEnrichments/ProvisionEnrichment.vue
@@ -3,7 +3,7 @@
     :anchor.prop="anchorElement"
   >
     <i
-      :class="`bi bi-exclamation-triangle-fill mobile-gutter-item-icon ${mobileIconColour}`"
+      :class="`bi ${icon} mobile-gutter-item-icon ${mobileIconColour}`"
       role="button"
       @click="activate"
     />
@@ -12,7 +12,7 @@
       <div class="card-body">
         <div class="d-flex">
           <div>
-            <i class="bi bi-exclamation-triangle-fill" /> <span
+            <i :class="`bi ${icon}`" /> <span
               v-if="enrichment.enrichment_type==='unconstitutional_provision'">{{ $t('Unconstitutional provision') }}
             </span>
             <span v-else-if="enrichment.enrichment_type==='uncommenced_provision'">{{ $t('Uncommenced provision') }}</span>
@@ -66,6 +66,13 @@ export default {
     anchorElement: null
   }),
   computed: {
+    icon () {
+      if (this.enrichment.enrichment_type === 'unconstitutional_provision' && this.enrichment.resolved) {
+        return 'bi-info-circle-fill';
+      } else {
+        return 'bi-exclamation-triangle-fill';
+      }
+    },
     mobileIconColour () {
       if (this.enrichment.enrichment_type === 'unconstitutional_provision' && !this.enrichment.resolved) {
         return 'text-danger';

--- a/peachjam/js/components/ProvisionEnrichments/ProvisionEnrichment.vue
+++ b/peachjam/js/components/ProvisionEnrichments/ProvisionEnrichment.vue
@@ -3,20 +3,19 @@
     :anchor.prop="anchorElement"
   >
     <i
-      :class="`bi ${icon} mobile-gutter-item-icon`"
+      :class="`bi bi-exclamation-triangle-fill mobile-gutter-item-icon ${mobileIconColour}`"
       role="button"
       @click="activate"
     />
-    <div class="card gutter-item-card">
+    <!-- TODO: introduce and use a card-alert class -->
+    <div :class="`card gutter-item-card alert ${alertLevel} p-0`">
       <div class="card-body">
         <div class="d-flex">
-          <div v-if="enrichment.enrichment_type==='unconstitutional_provision'">
-            <i :class="`bi ${icon}`" />
-            {{ $t('Unconstitutional provision') }}
-          </div>
-          <div v-else-if="enrichment.enrichment_type==='uncommenced_provision'">
-            <i :class="`bi ${icon}`" />
-            {{ $t('Uncommenced provision') }}
+          <div>
+            <i class="bi bi-exclamation-triangle-fill" /> <span
+              v-if="enrichment.enrichment_type==='unconstitutional_provision'">{{ $t('Unconstitutional provision') }}
+            </span>
+            <span v-else-if="enrichment.enrichment_type==='uncommenced_provision'">{{ $t('Uncommenced provision') }}</span>
           </div>
           <button
             type="button"
@@ -67,14 +66,23 @@ export default {
     anchorElement: null
   }),
   computed: {
-    icon () {
-      switch (this.enrichment.enrichment_type) {
-        case 'unconstitutional_provision':
-          return 'bi-journal-x';
-        case 'uncommenced_provision':
-          return 'bi-lightbulb-off';
+    mobileIconColour () {
+      if (this.enrichment.enrichment_type === 'unconstitutional_provision' && !this.enrichment.resolved) {
+        return 'text-danger';
+      } else if (this.enrichment.enrichment_type === 'uncommenced_provision') {
+        return 'text-warning';
       }
-      return '';
+      // the default uses --bs-primary
+      return null;
+    },
+    alertLevel () {
+      if (this.enrichment.enrichment_type === 'unconstitutional_provision' && !this.enrichment.resolved) {
+        return 'alert-danger';
+      } else if (this.enrichment.enrichment_type === 'uncommenced_provision') {
+        return 'alert-warning';
+      }
+      // for resolved unconstitutional provisions / the default
+      return 'alert-primary';
     }
   },
   mounted () {
@@ -96,7 +104,11 @@ export default {
       this.anchorElement = document.querySelector(`[data-eid="${this.enrichment.provision_eid}"`);
       if (this.anchorElement) {
         if (this.enrichment.enrichment_type === 'unconstitutional_provision') {
-          this.anchorElement.classList.add('enrich', 'enrich-unconstitutional-provision');
+          if (!this.enrichment.resolved) {
+            this.anchorElement.classList.add('enrich', 'enrich-unconstitutional-provision-unresolved');
+          } else {
+            this.anchorElement.classList.add('enrich', 'enrich-unconstitutional-provision-resolved');
+          }
         } else if (this.enrichment.enrichment_type === 'uncommenced_provision') {
           this.anchorElement.classList.add('enrich', 'enrich-uncommenced-provision');
         }

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -16,7 +16,7 @@ $linkedin-color: #0a66c2 !default;
 $envelope-at-fill-color: #6c757d !default;
 $youtube-color: #FF0000 !default;
 $anntn-highlight-color: #a68bdc !default;
-$uncommenced-highlight-color: #ced4da !default;
+$uncommenced-highlight-color: #758696 !default;
 $unconstitutional-highlight-color: #FF5555 !default;
 $diff-green-color: #a6f3a6 !default;
 $diff-red-color: #f8cbcb !default;

--- a/peachjam/static/stylesheets/_variables.scss
+++ b/peachjam/static/stylesheets/_variables.scss
@@ -16,8 +16,8 @@ $linkedin-color: #0a66c2 !default;
 $envelope-at-fill-color: #6c757d !default;
 $youtube-color: #FF0000 !default;
 $anntn-highlight-color: #a68bdc !default;
-$uncommenced-highlight-color: #758696 !default;
-$unconstitutional-highlight-color: #FF5555 !default;
+$uncommenced-highlight-color: #fff3cd !default; // --bs-warning-bg-subtle from data-bs-theme=light
+$unconstitutional-highlight-color: #f8d7da !default; // --bs-danger-bg-subtle from data-bs-theme=light
 $diff-green-color: #a6f3a6 !default;
 $diff-red-color: #f8cbcb !default;
 $visited-link: #1A77F2 !default;

--- a/peachjam/static/stylesheets/components/_enrichments.scss
+++ b/peachjam/static/stylesheets/components/_enrichments.scss
@@ -12,18 +12,24 @@
   }
 
   .enrich-uncommenced-provision {
-    background-color: transparentize($uncommenced-highlight-color, 0.8);
+    background-color: tint-color($uncommenced-highlight-color, 30%);
 
     &.active {
-      background-color: transparentize($uncommenced-highlight-color, 0.6);
+      background-color: $uncommenced-highlight-color;
     }
   }
 
-  .enrich-unconstitutional-provision {
-    background-color: transparentize($unconstitutional-highlight-color, 0.8);
+  .enrich-unconstitutional-provision-unresolved {
+    background-color: tint-color($unconstitutional-highlight-color, 30%);
 
     &.active {
-      background-color: transparentize($unconstitutional-highlight-color, 0.4);
+      background-color: $unconstitutional-highlight-color;
+    }
+  }
+
+  .enrich-unconstitutional-provision-resolved {
+    &.active {
+      background-color: var(--bs-primary-bg-subtle);
     }
   }
 

--- a/peachjam/static/stylesheets/components/_icons.scss
+++ b/peachjam/static/stylesheets/components/_icons.scss
@@ -8,8 +8,6 @@
   &.pj-document-detail::before { content: "\f3b9"; /* bi-file-text */ }
   &.pj-history::before { content: "\f292"; /* bi-file-text */ }
   &.pj-related::before { content: "\f548"; /* bi-signpost-split-fill */ }
-  &.pj-uncommenced-provisions::before { content: "\f46a"; /* bi-lightbulb-off */ }
-  &.pj-unconstitutional-provisions::before { content: "\f445"; /* bi-tags-fill */ }
   &.pj-taxonomies::before { content: "\f5b1"; /* bi-tags-fill */ }
   &.pj-ai::before {
     color: $text-ai;

--- a/peachjam/templates/peachjam/document/_uncommenced_provisions.html
+++ b/peachjam/templates/peachjam/document/_uncommenced_provisions.html
@@ -1,6 +1,6 @@
 {% load peachjam i18n %}
 <h4 class="mb-3">
-  <i class="bi bi-pj pj-uncommenced-provisions"></i>
+  <i class="bi bi-pj bi-exclamation-triangle-fill"></i>
   {% trans 'Uncommenced provisions' %}
 </h4>
 <div class="mb-4">

--- a/peachjam/templates/peachjam/document/_unconstitutional_provisions.html
+++ b/peachjam/templates/peachjam/document/_unconstitutional_provisions.html
@@ -1,6 +1,6 @@
 {% load peachjam i18n %}
 <h4 class="mb-3">
-  <i class="bi bi-pj pj-unconstitutional-provisions"></i>
+  <i class="bi bi-pj bi-exclamation-triangle-fill"></i>
   {% trans 'Unconstitutional provisions' %}
 </h4>
 <div class="mb-4">

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -121,7 +121,7 @@
                           role="tab"
                           aria-controls="unconstitutional-provisions-tab"
                           aria-selected="false">
-                    <i class="bi bi-pj pj-unconstitutional-provisions"></i>
+                    <i class="bi bi-pj bi-exclamation-triangle-fill"></i>
                     {% trans "Unconstitutional provisions" %}
                     <span class="badge bg-secondary">{{ unconstitutional_provisions|length }}</span>
                   </button>
@@ -138,7 +138,7 @@
                           role="tab"
                           aria-controls="uncommenced-provisions-tab"
                           aria-selected="false">
-                    <i class="bi bi-pj pj-uncommenced-provisions"></i>
+                    <i class="bi bi-pj bi-exclamation-triangle-fill"></i>
                     {% trans "Uncommenced provisions" %}
                     <span class="badge bg-secondary">{{ uncommenced_provisions|length }}</span>
                   </button>

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -162,7 +162,7 @@ class LegislationDetailView(BaseDocumentDetailView):
                         "type": messages.WARNING,
                         "html": _(
                             "This %(friendly_type)s has not yet come into force in full."
-                            " See the Document detail tab for more information."
+                            " See the Uncommenced provisions tab for more information."
                         )
                         % {"friendly_type": friendly_type},
                     }


### PR DESCRIPTION
- [x] Point to the Uncommenced provisions tab, not the Document detail tab, in the notice
- [x] ~Darker grey highlight~
- [x] Amber highlight instead — match 'warning' when active, lighter when not
- [x] Similarly for unconstitutional and 'danger'
    - [x] Resolved unconstitutional provisions should probably be ~'info'~ 'primary'
- [x] Color the gutter items too (warning / danger)
- [x] Icon: warning triangle (and for unconstitutional provisions)
- [x] Link to global list from legislation list

<img width="787" alt="image" src="https://github.com/user-attachments/assets/e664e2e1-7709-4267-a181-b0838e09a546" />

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/5f704859-cffa-437d-a8a6-6aed34ca9f39" />
