### PR TITLE
extra whitespace around flynote/blurb in search and listings

### DIFF
--- a/peachjam/templates/peachjam/_document_table_row.html
+++ b/peachjam/templates/peachjam/_document_table_row.html
@@ -37,8 +37,8 @@
         {% include 'peachjam/document/_document_treatments.html' with treatments=document.treatments.all %}
       {% endif %}
       {% if document.doc_type == "judgment" %}
-        {% if document.blurb %}<div>{{ document.blurb }}</div>{% endif %}
-        {% if document.flynote %}<div class="fst-italic">{{ document.flynote|safe }}</div>{% endif %}
+        {% if document.blurb %}<div class="my-2">{{ document.blurb }}</div>{% endif %}
+        {% if document.flynote %}<div class="fst-italic my-2">{{ document.flynote|safe }}</div>{% endif %}
       {% elif document.listing_taxonomies %}
         <div class="d-none d-md-block ms-3">
           {% include 'peachjam/_document_taxonomies.html' with taxonomies=document.listing_taxonomies %}

--- a/peachjam_search/templates/peachjam_search/_search_hit.html
+++ b/peachjam_search/templates/peachjam_search/_search_hit.html
@@ -70,8 +70,8 @@
         </div>
         {% if hit.document.matter_type %}<div>{{ hit.document.matter_type }}</div>{% endif %}
         {% if hit.document.doc_type == "judgment" %}
-          {% if hit.document.blurb %}<div class="pt-2">{{ hit.document.blurb }}</div>{% endif %}
-          {% if hit.document.flynote %}<div class="fst-italic pb-2">{{ hit.document.flynote|safe }}</div>{% endif %}
+          {% if hit.document.blurb %}<div class="my-2">{{ hit.document.blurb }}</div>{% endif %}
+          {% if hit.document.flynote %}<div class="fst-italic my-2">{{ hit.document.flynote|safe }}</div>{% endif %}
         {% elif hit.document.listing_taxonomies %}
           {% include 'peachjam/_document_taxonomies.html' with taxonomies=hit.document.listing_taxonomies %}
         {% endif %}


### PR DESCRIPTION
this makes it a bit easier to differentiate between them

top item has space, bottom item doesn't:

<img width="864" height="485" alt="image" src="https://github.com/user-attachments/assets/b6d3f566-1ee5-4ba0-bac2-0cf192d89234" />
