### PR TITLE
no need to vary search on cookie

### DIFF
--- a/peachjam/views/accounts.py
+++ b/peachjam/views/accounts.py
@@ -65,6 +65,7 @@ class GetAccountView(View):
                 "id": self.request.user.id,
                 "email": self.request.user.email,
                 "name": user_display(self.request.user),
+                "is_staff": self.request.user.is_staff,
             }
             response = JsonResponse(user_details)
             return response

--- a/peachjam_search/forms.py
+++ b/peachjam_search/forms.py
@@ -2,6 +2,7 @@ import datetime
 
 from django import forms
 
+from peachjam.resources import DownloadDocumentsResource
 from peachjam_search.models import SavedSearch, SearchFeedback
 
 
@@ -17,6 +18,10 @@ class SearchForm(forms.Form):
         required=False, choices=[(x, x) for x in ["text", "semantic", "hybrid"]]
     )
     facets = forms.BooleanField(required=False)
+    format = forms.ChoiceField(
+        required=False,
+        choices=[(x, x) for x in DownloadDocumentsResource.download_formats.keys()],
+    )
 
     def clean_ordering(self):
         if self.cleaned_data["ordering"] == "-score":

--- a/peachjam_search/models.py
+++ b/peachjam_search/models.py
@@ -51,7 +51,6 @@ class SearchTrace(models.Model):
         permissions = [
             ("can_debug_search", "Can debug search"),
             ("can_download_search", "Can download search results"),
-            ("can_semantic_search", "Can use semantic search"),
         ]
 
     @classmethod

--- a/peachjam_search/templates/peachjam_search/_download_403.html
+++ b/peachjam_search/templates/peachjam_search/_download_403.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% url 'account_signup' as signup %}
+{% url 'account_login' as login %}
+{% blocktrans trimmed with signup_url=signup login_url=login next=request.get_full_path|urlencode %}
+  <a href="{{ signup_url }}?next={{ next }}">Sign up</a> or <a href="{{ login_url }}?next={{ next }}">log in</a> to download search results.
+{% endblocktrans %}

--- a/peachjam_search/tests/test_views.py
+++ b/peachjam_search/tests/test_views.py
@@ -81,4 +81,4 @@ class SearchViewsTest(TestCase):
 
         response = self.client.get(reverse("search:search_documents") + "?search=test")
         self.assertEqual(response.status_code, 200)
-        self.assertIn("public", response.headers["Cache-Control"])
+        self.assertIn("max-age=900", response.headers["Cache-Control"])

--- a/peachjam_search/tests/test_views.py
+++ b/peachjam_search/tests/test_views.py
@@ -1,0 +1,84 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from elasticsearch_dsl.response import Response
+
+
+class SearchViewsTest(TestCase):
+    fixtures = ["tests/countries", "tests/users"]
+
+    def setUp(self):
+        self.user = User.objects.get(username="admin@example.com")
+
+    @patch("peachjam_search.engine.RetrieverSearch.execute")
+    def test_explain(self, mock_search):
+        mock_search.return_value = Response(
+            mock_search,
+            {
+                "_shards": {
+                    "failed": 0,
+                },
+                "hits": {
+                    "total": {
+                        "value": 0,
+                    },
+                    "hits": [],
+                },
+            },
+        )
+
+        response = self.client.get(reverse("search:search_explain") + "?search=test")
+        self.assertEqual(response.status_code, 403)
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("search:search_explain") + "?search=test")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("no-cache", response.headers["Cache-Control"])
+
+    @patch("peachjam_search.engine.RetrieverSearch.execute")
+    def test_download(self, mock_search):
+        mock_search.return_value = Response(
+            mock_search,
+            {
+                "_shards": {
+                    "failed": 0,
+                },
+                "hits": {
+                    "total": {
+                        "value": 0,
+                    },
+                    "hits": [],
+                },
+            },
+        )
+
+        response = self.client.get(reverse("search:search_download") + "?search=test")
+        self.assertEqual(response.status_code, 403)
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("search:search_download") + "?search=test")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("no-cache", response.headers["Cache-Control"])
+
+    @patch("peachjam_search.engine.RetrieverSearch.execute")
+    def test_search(self, mock_search):
+        mock_search.return_value = Response(
+            mock_search,
+            {
+                "_shards": {
+                    "failed": 0,
+                },
+                "hits": {
+                    "total": {
+                        "value": 0,
+                    },
+                    "hits": [],
+                },
+            },
+        )
+
+        response = self.client.get(reverse("search:search_documents") + "?search=test")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("public", response.headers["Cache-Control"])

--- a/peachjam_search/urls.py
+++ b/peachjam_search/urls.py
@@ -9,9 +9,19 @@ router.register("click", views.SearchClickViewSet, basename="search_click")
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    path("api/documents/", views.DocumentSearchView.as_view()),
-    path("api/documents/suggest/", views.DocumentSearchView.as_view(action="suggest")),
+    path("api/documents/", views.DocumentSearchView.as_view(), name="search_documents"),
+    path(
+        "api/documents/download",
+        views.DocumentSearchView.as_view(action="download"),
+        name="search_download",
+    ),
+    path(
+        "api/documents/explain",
+        views.DocumentSearchView.as_view(action="explain"),
+        name="search_explain",
+    ),
     path("api/documents/facets", views.DocumentSearchView.as_view(action="facets")),
+    path("api/documents/suggest/", views.DocumentSearchView.as_view(action="suggest")),
     path("api/link-traces", views.LinkTracesView.as_view()),
     path("api/", include(router.urls)),
     path(

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -16,12 +16,12 @@ from django.http.response import (
 )
 from django.shortcuts import redirect, reverse
 from django.template.loader import render_to_string
+from django.utils.cache import add_never_cache_headers
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django.views import View
-from django.views.decorators.cache import cache_page
-from django.views.decorators.vary import vary_on_cookie
+from django.views.decorators.cache import cache_page, never_cache
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -30,6 +30,7 @@ from django.views.generic import (
     TemplateView,
     UpdateView,
 )
+from django_htmx.http import HttpResponseClientRedirect
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import GenericViewSet
@@ -76,26 +77,34 @@ class DocumentSearchView(TemplateView):
     action = "search"
     template_name = "peachjam_search/search_request_debug.html"
     config_version = "2025-07-28"
+    user_can_debug = False
+    # used by the /explain endpoint
+    use_explain = False
 
     def get(self, request, *args, **kwargs):
+        self.user_can_debug = self.request.user.has_perm("peachjam_search.debug_search")
         return getattr(self, self.action)(request, *args, **kwargs)
 
-    @vary_on_cookie
-    @method_decorator(cache_page(CACHE_SECS))
-    def search(self, request, *args, **kwargs):
+    def prepare(self, request, facets=False):
         form = SearchForm(request.GET)
         if not form.is_valid():
-            return JsonResponse({"error": form.errors}, status=400)
+            return JsonResponse({"error": form.errors}, status=400), None, None
+
+        if facets:
+            form.cleaned_data["facets"] = True
 
         engine = self.make_search_engine(form)
-
         if not engine.query and not engine.field_queries:
             # no search term
-            return JsonResponse({"error": "No search term"}, status=400)
+            return JsonResponse({"error": "No search term"}, status=400), None, None
 
-        # download as xlsx
-        if self.request.GET.get("format"):
-            return self.download_results(engine, self.request.GET["format"])
+        return None, form, engine
+
+    @method_decorator(cache_page(CACHE_SECS))
+    def search(self, request, *args, **kwargs):
+        response, form, engine = self.prepare(request)
+        if response:
+            return response
 
         es_response = engine.execute()
         trace = self.save_search_trace(engine, es_response.hits.total.value)
@@ -113,23 +122,25 @@ class DocumentSearchView(TemplateView):
                 {
                     "request": request,
                     "hits": hits,
-                    "can_debug": self.request.user.has_perm(
-                        "peachjam_search.debug_search"
-                    ),
+                    "can_debug": self.use_explain,
                     "show_jurisdiction": settings.PEACHJAM[
                         "SEARCH_JURISDICTION_FILTER"
                     ],
                 },
             ),
             "trace_id": str(trace.id) if trace else None,
-            "can_download": self.request.user.has_perm(
-                "peachjam_search.download_search"
-            ),
-            "can_semantic": settings.PEACHJAM["SEARCH_SEMANTIC"]
-            and self.request.user.has_perm("peachjam_search.semantic_search"),
+            "can_semantic": settings.PEACHJAM["SEARCH_SEMANTIC"],
         }
 
         return self.render(response)
+
+    @method_decorator(never_cache)
+    def explain(self, request, *args, **kwargs):
+        if not self.user_can_debug:
+            return HttpResponseForbidden()
+
+        self.use_explain = True
+        return self.search(request, *args, **kwargs)
 
     @method_decorator(cache_page(SUGGESTIONS_CACHE_SECS))
     def suggest(self, request, *args, **kwargs):
@@ -143,19 +154,12 @@ class DocumentSearchView(TemplateView):
         response = {"suggestions": suggestions}
         return self.render(response)
 
-    @vary_on_cookie
     @method_decorator(cache_page(CACHE_SECS))
     def facets(self, request, *args, **kwargs):
         """Only return facets from search."""
-        form = SearchForm(request.GET)
-        if not form.is_valid():
-            return JsonResponse({"error": form.errors}, status=400)
-
-        form.cleaned_data["facets"] = True
-        engine = self.make_search_engine(form)
-        if not engine.query and not engine.field_queries:
-            # no search term
-            return JsonResponse({"error": "No search term"}, status=400)
+        response, form, engine = self.prepare(request, facets=True)
+        if response:
+            return response
 
         engine.page_size = 0
         es_response = engine.execute()
@@ -167,25 +171,70 @@ class DocumentSearchView(TemplateView):
             }
         )
 
+    @method_decorator(never_cache)
+    def download(self, request, *args, **kwargs):
+        """Download. Doesn't allow caching to prevent permission spillage."""
+        response, form, engine = self.prepare(request)
+        if response:
+            return response
+
+        if True or not request.user.has_perm("peachjam_search.download_search"):
+            if request.htmx:
+                # this is the initial request to download, show a friendly permission-denied box
+                self.template_name = "peachjam_search/_download_403.html"
+                return self.render_to_response({})
+            return HttpResponseForbidden()
+
+        if request.htmx:
+            # the download is allowed, do a full redirect to start it
+            return HttpResponseClientRedirect(request.get_full_path())
+
+        # only need the ids
+        engine.source = ["_id"]
+        engine.explain = False
+        # TODO: first 1000 hits
+        engine.page = 1
+        engine.page_size = 1000
+        response = engine.execute()
+        pks = [int(hit.meta.id) for hit in response.hits]
+
+        dataset = DownloadDocumentsResource().export(
+            DownloadDocumentsResource.get_objects_for_download(pks)
+        )
+        fmt = DownloadDocumentsResource.download_formats[
+            form.cleaned_data.get("format") or "xlsx"
+        ]()
+        data = fmt.export_data(dataset)
+
+        response = HttpResponse(data, content_type=fmt.get_content_type())
+        # prevent caching, so that we can enforce download permissions
+        add_never_cache_headers(response)
+
+        fname = "search-results." + fmt.get_extension()
+        response["Content-Disposition"] = f'attachment; filename="{fname}"'
+
+        return response
+
     def make_search_engine(self, form):
         engine = SearchEngine()
         form.configure_engine(engine)
 
-        engine.explain = self.request.user.has_perm("peachjam_search.debug_search")
-        if settings.PEACHJAM["SEARCH_SEMANTIC"] and self.request.user.has_perm(
-            "peachjam_search.semantic_search"
-        ):
+        engine.explain = self.use_explain
+        if settings.PEACHJAM["SEARCH_SEMANTIC"]:
             engine.mode = form.cleaned_data.get("mode") or engine.mode
 
         return engine
 
     def render(self, response):
-        if "html" in self.request.GET:
+        if "html" in self.request.GET and self.user_can_debug:
             # useful for debugging and showing django debug panel details
-            return self.render_to_response(
+            response = self.render_to_response(
                 {"response_json": json.dumps(response, indent=2)}
             )
-        return JsonResponse(response)
+        else:
+            response = JsonResponse(response)
+
+        return response
 
     def save_search_trace(self, engine, n_results):
         filters_string = "; ".join(f"{k}={v}" for k, v in engine.filters.items())
@@ -211,33 +260,6 @@ class DocumentSearchView(TemplateView):
             ip_address=self.request.headers.get("x-forwarded-for"),
             user_agent=self.request.headers.get("user-agent"),
         )
-
-    def download_results(self, engine, format):
-        if not self.request.user.has_perm("peachjam_search.download_search"):
-            return HttpResponseForbidden()
-
-        if format not in DownloadDocumentsResource.download_formats:
-            return HttpResponseBadRequest("Invalid format")
-
-        # only need the ids
-        engine.source = ["_id"]
-        engine.explain = False
-        # TODO: first 1000 hits
-        engine.page = 1
-        engine.page_size = 1000
-        response = engine.execute()
-        pks = [int(hit.meta.id) for hit in response.hits]
-
-        dataset = DownloadDocumentsResource().export(
-            DownloadDocumentsResource.get_objects_for_download(pks)
-        )
-        fmt = DownloadDocumentsResource.download_formats[format]()
-        data = fmt.export_data(dataset)
-
-        response = HttpResponse(data, content_type=fmt.get_content_type())
-        fname = "search-results." + fmt.get_extension()
-        response["Content-Disposition"] = f'attachment; filename="{fname}"'
-        return response
 
 
 class SearchClickViewSet(CreateModelMixin, GenericViewSet):

--- a/peachjam_search/views.py
+++ b/peachjam_search/views.py
@@ -178,7 +178,7 @@ class DocumentSearchView(TemplateView):
         if response:
             return response
 
-        if True or not request.user.has_perm("peachjam_search.download_search"):
+        if not request.user.has_perm("peachjam_search.download_search"):
             if request.htmx:
                 # this is the initial request to download, show a friendly permission-denied box
                 self.template_name = "peachjam_search/_download_403.html"


### PR DESCRIPTION
split authed vs non-authed search endpoints; all users get semantic search if enabled