### PR TITLE
IntegrityError: null value in column "folder_id" of relation "peachjam_saveddocument_folders" violates not-null constraint

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -563,7 +563,7 @@ class SaveDocumentForm(forms.ModelForm):
                 "-created_at"
             ).first()
             if most_recent_saved:
-                folders = [most_recent_saved.folders.all().last()]
+                folders = most_recent_saved.folders.all().last()
 
             if not folders:
                 folders = self.instance.user.folders.all()[:1]
@@ -575,7 +575,7 @@ class SaveDocumentForm(forms.ModelForm):
                     )[0]
                 ]
 
-        cleaned_data["folders"] = folders
+        cleaned_data["folders"] = list(folders)
         return cleaned_data
 
 

--- a/peachjam/signals.py
+++ b/peachjam/signals.py
@@ -14,6 +14,7 @@ from peachjam.models import (
     CoreDocument,
     DocumentContent,
     ExtractedCitation,
+    Folder,
     SavedDocument,
     SourceFile,
     UserFollowing,
@@ -202,3 +203,12 @@ def judgment_content_changed_generate_summary(sender, instance, **kwargs):
     )
     if should_generate:
         generate_judgment_summary(judgment.pk)
+
+
+@receiver(signals.pre_delete, sender=Folder)
+def delete_saved_document_if_no_folder(sender, instance, **kwargs):
+    saved_documents = instance.saved_documents.all()
+
+    for doc in saved_documents:
+        if doc.folders.count() == 1:
+            doc.delete()


### PR DESCRIPTION
Closes #2618 

The issue arises in cases where a document is saved to only one folder, and that folder is subsequently deleted; the saved document remains without a folder. If that document was the most recently created and the user wants to save a new document, the folder for the _most_recent_saved_ becomes [None], which triggers the error.

https://www.loom.com/share/49d5bc2c37ee443198a87630e56b2a07?sid=313cf54d-1775-411f-8935-ccd19fe973b9