### PR TITLE
utils to collect preceding and following node text

### DIFF
--- a/peachjam/tests/test_xmlutils.py
+++ b/peachjam/tests/test_xmlutils.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+
+from peachjam.xmlutils import get_following_text, get_preceding_text, parse_html_str
+
+
+class WrapTextTestCase(TestCase):
+    def check_pre(self, xml, expected, max_chars=None):
+        """Check that the given XML has the expected text."""
+        tree = parse_html_str(xml)
+        self.assertEqual(
+            expected, get_preceding_text(tree.xpath("//a")[0], ["p"], max_chars)
+        )
+
+    def test_preceding_text(self):
+        self.check_pre("<a>baz</a>", "")
+        self.check_pre("<p><a>baz</a></p>", "")
+        self.check_pre("<div><p>foo bar <a>baz</a></p></div>", "foo bar ")
+        self.check_pre(
+            "<div><p>foo bar <b>x <i>yy </i></b><a>baz</a></p></div>", "foo bar x yy "
+        )
+        self.check_pre(
+            "<div><p>foo bar <b>x <i>yy </i></b>z<b>x <span>z <a>baz</a>tail</span></b></p>tail</div>",
+            "foo bar x yy zx z ",
+        )
+        self.check_pre(
+            "<div><section>xxx <p>foo bar <a>baz</a></p></section></div>", "foo bar "
+        )
+
+    def test_preceding_text_max_chars(self):
+        self.check_pre("<div><p>foo bar <a>baz</a></p></div>", "bar ", 4)
+        self.check_pre(
+            "<div><p>foo bar <b>x <i>yy </i></b><a>baz</a></p></div>", "x yy ", 5
+        )
+        self.check_pre(
+            "<div><p>foo bar <b>x <i>yy </i></b>z<b>x <span>z <a>baz</a>tail</span></b></p>tail</div>",
+            "y zx z ",
+            7,
+        )
+        self.check_pre(
+            "<div><section>xxx <p>foo bar <a>baz</a></p></section></div>", "bar ", 4
+        )
+
+    def check_fol(self, xml, expected, max_chars=None):
+        """Check that the given XML has the expected following text."""
+        tree = parse_html_str(xml)
+        self.assertEqual(
+            expected, get_following_text(tree.xpath("//a")[0], ["p"], max_chars)
+        )
+
+    def test_following_text(self):
+        self.check_fol("<a>baz</a>", "")
+        self.check_fol("<p><a>baz</a></p>", "")
+        self.check_fol("<div><p><a>baz</a> foo bar</p></div>", " foo bar")
+        self.check_fol(
+            "<div><p><a>baz</a><b>x <i>yy </i></b>foo bar</p></div>", "x yy foo bar"
+        )
+        self.check_fol(
+            "<div><p><span><a>baz</a>z<b>x <span>z tail</span></b></span></p>outer</div>",
+            "zx z tail",
+        )
+        self.check_fol(
+            "<div><section><p><a>baz</a>foo bar</p>xxx</section></div>", "foo bar"
+        )
+
+    def test_following_text_max_chars(self):
+        self.check_fol("<div><p><a>baz</a> foo bar</p></div>", " foo", 4)
+        self.check_fol(
+            "<div><p><a>baz</a><b>x <i>yy </i></b>foo bar</p></div>", "x yy ", 5
+        )
+        self.check_fol(
+            "<div><p><span><a>baz</a>z<b>x <span>z tail</span></b></span></p>outer</div>",
+            "zx z t",
+            6,
+        )
+        self.check_fol(
+            "<div><section><p><a>baz</a>foo bar</p>xxx</section></div>", "foo", 3
+        )

--- a/peachjam/xmlutils.py
+++ b/peachjam/xmlutils.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import lxml.html
 
 html_parser = lxml.html.HTMLParser(encoding="utf-8")
@@ -12,3 +14,99 @@ def strip_remarks(root: lxml.html.HtmlElement):
     """Removes akn-remark elements from the HTML tree."""
     for remark in root.xpath("//*[@class='akn-remark']"):
         remark.getparent().remove(remark)
+
+
+def get_preceding_text(
+    node: lxml.html.HtmlElement, not_above: List[str], max_chars: int = None
+) -> str:
+    """Get all the text preceding the given node (up to max_chars, if  given), but not going above the elements
+    named in not_above."""
+    parts = []
+    length = 0
+
+    def collect(text):
+        """Append text to parts and update length."""
+        nonlocal length
+        parts.append(text)
+        length += len(text)
+
+    def collect_preceding_siblings(n):
+        """Collect all text from siblings that precede node n."""
+        prev = n.getprevious()
+        while prev is not None:
+            collect("".join(prev.itertext()) + (prev.tail or ""))
+            prev = prev.getprevious()
+
+    current = node
+    while current is not None:
+        # Collect any text before the current node in its parent
+        collect_preceding_siblings(current)
+
+        # get the text at the start of the parent
+        parent = current.getparent()
+        if parent and parent.text:
+            collect(parent.text)
+
+        # include text at the end of the current node
+        if current != node and current.tail:
+            collect(current.tail)
+
+        # Stop if we've reached a tag we're not supposed to go above, or if we have enough text
+        if (parent is not None and parent.tag in not_above) or (
+            max_chars is not None and length >= max_chars
+        ):
+            break
+
+        current = parent
+
+    text = "".join(reversed(parts))
+    if max_chars is not None:
+        text = text[-max_chars:]
+
+    return text
+
+
+def get_following_text(
+    node: lxml.html.HtmlElement, not_above: List[str], max_chars: int = None
+) -> str:
+    """Get all the text following the given node (up to max_chars, if given), but not going above the elements named
+    in not_above."""
+    parts = []
+    length = 0
+
+    def collect(text):
+        """Append text to parts and update length."""
+        nonlocal length
+        parts.append(text)
+        length += len(text)
+
+    def collect_following_siblings(n):
+        """Collect all text from siblings that follow node n."""
+        next_sibling = n.getnext()
+        while next_sibling is not None:
+            collect("".join(next_sibling.itertext()) + (next_sibling.tail or ""))
+            next_sibling = next_sibling.getnext()
+
+    current = node
+    while current is not None:
+        if current.tail:
+            collect(current.tail)
+
+        # Collect any text after the current node in its parent
+        collect_following_siblings(current)
+
+        parent = current.getparent()
+
+        # Stop if we've reached a tag we're not supposed to go above, or if we have enough text
+        if (parent is not None and parent.tag in not_above) or (
+            max_chars is not None and length >= max_chars
+        ):
+            break
+
+        current = parent
+
+    text = "".join(parts)
+    if max_chars is not None:
+        text = text[:max_chars]
+
+    return text


### PR DESCRIPTION
* adds utilities to extract preceding and following text content, without going above certain tags

This makes it difficult to have accurate "start" and "end" position counts for the offset within the document / to the anchor element. If we need that, then we need to find the text relative to the anchor element from the very start.

We don't strictly need the selector details, we only need the prefix and suffix text. I think we can safely exclude that information for now.