### PR TITLE
Improve request logging a bit

### DIFF
--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -559,16 +559,18 @@ JAZZMIN_UI_TWEAKS = {
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
+    "filters": {"request_id": {"()": "log_request_id.filters.RequestIDFilter"}},
     "handlers": {
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "simple",
+            "filters": ["request_id"],
         },
     },
     "formatters": {
         "simple": {
-            "format": "%(asctime)s %(levelname)s %(module)s %(process)d %(thread)d %(message)s",
+            "format": "%(asctime)s %(levelname)s %(name)s %(request_id)s %(process)d %(thread)d %(message)s",
             "datefmt": "%Y-%m-%d %H:%M:%S",
         }
     },
@@ -687,11 +689,6 @@ X_FRAME_OPTIONS = "SAMEORIGIN"
 # Setup request id logging
 LOG_REQUEST_ID_HEADER = "HTTP_X_REQUEST_ID"
 REQUEST_ID_RESPONSE_HEADER = "X-Request-Id"
-LOGGING["filters"] = {"request_id": {"()": "log_request_id.filters.RequestIDFilter"}}
-LOGGING["formatters"]["simple"][
-    "format"
-] = "%(asctime)s %(levelname)s %(module)s %(request_id)s %(process)d %(thread)d %(message)s"
-LOGGING["handlers"]["console"]["filters"] = ["request_id"]
 
 
 # E-mail configuration


### PR DESCRIPTION
* set django.request log level to ERROR so that 404 Not Found are excluded. Otherwise our django logs (not nginx logs) have lots of 404s which aren't useful. We have richer nginx logs to handle these.
* unify logging config in settings.py
* change the `%(module)s` part of the message format to `%(name)s` which is more meaningful

eg:

```
2026-02-02 06:58:20 INFO django.server none 34568 6277427200 "GET /user/loaded HTTP/1.1" 200 422
```