### PR TITLE
handle glossary permissions

### DIFF
--- a/peachjam/templates/peachjam/glossary/glossary.html
+++ b/peachjam/templates/peachjam/glossary/glossary.html
@@ -1,7 +1,7 @@
 {% extends 'peachjam/layouts/main.html' %}
 {% load i18n %}
 {% block title %}
-  {% trans "Glossary" %}
+  {% trans "Glossary" %} - {{ place.name }}
 {% endblock %}
 {% block page-content %}
   <div class="container">
@@ -19,8 +19,8 @@
   <div class="container">
     <h1>{% trans 'Glossary of defined terms' %}</h1>
     <div class="mb-5">
-      {% blocktrans trimmed %}
-        Terms that have been defined in legislation across {{ place_name }}.
+      {% blocktrans trimmed with name=place.name %}
+        Terms that have been defined in legislation across {{ name }}.
       {% endblocktrans %}
     </div>
   </div>

--- a/peachjam/views/legislation.py
+++ b/peachjam/views/legislation.py
@@ -576,12 +576,19 @@ class UnconstitutionalProvisionListView(SubscriptionRequiredMixin, LegislationLi
         return context
 
 
+@method_decorator(never_cache, name="dispatch")
 class PlaceGlossaryView(SubscriptionRequiredMixin, DetailView):
     model = Glossary
     slug_url_kwarg = "place_code"
     slug_field = "place_code"
     permission_required = "peachjam.view_glossary"
     template_name = "peachjam/glossary/glossary.html"
+
+    def get_subscription_required_context(self):
+        context = {"glossary": getattr(self, "object", self.get_object())}
+        country, locality = get_country_and_locality(context["glossary"].place_code)
+        context["place"] = locality or country
+        return context
 
     def get_subscription_required_template(self):
         return self.template_name
@@ -594,8 +601,7 @@ class PlaceGlossaryView(SubscriptionRequiredMixin, DetailView):
             letters.append("0")
         context["letters"] = letters
         context["first_letter"] = letters[0] if letters else None
-        country, locality = get_country_and_locality(self.object.place_code)
-        context["place_name"] = locality.name if locality else country.name
+        context.update(self.get_subscription_required_context())
         return context
 
 


### PR DESCRIPTION
This was throwing an error when the user didn't have perms. Fixes LII-3TE in sentry