### PR TITLE
tell robots not to index historical versions

### DIFF
--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -3,7 +3,7 @@
 {% block title %}{{ document.title }}{% endblock %}
 {% block head-meta %}
   {{ block.super }}
-  {% if not document.allow_robots %}<meta name="robots" content="noindex" />{% endif %}
+  {% if not document.allow_robots or not document.is_most_recent %}<meta name="robots" content="noindex" />{% endif %}
   <meta property="og:title" content="{{ document.title }}" />
   <meta property="og:type" content="article" />
   <meta property="og:image"


### PR DESCRIPTION
this blows up the number of pages crawlers index, and makes our sites look like they have lots of duplicate content