### PR TITLE
in document listing views, put nature facet first

### DIFF
--- a/peachjam/views/generic_views.py
+++ b/peachjam/views/generic_views.py
@@ -343,9 +343,9 @@ class FilteredDocumentListView(DocumentListView):
 
     def add_facets(self, context):
         context["facet_data"] = {}
+        self.add_natures_facet(context)
         self.add_years_facet(context)
         self.add_authors_facet(context)
-        self.add_natures_facet(context)
         self.add_taxonomies_facet(context)
         self.add_alphabet_facet(context)
 


### PR DESCRIPTION
when there are multiple natures, it's more useful to be able to see that and facet by them than by year or author. For example, in the provision citation view, it's better to be able to facet by document type than by year.

I think this holds for other versions of this view, too, so this applies globally.

<img width="836" height="932" alt="image" src="https://github.com/user-attachments/assets/668ab981-dcef-4e33-aae6-cd71966a7d88" />
