### PR TITLE
use setproctitle to set gunicorn process to descriptive name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "python-magic>=0.4.25",
     "requests>=2.27.1",
     "sentry-sdk>=1.16.0,<=2.22",
+    "setproctitle",
     "whitenoise==5.3.0",
 ]
 


### PR DESCRIPTION
It looks like this when using `ps`:

```
gunicorn: worker [lawlibrary.wsgi:application]
```