### PR TITLE
Shortens the saved documents URL by shortening the params

### DIFF
--- a/peachjam/js/components/saved-documents.ts
+++ b/peachjam/js/components/saved-documents.ts
@@ -39,8 +39,11 @@ export function loadSavedDocuments (root: HTMLElement | null = null) {
   }
 
   if (ids.size) {
-    const query = Array.from(ids).map(id => `doc_id=${id}`).join('&');
+    const seachParams = new URLSearchParams();
+
+    seachParams.set('doc_ids', Array.from(ids).join(','));
+
     // @ts-ignore
-    htmxAjax('get', `${peachjam.config.urlLangPrefix}/user/saved-documents/fragments?${query}`);
+    htmxAjax('get', `${peachjam.config.urlLangPrefix}/user/saved-documents/fragments?${searchParams.toString()}`);
   }
 }

--- a/peachjam/tests/test_saved_documents.py
+++ b/peachjam/tests/test_saved_documents.py
@@ -31,7 +31,18 @@ class SavedDocumentViewsTest(TestCase):
             Permission.objects.get(codename="delete_saveddocument")
         )
         self.folder = Folder.objects.create(user=self.user, name="test")
+
         Subscription.get_or_create_active_for_user(self.user)
+
+        self.doc1 = SavedDocument.objects.create(
+            user=self.user, work=CoreDocument.objects.get(pk=5389).work
+        )
+        self.doc2 = SavedDocument.objects.create(
+            user=self.user, work=CoreDocument.objects.get(pk=3407).work
+        )
+
+        self.doc1.folders.set([self.folder])
+        self.doc2.folders.set([self.folder])
 
     def assert_no_recursive(self, response):
         self.assertNotContains(
@@ -54,7 +65,7 @@ class SavedDocumentViewsTest(TestCase):
             ).status_code,
         )
 
-    def test_fragments(self):
+    def test_cached_js_fragments(self):
         response = self.client.get(reverse("saved_document_fragments") + "?doc_id=4124")
         self.assertNotContains(response, "Saved")
         self.assertContains(response, "saved-document-star--4124")
@@ -65,6 +76,7 @@ class SavedDocumentViewsTest(TestCase):
         sd = SavedDocument.objects.create(
             user=self.user, work=CoreDocument.objects.get(pk=4124).work
         )
+
         sd.folders.set([self.folder])
 
         response = self.client.get(reverse("saved_document_fragments") + "?doc_id=4124")
@@ -72,6 +84,59 @@ class SavedDocumentViewsTest(TestCase):
         self.assertContains(response, "saved-document-star--4124")
         self.assertContains(response, "save-document-button--4124")
         self.assertContains(response, "saved-document-table-detail--4124")
+        self.assert_no_recursive(response)
+
+    def test_new_fragment_format_only(self):
+        saved_documents = [(self.doc1, 5389), (self.doc2, 3407)]
+
+        response = self.client.get(
+            reverse("saved_document_fragments") + "?doc_ids=5389,3407"
+        )
+        self.assertContains(response, "Saved")
+
+        for doc, id in saved_documents:
+            self.assertContains(response, f"saved-document-star--{id}")
+            self.assertContains(response, f"save-document-button--{id}")
+            self.assertContains(response, f"saved-document-table-detail--{id}")
+            self.assert_no_recursive(response)
+
+        self.assert_no_recursive(response)
+
+    def test_hybrid_fragment_format(self):
+        saved_documents = [(self.doc1, 5389), (self.doc2, 3407)]
+
+        response = self.client.get(
+            reverse("saved_document_fragments") + "?doc_id=5389&doc_ids=3407"
+        )
+        self.assertContains(response, "Saved")
+
+        for doc, id in saved_documents:
+            self.assertContains(response, f"saved-document-star--{id}")
+            self.assertContains(response, f"save-document-button--{id}")
+            self.assertContains(response, f"saved-document-table-detail--{id}")
+
+        self.assert_no_recursive(response)
+
+    def test_fragment_deduplication(self):
+        response = self.client.get(
+            reverse("saved_document_fragments")
+            + "?doc_ids=5389,3407,5389,3407, 5389, 3407, 5389,3407"
+        )
+
+        self.assertContains(response, "Saved")
+
+        self.assertContains(response, "saved-document-star--5389", 1)
+        self.assertContains(
+            response, "save-document-button save-document-button--5389", 1
+        )
+        self.assertContains(response, "saved-document-table-detail--5389", 1)
+
+        self.assertContains(response, "saved-document-star--3407", 1)
+        self.assertContains(
+            response, "save-document-button save-document-button--3407", 1
+        )
+        self.assertContains(response, "saved-document-table-detail--3407", 1)
+
         self.assert_no_recursive(response)
 
     def test_create(self):

--- a/peachjam/views/save_document.py
+++ b/peachjam/views/save_document.py
@@ -160,8 +160,18 @@ class SavedDocumentFragmentsView(AllowSavedDocumentMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        legacy_ids = self.request.GET.getlist("doc_id")
+
+        if "doc_ids" in self.request.GET:
+            csv_val = self.request.GET.get("doc_ids", "")
+
+            legacy_ids.extend(csv_val.split(","))
+
         try:
-            requested_ids = [int(pk) for pk in self.request.GET.getlist("doc_id")]
+            requested_ids = [
+                int(pk)
+                for pk in set(pk.strip() for pk in legacy_ids if pk and pk.strip())
+            ]
         except ValueError:
             requested_ids = []
 


### PR DESCRIPTION
Shortens the query parameters for the user/saved-documents URL from doc_id=<Id1>&doc_id=<Id2> to doc_ids=1,2