### PR TITLE
fix conflicting updates race condition

### DIFF
--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -40,10 +40,7 @@ from peachjam.frbr_uri import (
 from peachjam.helpers import pdfjs_to_text
 from peachjam.models.attachments import Image
 from peachjam.models.citations import CitationLink, ExtractedCitation
-from peachjam.models.enrichments import (
-    ProvisionCitation,
-    refresh_provision_citation_counts,
-)
+from peachjam.models.enrichments import ProvisionCitation, ProvisionCitationCount
 from peachjam.models.settings import pj_settings
 from peachjam.pipelines import DOC_MIMETYPES, word_pipeline
 from peachjam.xmlutils import parse_html_str
@@ -761,7 +758,7 @@ class CoreDocument(PolymorphicModel):
         )
         affected_work_ids = removed_work_ids | current_work_ids
         if affected_work_ids:
-            refresh_provision_citation_counts(affected_work_ids)
+            ProvisionCitationCount.refresh_for_works(affected_work_ids)
 
     def delete_provision_citations(self):
         """Delete existing provision citations for this document."""

--- a/peachjam/models/enrichments.py
+++ b/peachjam/models/enrichments.py
@@ -162,40 +162,41 @@ class ProvisionCitationCount(models.Model):
             )
         ]
 
+    @classmethod
+    def refresh_for_works(cls, work_ids):
+        """Recompute provision citation counts for the supplied works using raw SQL."""
 
-def refresh_provision_citation_counts(work_ids):
-    """Recompute provision citation counts for the supplied works using raw SQL."""
+        work_ids = {w for w in work_ids if w is not None}
+        if not work_ids:
+            return
 
-    work_ids = {w for w in work_ids if w is not None}
-    if not work_ids:
-        return
+        work_ids = list(work_ids)
 
-    work_ids = list(work_ids)
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "DELETE FROM peachjam_provisioncitationcount WHERE work_id = ANY(%s)",
+                    [work_ids],
+                )
 
-    with transaction.atomic():
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "DELETE FROM peachjam_provisioncitationcount WHERE work_id = ANY(%s)",
-                [work_ids],
-            )
-
-            cursor.execute(
-                """
-                INSERT INTO peachjam_provisioncitationcount (work_id, provision_eid, count)
-                SELECT
-                    pe.work_id,
-                    pe.provision_eid,
-                    COUNT(DISTINCT pc.citing_document_id) AS citation_count
-                FROM peachjam_provisionenrichment pe
-                INNER JOIN peachjam_provisioncitation pc ON pc.provisionenrichment_ptr_id = pe.id
-                WHERE
-                    pe.enrichment_type = 'provision_citation' AND pe.provision_eid IS NOT NULL AND pe.work_id = ANY(%s)
-                GROUP BY pe.work_id, pe.provision_eid
-                ON CONFLICT (work_id, provision_eid)
-                DO UPDATE SET count = EXCLUDED.count
-                """,
-                [work_ids],
-            )
+                cursor.execute(
+                    """
+                    INSERT INTO peachjam_provisioncitationcount (work_id, provision_eid, count)
+                    SELECT
+                        pe.work_id,
+                        pe.provision_eid,
+                        COUNT(DISTINCT pc.citing_document_id) AS citation_count
+                    FROM peachjam_provisionenrichment pe
+                    INNER JOIN peachjam_provisioncitation pc ON pc.provisionenrichment_ptr_id = pe.id
+                    WHERE
+                        pe.enrichment_type = 'provision_citation'
+                        AND pe.provision_eid IS NOT NULL AND pe.work_id = ANY(%s)
+                    GROUP BY pe.work_id, pe.provision_eid
+                    ON CONFLICT (work_id, provision_eid)
+                    DO UPDATE SET count = EXCLUDED.count
+                    """,
+                    [work_ids],
+                )
 
 
 place_code_validator = RegexValidator(


### PR DESCRIPTION
1. run in a transaction
2. if there is an existing entry, then update the count rather than conflicting

Codex says:

> ON CONFLICT … DO UPDATE SET count = EXCLUDED.count tells Postgres how to resolve insert collisions. When another transaction already inserted the same (work_id, provision_eid) row,
  the failed insert produces a virtual row alias named EXCLUDED. That alias carries the values we were trying to insert. Setting count = EXCLUDED.count means “keep the row but update its
  count column to the freshly computed value.” This way the refresh stays idempotent: we either insert the new count or overwrite the existing row with the same number, so no duplicate key
  exception.