### PR TITLE
Improve confirmation email text to include a clear call-to-action

### DIFF
--- a/peachjam/auth.py
+++ b/peachjam/auth.py
@@ -3,9 +3,11 @@ from allauth.account.utils import perform_login
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.auth.views import redirect_to_login
+from templated_email import send_templated_mail
 
 from peachjam.models import pj_settings
 from peachjam.signals import password_reset_started
@@ -31,7 +33,12 @@ class AccountAdapter(DefaultAccountAdapter):
                 user=user,
             )
 
-        super().send_mail(template_prefix, email, context)
+        send_templated_mail(
+            template_name=template_prefix,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[email],
+            context=context,
+        )
 
 
 class SocialAccountAdapter(DefaultSocialAccountAdapter):

--- a/peachjam/templates/peachjam/emails/account/email/email_confirmation_signup.email
+++ b/peachjam/templates/peachjam/emails/account/email/email_confirmation_signup.email
@@ -1,0 +1,16 @@
+{% block subject %}{{ APP_NAME }} Account Confirmation{% endblock %}
+{% block html %}
+    <p>Hello,</p>
+
+    <p>
+      To activate your {{ APP_NAME }} account, please confirm your email address.
+    </p>
+
+    <div style="text-align: center">
+      <a href="{{ activate_url }}" style="text-decoration: none">
+        <button style="height: 50px; background-color: #248159; color: #fff; font-size: 1rem; border-radius: 0.25rem; border: none; padding: 0 1rem">Confirm your email address</button>
+      </a>
+    </div>
+
+    <p>The {{ APP_NAME }} team.</p>
+{% endblock %}


### PR DESCRIPTION
Closes #2654 
<img width="1307" height="284" alt="Screenshot 2025-10-01 at 18 39 34" src="https://github.com/user-attachments/assets/b10a1112-7d40-42d1-9c33-253b4ca48059" />
