### PR TITLE
fix bug that prevented webhooks from authenticating

### DIFF
--- a/peachjam/adapters/indigo.py
+++ b/peachjam/adapters/indigo.py
@@ -757,7 +757,7 @@ class IndigoAdapter(RequestsAdapter):
 
         # check perms
         if not CoreDocumentPermission().has_permission(request, None):
-            logger.warning("Unauthorized webhook request")
+            logger.warning(f"Unauthorized webhook request from {request.user}")
             return
 
         logger.info(f"Handling webhook {data}")

--- a/peachjam_api/views.py
+++ b/peachjam_api/views.py
@@ -65,7 +65,6 @@ class CitationLinkViewSet(viewsets.ModelViewSet):
 
 
 class IngestorWebhookView(APIView):
-    authentication_classes = []
     permission_classes = []
 
     def post(self, request, ingestor_id):


### PR DESCRIPTION
Otherwise no authentication takes place at all and all requests fail. Token authentication (the default) ignores unauthenticated requests which is what we need for certain secret-based webhooks