### PR TITLE
glossary links to documentation

### DIFF
--- a/peachjam/templates/peachjam/glossary/glossary.html
+++ b/peachjam/templates/peachjam/glossary/glossary.html
@@ -26,6 +26,9 @@
   </div>
   <div class="container">
     <h1>{% trans 'Glossary of defined terms' %}</h1>
+    {% block help %}
+      {% include "peachjam/_help_button.html" with help_link="legislation/glossary-of-defined-terms" %}
+    {% endblock %}
     <div class="mb-5">
       {% blocktrans trimmed with name=place.name %}
         Terms that have been defined in legislation across {{ name }}.


### PR DESCRIPTION
<img width="982" height="376" alt="image" src="https://github.com/user-attachments/assets/84a50206-df1c-4331-99f9-d0cb5aba0747" />
