### PR TITLE
Added "what changed" box to dom before data loads

### DIFF
--- a/peachjam/js/components/DocDiffs/index.ts
+++ b/peachjam/js/components/DocDiffs/index.ts
@@ -64,13 +64,6 @@ class DocDiffsManager {
       return;
     }
     if (this.inlineDiff) this.inlineDiff.close();
-
-    const target = document.createElement('div');
-    const anchorElement = document.querySelector(`[data-eid="${provision.id}"`);
-    if (anchorElement) {
-      anchorElement.after(target);
-    }
-
     this.inlineDiff = createAndMountApp({
       component: ProvisionDiffInline,
       props: {
@@ -80,7 +73,7 @@ class DocDiffsManager {
         serviceUrl: this.serviceUrl
       },
       use: [vueI18n],
-      mountTarget: target
+      mountTarget: document.createElement('div')
     });
     this.inlineDiff.$el.addEventListener('close', () => {
       this.inlineDiff = null;


### PR DESCRIPTION
Closes #2986 
- We already have a fallback for when there's no diffsets, so used that instead.
- I appended the target to the DOM, so it's already there while it's fetching the changes.
- Tested on 3G network

https://www.loom.com/share/49a03f5f02594f35bfbba6da2f6fdf4a