### PR TITLE
Add tests for relationship timeline events and emails

### DIFF
--- a/peachjam/tests/test_timeline.py
+++ b/peachjam/tests/test_timeline.py
@@ -152,34 +152,28 @@ class TimelineRelationshipTests(TestCase):
         self.saved_followed = SavedDocument.objects.create(
             user=self.user, work=self.followed_work
         )
-        self.follow_followed = UserFollowing.objects.create(
+        self.follow_followed = UserFollowing.objects.get(
             user=self.user, saved_document=self.saved_followed
         )
 
         self.saved_overturned = SavedDocument.objects.create(
             user=self.user, work=self.overturned_work
         )
-        self.follow_overturned = UserFollowing.objects.create(
+        self.follow_overturned = UserFollowing.objects.get(
             user=self.user, saved_document=self.saved_overturned
         )
 
         self.amended_predicate = Predicate.objects.create(
             name="amended by",
             slug="amended-by",
-            verb="is amended by",
-            reverse_verb="amends",
         )
-        self.repealed_predicate = Predicate.objects.create(
+        self.repealed_predicate, _ = Predicate.objects.get_or_create(
             name="repealed by",
             slug="repealed-by",
-            verb="is repealed by",
-            reverse_verb="repeals",
         )
-        self.overturns_predicate = Predicate.objects.create(
+        self.overturns_predicate, _ = Predicate.objects.get_or_create(
             name="overturns",
             slug="overturns",
-            verb="overturns",
-            reverse_verb="is overturned by",
         )
 
     def test_update_new_relationship_follows_creates_timeline_events(self):


### PR DESCRIPTION
### Motivation
- Add automated coverage for the new relationship-detection flows to ensure amendments, repeals and overturns create timeline events for users who have saved documents. 
- Verify that relationship email alerts are dispatched using the correct templates and that corresponding `TimelineEvent` rows are marked as sent.

### Description
- Added a new `TimelineRelationshipTests` `TestCase` in `peachjam/tests/test_timeline.py` that exercises relationship handling for `amended-by`, `repealed-by`, and `overturns` predicates using existing fixtures. 
- The tests create `Predicate` and `Relationship` records, create `SavedDocument` + `UserFollowing` entries, call `UserFollowing.update_new_relationship_follows(...)`, and assert `TimelineEvent` creation and `subject_works` population. 
- Added a test that enables `PEACHJAM['EMAIL_ALERTS_ENABLED']`, patches `send_templated_mail`, calls `TimelineEmailService.send_new_relationship_email(...)`, asserts both `new_relationship_alert` and `new_overturn_alert` templates were sent, and verifies events are marked with `email_alert_sent_at`.
- Only `peachjam/tests/test_timeline.py` was modified to add imports and the new tests.

### Testing
- No automated tests were executed as part of this change (no test run was requested during the rollout). 
- Recommended automated verification is to run `python manage.py test` (or scope to `peachjam.tests.test_timeline`) in CI or locally to validate the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e5d7bbf6c832f8cc6461cafdf0145)