### PR TITLE
show only latest expression in suggested documents

### DIFF
--- a/peachjam_ml/models.py
+++ b/peachjam_ml/models.py
@@ -9,7 +9,7 @@ from django.db.models import Avg, F
 from django.forms import model_to_dict
 from pgvector.django import HnswIndex, MaxInnerProduct, VectorField
 
-from peachjam.models import Work
+from peachjam.models import CoreDocument, Work
 from peachjam_ml.embeddings import TEXT_INJECTION_SEPARATOR, get_text_embedding_batch
 from peachjam_search.tasks import search_model_saved
 
@@ -212,6 +212,12 @@ class DocumentEmbedding(models.Model):
             )
             .order_by("-similarity")
         )[:top_k]
+        similar_docs = filter(
+            lambda doc: CoreDocument.objects.filter(pk=doc["document_id"])
+            .first()
+            .is_most_recent(),
+            similar_docs,
+        )
 
         # re-rank based on a weighted average of similarity and authority score, and keep the top 10
         similar_docs = sorted(


### PR DESCRIPTION
Closes #2542 

@actlikewill I'd have had to repeat the Coredocuments mapping for the folder view, so I chose to filter from the base function.

The before and after

<img width="1178" height="502" alt="Screenshot 2025-08-27 at 17 51 56" src="https://github.com/user-attachments/assets/378d28b1-892d-4132-8705-c8fb34a8395a" />

<img width="1143" height="509" alt="Screenshot 2025-08-27 at 17 51 24" src="https://github.com/user-attachments/assets/a2b25b3c-18fb-4118-b4d2-a65d5ec1b446" />
