### PR TITLE
fix search perm names and related tests

### DIFF
--- a/peachjam_search/tests/test_views.py
+++ b/peachjam_search/tests/test_views.py
@@ -1,16 +1,30 @@
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.urls import reverse
 from elasticsearch_dsl.response import Response
+
+from peachjam_search.models import SearchTrace
 
 
 class SearchViewsTest(TestCase):
     fixtures = ["tests/countries", "tests/users"]
 
     def setUp(self):
-        self.user = User.objects.get(username="admin@example.com")
+        self.user = User.objects.get(username="officer@example.com")
+        # ensure user has the correct permission
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename="can_download_search",
+                content_type=ContentType.objects.get_for_model(SearchTrace),
+            ),
+            Permission.objects.get(
+                codename="can_debug_search",
+                content_type=ContentType.objects.get_for_model(SearchTrace),
+            ),
+        )
 
     @patch("peachjam_search.engine.RetrieverSearch.execute")
     def test_explain(self, mock_search):

--- a/peachjam_search/views/search.py
+++ b/peachjam_search/views/search.py
@@ -86,7 +86,9 @@ class DocumentSearchView(TemplateView):
     use_explain = False
 
     def get(self, request, *args, **kwargs):
-        self.user_can_debug = self.request.user.has_perm("peachjam_search.debug_search")
+        self.user_can_debug = self.request.user.has_perm(
+            "peachjam_search.can_debug_search"
+        )
         return getattr(self, self.action)(request, *args, **kwargs)
 
     def prepare(self, request, facets=False):
@@ -182,7 +184,7 @@ class DocumentSearchView(TemplateView):
         if response:
             return response
 
-        if not request.user.has_perm("peachjam_search.download_search"):
+        if not request.user.has_perm("peachjam_search.can_download_search"):
             if request.htmx:
                 # this is the initial request to download, show a friendly permission-denied box
                 self.template_name = "peachjam_search/_download_403.html"


### PR DESCRIPTION
Incorrect permission names were being checked. The tests have been updated to use a regular user not a superuser.