### PR TITLE
Fix homepage video autoplay and Error 153

### DIFF
--- a/africanlii/templates/peachjam/home.html
+++ b/africanlii/templates/peachjam/home.html
@@ -22,6 +22,7 @@
                   src="{{ video_link }}"
                   title="YouTube video player"
                   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  referrerpolicy="strict-origin-when-cross-origin"
                   allowfullscreen></iframe>
         </div>
       </div>

--- a/africanlii/views/home.py
+++ b/africanlii/views/home.py
@@ -65,9 +65,9 @@ class HomePageView(BaseHomePageView):
         # check user's preferred language
         current_language = get_language_from_request(self.request)
         video_links = {
-            "en": "https://www.youtube.com/embed/m54qqXDkCfk",
-            "fr": "https://www.youtube.com/embed/BMN38Hvt6Uw",
-            "sw": "https://www.youtube.com/embed/CbtPXhdTZyA",
+            "en": "https://www.youtube.com/embed/m54qqXDkCfk?autoplay=1&mute=1",
+            "fr": "https://www.youtube.com/embed/BMN38Hvt6Uw?autoplay=1&mute=1",
+            "sw": "https://www.youtube.com/embed/CbtPXhdTZyA?autoplay=1&mute=1",
         }
 
         # set video link based on user's preferred language, default to English if not available


### PR DESCRIPTION
I updated the video embed code to include the required autoplay parameters and configured the correct security policy (referrer) to comply with YouTube's latest embedding requirements

Before:

<img width="1383" height="656" alt="Screenshot 2026-02-12 at 3 12 58 PM" src="https://github.com/user-attachments/assets/809d9e68-a99e-4c11-b48d-225d4c0c1b76" />


After:

<img width="1556" height="712" alt="Screenshot 2026-02-12 at 3 13 31 PM" src="https://github.com/user-attachments/assets/6be467cc-d68d-4663-8d5e-bee0f9f01b4b" />

