### PR TITLE
don't record 404s as errors when fetching PDFs

### DIFF
--- a/peachjam/js/components/DocumentContent/pdf-renderer.ts
+++ b/peachjam/js/components/DocumentContent/pdf-renderer.ts
@@ -312,7 +312,7 @@ class PdfRenderer {
       err.innerText = message;
     }
 
-    if (response) {
+    if (response && response.status !== 404) {
       throw new Error(`Error fetching PDF: ${message}`);
     }
   }


### PR DESCRIPTION
this is just noise otherwise