### PR TITLE
import taxonomy tree from indigo

### DIFF
--- a/peachjam/tests/test_adapters.py
+++ b/peachjam/tests/test_adapters.py
@@ -1,9 +1,12 @@
 from django.test import TestCase
 
 from peachjam.adapters import IndigoAdapter
+from peachjam.models import Taxonomy
 
 
 class IndigoAdapterTest(TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.adapter = IndigoAdapter(
             None,
@@ -68,4 +71,166 @@ class IndigoAdapterTest(TestCase):
         self.assertTrue(self.adapter.is_responsible_for("/akn/za/act/by-law/2009/1"))
         self.assertTrue(
             self.adapter.is_responsible_for("/akn/za/act/by-law/bar/1999/1")
+        )
+
+    def test_import_taxonomy_tree(self):
+        self.adapter.taxonomy_topic_root = "src1:dest1 src2:dest2"
+
+        src_tree = [
+            {
+                "name": "src1",
+                "slug": "src1",
+                "children": [
+                    {
+                        "name": "child-1",
+                        "slug": "src1-child-1",
+                        "children": [],
+                    },
+                    {
+                        "name": "child-2",
+                        "slug": "src1-child-2",
+                        "children": [],
+                    },
+                ],
+            },
+            {
+                "name": "src2",
+                "slug": "src2",
+                "children": [
+                    {
+                        "name": "child-a",
+                        "slug": "src2-child-a",
+                        "children": [],
+                    },
+                    {
+                        "name": "child-b",
+                        "slug": "src2-child-b",
+                        "children": [],
+                    },
+                ],
+            },
+        ]
+        self.adapter.get_taxonomy_tree = lambda: src_tree
+
+        # pre-populate dest1 and dest2 locally
+        Taxonomy.load_bulk(
+            [
+                {
+                    "data": {
+                        "name": "dest1",
+                        "slug": "dest1",
+                    },
+                    "children": [],
+                },
+                {
+                    "data": {
+                        "name": "dest2",
+                        "slug": "dest2",
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "name": "child-a",
+                                "slug": "dest2-child-a",
+                            },
+                        },
+                        {
+                            # this must be deleted
+                            "data": {
+                                "name": "child-z",
+                                "slug": "dest2-child-z",
+                            }
+                        },
+                    ],
+                },
+            ]
+        )
+
+        # dest1 will be empty locally, and dest2 will have some topics and some which must be deleted
+        src_mapping, tree_mapping = self.adapter.import_taxonomy_tree()
+
+        self.assertEqual(
+            {
+                "src1": "dest1",
+                "src2": "dest2",
+            },
+            src_mapping,
+        )
+
+        self.assertEqual(
+            {
+                "src1-child-1": Taxonomy.objects.get(slug="dest1-child-1"),
+                "src1-child-2": Taxonomy.objects.get(slug="dest1-child-2"),
+                "src2-child-a": Taxonomy.objects.get(slug="dest2-child-a"),
+                "src2-child-b": Taxonomy.objects.get(slug="dest2-child-b"),
+            },
+            tree_mapping,
+        )
+
+        def simplify(entries):
+            # keep only necessary data fields for comparison
+            for entry in entries:
+                entry["data"] = {
+                    k: v for k, v in entry["data"].items() if k in ["name", "slug"]
+                }
+                simplify(entry.get("children", []))
+
+        local_tree = Taxonomy.dump_bulk(
+            parent=Taxonomy.objects.get(slug="dest1"), keep_ids=False
+        )
+        simplify(local_tree)
+        self.assertEqual(
+            [
+                {
+                    "data": {
+                        "name": "dest1",
+                        "slug": "dest1",
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "name": "child-1",
+                                "slug": "dest1-child-1",
+                            }
+                        },
+                        {
+                            "data": {
+                                "name": "child-2",
+                                "slug": "dest1-child-2",
+                            }
+                        },
+                    ],
+                }
+            ],
+            local_tree,
+        )
+
+        local_tree = Taxonomy.dump_bulk(
+            parent=Taxonomy.objects.get(slug="dest2"), keep_ids=False
+        )
+        simplify(local_tree)
+        self.assertEqual(
+            [
+                {
+                    "data": {
+                        "name": "dest2",
+                        "slug": "dest2",
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "name": "child-a",
+                                "slug": "dest2-child-a",
+                            }
+                        },
+                        {
+                            "data": {
+                                "name": "child-b",
+                                "slug": "dest2-child-b",
+                            }
+                        },
+                    ],
+                }
+            ],
+            local_tree,
         )


### PR DESCRIPTION
This changes the indigo adapter to import the specified taxonomy tree from Indigo into the local peachjam service, under a different root node if necessary.

This means that Indigo can be treated as authoritative for that taxonomy tree. Changes (including deletions) will be propagated to peachjam.

This will make it possible to import CIV codes under the Code tree already in Indigo, into peachjam.