### PR TITLE
remove open-law-africa top bar

### DIFF
--- a/seylii/templates/peachjam/_header.html
+++ b/seylii/templates/peachjam/_header.html
@@ -1,8 +1,5 @@
 {% extends 'peachjam/_header.html' %}
 {% load static i18n %}
-{% block top-bar %}
-  {% include 'peachjam/_open_law_africa.html' %}
-{% endblock %}
 {% block nav-items %}
   <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'judgments' %}active{% endif %}"

--- a/tanzlii/templates/peachjam/_header.html
+++ b/tanzlii/templates/peachjam/_header.html
@@ -1,8 +1,5 @@
 {% extends 'peachjam/_header.html' %}
 {% load static i18n %}
-{% block top-bar %}
-  {% include "peachjam/_open_law_africa.html" %}
-{% endblock %}
 {% block nav-items %}
   <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'judgments' %}active{% endif %}"

--- a/ulii/templates/peachjam/_header.html
+++ b/ulii/templates/peachjam/_header.html
@@ -1,8 +1,5 @@
 {% extends 'peachjam/_header.html' %}
 {% load static i18n %}
-{% block top-bar %}
-  {% include 'peachjam/_open_law_africa.html' %}
-{% endblock %}
 {% block nav-items %}
   <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'judgments' %}active{% endif %}"


### PR DESCRIPTION
this is not a good use of this space and it dominates on mobile; the footer logo is sufficient