### PR TITLE
Removed type field in document metadata

### DIFF
--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -393,14 +393,6 @@
                           </dd>
                         {% endif %}
                       {% endblock %}
-                      {% block document-metadata-content-doctype %}
-                        <dt>
-                          {% trans 'Type' %}
-                        </dt>
-                        <dd class="text-muted">
-                          {% trans document.get_doc_type_display %}
-                        </dd>
-                      {% endblock %}
                       {% block document-metadata-content-publication %}
                         {% if document.publication_file %}
                           <dt>


### PR DESCRIPTION
<img width="610" height="377" alt="Screenshot 2025-07-30 at 11 04 02" src="https://github.com/user-attachments/assets/7e1fa8df-3bdd-4b51-90f3-ce28bcdc90c8" />
