### PR TITLE
Fix missing provision anchor in incoming citation detail view

### DIFF
--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -580,6 +580,7 @@ class DocumentProvisionCitationView(
                 self.provision_eid
             ),
             "provision_html": self.document.get_provision_by_eid(self.provision_eid),
+            "provision_eid": self.provision_eid,
         }
 
     def get_template_names(self):


### PR DESCRIPTION
## Summary
- ensure the provision citations view adds the provision EID to its context so the heading link anchors correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3fd54764c8329aaec02bdc474cdb7