### PR TITLE
Include language-prefixed robots.txt disallow entries

### DIFF
--- a/peachjam/views/robots.py
+++ b/peachjam/views/robots.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.views.generic import TemplateView
 
 from peachjam.models import CoreDocument, PeachJamSettings
@@ -10,13 +11,20 @@ class RobotsView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        disallowed_content = [
-            f"Disallow: {frbr_uri}/"
-            for frbr_uri in CoreDocument.objects.filter(allow_robots=False)
+        language_prefixes = [""]
+        if len(settings.LANGUAGES) > 1:
+            language_prefixes.extend(f"/{code}" for code, _ in settings.LANGUAGES)
+
+        disallowed_content = []
+        for frbr_uri in (
+            CoreDocument.objects.filter(allow_robots=False)
             .values_list("work_frbr_uri", flat=True)
             .order_by()
             .distinct()
-        ]
+        ):
+            normalized_uri = frbr_uri.rstrip("/")
+            for prefix in language_prefixes:
+                disallowed_content.append(f"Disallow: {prefix}{normalized_uri}/")
         context["disallowed_content"] = "\n".join(disallowed_content)
         context["extra_content"] = PeachJamSettings.load().robots_txt or ""
 


### PR DESCRIPTION
## Summary
- update the robots.txt view to emit disallow rules for each site language prefix when documents block indexing
- add a regression test that ensures the generated robots.txt includes language-prefixed disallow entries

## Testing
- python manage.py test peachjam.tests.test_views.PeachjamViewsTest.test_robots_txt_includes_language_prefixes *(fails: missing psycopg2 dependency in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f89143e714832faf0a4b615a0b5ef4