### PR TITLE
Restrict import-export formats to CSV and XLSX

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -21,9 +21,9 @@ import sentry_sdk
 from django.contrib.messages import constants as messages
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
+from import_export.formats import base_formats
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
-from import_export.formats import base_formats
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- limit django-import-export to CSV and XLSX formats for import and export operations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6902281324cc83299b4f0b71e1e7321a