### PR TITLE
ensure data written when getting text from a pdf

### DIFF
--- a/peachjam/adapters/gazettes.py
+++ b/peachjam/adapters/gazettes.py
@@ -128,6 +128,8 @@ class GazetteAPIAdapter(RequestsAdapter):
         # force the dynamic file field to be set correctly
         SourceFile.objects.filter(pk=sf.pk).update(file=s3_file)
 
+        # ensure gazette.source_file is up to date
+        gazette.refresh_from_db()
         gazette.update_text_content()
 
         logger.info("Done.")


### PR DESCRIPTION
there is a small chance that the S3 pdf handle may be stale (hence refresh_from_db()) and that we may not be at the start of the file.

This fixes LII-3C9 in sentry.

I'm a little surprised that we need to do this, but I have tested on the gazettes site and it works. 