### PR TITLE
alert cutoff date

### DIFF
--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -5,7 +5,6 @@ import shutil
 import tempfile
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import date
 
 from cobalt.akn import StructuredDocument, datestring
 from cobalt.uri import FrbrUri
@@ -281,33 +280,6 @@ class Work(models.Model):
     def save(self, *args, **kwargs):
         self.explode_frbr_uri()
         super().save(*args, **kwargs)
-
-    @property
-    def parsed_date(self):
-        """
-        Parse frbr_uri_date into a real date.
-        Handles:
-        - YYYY-MM-DD
-        - YYYY
-        Returns None if unparsable.
-        """
-        if not self.frbr_uri_date:
-            return None
-
-        s = self.frbr_uri_date.strip()
-
-        # Full ISO format YYYY-MM-DD
-        if len(s) == 10 and "-" in s:
-            try:
-                return date.fromisoformat(s)
-            except ValueError:
-                return None
-
-        # Year-only YYYY
-        if len(s) == 4 and s.isdigit():
-            return date(int(s), 1, 1)
-
-        return None
 
     def explode_frbr_uri(self):
         frbr_uri = FrbrUri.parse(self.frbr_uri)

--- a/peachjam/models/user_following.py
+++ b/peachjam/models/user_following.py
@@ -303,7 +303,7 @@ class UserFollowing(models.Model):
         hits = self.documents_for_followed_search()
 
         # avoid alerts for documents older than cutoff
-        hits = [h for h in hits if h.document.date >= self.cutoff_date]
+        hits = [h for h in hits if h.document.date > self.cutoff_date]
 
         if self.last_alerted_at:
             hits = [h for h in hits if h.document.created_at > self.last_alerted_at][
@@ -324,10 +324,11 @@ class UserFollowing(models.Model):
         # check that we are passing a citation to the saved document
         assert citation.target_work == self.saved_document.work
 
-        assert citation.target_work.parsed_date
-
         # avoid alerts for citations from documents older than cutoff
-        if citation.citing_work.parsed_date < self.cutoff_date:
+        if (
+            citation.citing_work.documents.latest_expression().first().date
+            < self.cutoff_date
+        ):
             log.info(
                 "Citation from work %s is older than cutoff date %s for user %s",
                 citation.citing_work,


### PR DESCRIPTION
this adds a cutoff date for alerts. 
- adds a parsed date to the work model. The work model uses frbr_uri_date as a string so we need a way to convert that into a date, taking into account different styles of dates that can be present
- sets the default cutoff to one year.
- this check is enforced for all types of alerts: new documents for follows, search hits and new citations 