### PR TITLE
send created_at attribute to customerio

### DIFF
--- a/peachjam/customerio.py
+++ b/peachjam/customerio.py
@@ -57,6 +57,7 @@ class CustomerIO:
             "last_name": user.last_name,
             "is_staff": user.is_staff,
             "language": user.userprofile.preferred_language.iso,
+            "created_at": int(user.date_joined.timestamp()),
         }
         details.update(self.get_common_details())
         return details


### PR DESCRIPTION
this is a built-in attribute that customerio uses to know when a user first signed up to the app