### PR TITLE
Replaced collections with paralegals on navbar

### DIFF
--- a/zambialii/templates/peachjam/_header.html
+++ b/zambialii/templates/peachjam/_header.html
@@ -48,6 +48,9 @@
     </a>
   </li>
   <li class="nav-item">
+    <a class="nav-link" href="{% url 'paralegals' %}">Paralegal Resources</a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'gazettes' %}active{% endif %}"
        href="{% url 'gazettes' %}">
       {% trans 'Gazettes' %}
@@ -58,9 +61,6 @@
        href="{% url 'document_nature_list' 'bill' %}">
       {% trans 'Bills' %}
     </a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" href="{% url 'paralegals' %}">Paralegals</a>
   </li>
   <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'about' %}active{% endif %}"


### PR DESCRIPTION
Closes #2931 
<img width="902" height="169" alt="Screenshot 2026-01-30 at 14 38 35" src="https://github.com/user-attachments/assets/6e8949e3-eb34-42c6-a6b0-8f784dbf8bbe" />
