### PR TITLE
clean html fields before save

### DIFF
--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -577,17 +577,17 @@ class CoreDocument(PolymorphicModel):
         else:
             self.toc_json = []
 
-    def clean_content_html(self, content_html):
-        """Ensure that content_html is not just whitespace HTML. Returns the cleaned value."""
-        if not content_html:
+    def clean_html_field(self, html):
+
+        if not html:
             return None
 
         # return None if the HTML doesn't have any content
         try:
-            root = parse_html_str(content_html)
+            root = parse_html_str(html)
             iframes = root.xpath("//iframe")
             if iframes:
-                return content_html
+                return html
 
             text = "".join(root.itertext()).strip()
             text = re.sub(r"\s", "", text)
@@ -596,7 +596,11 @@ class CoreDocument(PolymorphicModel):
         except (ValueError, ParserError):
             return None
 
-        return content_html
+        return html
+
+    def clean_content_html(self, content_html):
+        """Ensure that content_html is not just whitespace HTML. Returns the cleaned value."""
+        return self.clean_html_field(content_html)
 
     def clean(self):
         super().clean()

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -474,6 +474,9 @@ class Judgment(CoreDocument):
     def clean(self):
         if self.auto_assign_details:
             self.assign_mnc()
+        self.flynote = self.clean_html_field(self.flynote)
+        self.case_summary = self.clean_html_field(self.case_summary)
+        self.order = self.clean_html_field(self.order)
         super().clean()
 
     def assign_title(self):


### PR DESCRIPTION
This cleans the html fields before save. 
Ulii has an where case summary fields have invalid data during judgment upload. Not sure how its happening but it is preventing automatic judgment summary generation.

here is the data in metabase:
<img width="492" height="169" alt="image" src="https://github.com/user-attachments/assets/9b4d10a7-9e83-4935-94c7-5020dc51889b" />
