### PR TITLE
use logo colours for civlii, better contrast

### DIFF
--- a/civlii/static/stylesheets/_variables.scss
+++ b/civlii/static/stylesheets/_variables.scss
@@ -1,3 +1,3 @@
-$primary: #EAA451;
-$visited-link: #915611;
+$primary: #ee7203;
+$visited-link: #ac5102;
 $secondary: #181818;


### PR DESCRIPTION
## before
<img width="1173" height="584" alt="CNDJ 2025-11-21 09-15-05" src="https://github.com/user-attachments/assets/6af49319-8940-4594-b814-8698ed83b2f3" />



## after

<img width="1182" height="580" alt="CNDJ 2025-11-21 09-14-28" src="https://github.com/user-attachments/assets/954d42ad-663b-4809-bf54-dde69b16ec75" />
