### PR TITLE
add extra filter to flynote count updates

### DIFF
--- a/peachjam/management/commands/update_flynote_counts.py
+++ b/peachjam/management/commands/update_flynote_counts.py
@@ -16,5 +16,5 @@ class Command(BaseCommand):
             )
             return
 
-        FlynoteDocumentCount.refresh_for_flynote(None)
+        FlynoteDocumentCount.refresh_for_all_flynotes()
         self.stdout.write(self.style.SUCCESS("Done."))

--- a/peachjam/management/commands/update_flynote_taxonomies.py
+++ b/peachjam/management/commands/update_flynote_taxonomies.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
             msg += f" Last pk processed: {last_pk}."
 
         if not skip_counts and processed > 0:
-            FlynoteDocumentCount.refresh_for_flynote(None)
+            FlynoteDocumentCount.refresh_for_all_flynotes()
             msg += " Flynote counts refreshed."
 
         self.stdout.write(self.style.SUCCESS(msg))

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -95,18 +95,18 @@ class FlynoteDocumentCount(models.Model):
         return f"{self.flynote.name}: {self.count}"
 
     @classmethod
-    def refresh_for_flynote(cls, root=None):
-        """Recompute document counts for flynotes.
-
-        If root is None, updates all FlynoteDocumentCount rows in bulk
-        (one transaction). Otherwise updates only the subtree rooted at root.
+    def refresh_for_flynote(cls, root):
+        """Recompute document counts for flynotes under *root*.
 
         Each node's count includes documents linked directly to it plus
         documents linked to any of its descendants. Uses treebeard's
         materialised path to walk ancestors efficiently in a single SQL
         query, following the same pattern as TaxonomyDocumentCount.
         """
-        root_path = root.path if root else ""
+        if root is None:
+            raise ValueError("refresh_for_flynote requires a root flynote node")
+
+        root_path = root.path
 
         with transaction.atomic():
             with connection.cursor() as cursor:
@@ -130,20 +130,30 @@ class FlynoteDocumentCount(models.Model):
                     FROM peachjam_flynote ancestor
                     INNER JOIN peachjam_flynote descendant
                         ON descendant.path LIKE ancestor.path || '%%'
+                        AND descendant.path LIKE %s
                     INNER JOIN peachjam_judgmentflynote jf
                         ON jf.flynote_id = descendant.id
                     WHERE ancestor.path LIKE %s
                     GROUP BY ancestor.id
                     """,
-                    [root_path + "%"],
+                    [root_path + "%", root_path + "%"],
                 )
 
-        if root:
-            log.info(
-                "Refreshed document counts for flynote tree rooted at '%s' (pk=%s)",
-                root.slug,
-                root.pk,
-            )
-        else:
-            count = cls.objects.count()
-            log.info("Refreshed document counts for all flynotes (%d rows).", count)
+        log.info(
+            "Refreshed document counts for flynote tree rooted at '%s' (pk=%s)",
+            root.slug,
+            root.pk,
+        )
+
+    @classmethod
+    def refresh_for_all_flynotes(cls):
+        """Recompute document counts for each flynote tree independently."""
+        refreshed = 0
+        for root in Flynote.get_root_nodes():
+            cls.refresh_for_flynote(root)
+            refreshed += 1
+
+        log.info(
+            "Refreshed document counts for all flynotes across %d roots.",
+            refreshed,
+        )

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -312,9 +312,9 @@ class FlynoteDocumentCountTest(TestCase):
         count_row = FlynoteDocumentCount.objects.get(flynote=criminal)
         self.assertEqual(count_row.count, 2)
 
-    def test_refresh_with_none_root_updates_all(self):
-        """refresh_for_flynote(None) updates counts for all flynotes in one go."""
-        FlynoteDocumentCount.refresh_for_flynote(None)
+    def test_refresh_for_all_flynotes_updates_all(self):
+        """refresh_for_all_flynotes() updates counts for all flynotes in one go."""
+        FlynoteDocumentCount.refresh_for_all_flynotes()
         self.assertEqual(FlynoteDocumentCount.objects.count(), 0)
 
         judgment = Judgment.objects.create(
@@ -326,13 +326,13 @@ class FlynoteDocumentCountTest(TestCase):
             flynote="Criminal law \u2014 admissibility",
         )
         self.updater.update_for_judgment(judgment)
-        FlynoteDocumentCount.refresh_for_flynote(None)
+        FlynoteDocumentCount.refresh_for_all_flynotes()
         criminal = Flynote.objects.get(name="Criminal law")
         count_row = FlynoteDocumentCount.objects.get(flynote=criminal)
         self.assertEqual(count_row.count, 1)
 
-    def test_refresh_with_none_root_updates_multiple_hierarchies(self):
-        """refresh_for_flynote(None) correctly updates counts across multiple roots."""
+    def test_refresh_for_all_flynotes_updates_multiple_hierarchies(self):
+        """refresh_for_all_flynotes() correctly updates counts across multiple roots."""
         judgment1 = Judgment.objects.create(
             case_name="Case 1",
             jurisdiction=Country.objects.first(),
@@ -351,12 +351,16 @@ class FlynoteDocumentCountTest(TestCase):
         )
         self.updater.update_for_judgment(judgment1)
         self.updater.update_for_judgment(judgment2)
-        FlynoteDocumentCount.refresh_for_flynote(None)
+        FlynoteDocumentCount.refresh_for_all_flynotes()
 
         criminal = Flynote.objects.get(name="Criminal law")
         admin = Flynote.objects.get(name="Administrative law")
         self.assertEqual(FlynoteDocumentCount.objects.get(flynote=criminal).count, 2)
         self.assertEqual(FlynoteDocumentCount.objects.get(flynote=admin).count, 1)
+
+    def test_refresh_for_flynote_requires_root(self):
+        with self.assertRaises(ValueError):
+            FlynoteDocumentCount.refresh_for_flynote(None)
 
 
 class FlynoteTopicListViewTest(TestCase):


### PR DESCRIPTION
this has a huge improvement on the efficiency of the updates.

it's far better to run large updates by updating every root, than the entire tree in one go


## old query

```
tanzlii=> explain
 INSERT INTO peachjam_flynotedocumentcount (flynote_id, count)
 SELECT
     ancestor.id,
     COUNT(DISTINCT jf.document_id)
 FROM peachjam_flynote ancestor
 INNER JOIN peachjam_flynote descendant
     ON descendant.path LIKE ancestor.path || '%'
 INNER JOIN peachjam_judgmentflynote jf
     ON jf.flynote_id = descendant.id
 WHERE ancestor.path LIKE '01LR%'
 GROUP BY ancestor.id
;
                                                                        QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 Insert on peachjam_flynotedocumentcount  (cost=166625.96..166824.57 rows=0 width=0)
   ->  Subquery Scan on "*SELECT*"  (cost=166625.96..166824.57 rows=34 width=20)
         ->  GroupAggregate  (cost=166625.96..166824.06 rows=34 width=16)
               Group Key: ancestor.id
               ->  Sort  (cost=166625.96..166691.88 rows=26367 width=16)
                     Sort Key: ancestor.id
                     ->  Nested Loop  (cost=65902.64..164689.78 rows=26367 width=16)
                           Join Filter: ((descendant.path)::text ~~ ((ancestor.path)::text || '%'::text))
                           ->  Hash Join  (cost=65902.09..72397.22 rows=155099 width=24)
                                 Hash Cond: (jf.flynote_id = descendant.id)
                                 ->  Seq Scan on peachjam_judgmentflynote jf  (cost=0.00..2552.99 rows=155099 width=16)
                                 ->  Hash  (cost=59576.93..59576.93 rows=344493 width=24)
                                       ->  Seq Scan on peachjam_flynote descendant  (cost=0.00..59576.93 rows=344493 width=24)
                           ->  Materialize  (cost=0.55..8.74 rows=34 width=24)
                                 ->  Index Scan using peachjam_flynote_path_63bd5477_like on peachjam_flynote ancestor  (cost=0.55..8.57 rows=34 width=24)
                                       Index Cond: (((path)::text ~>=~ '01LR'::text) AND ((path)::text ~<~ '01LS'::text))
                                       Filter: ((path)::text ~~ '01LR%'::text)
(17 rows)
```

## new query

```
tanzlii=> explain
 INSERT INTO peachjam_flynotedocumentcount (flynote_id, count)
 SELECT
     ancestor.id,
     COUNT(DISTINCT jf.document_id)
 FROM peachjam_flynote ancestor
 INNER JOIN peachjam_flynote descendant
     ON descendant.path LIKE ancestor.path || '%'
     AND descendant.path LIKE '01LR%'
 INNER JOIN peachjam_judgmentflynote jf
     ON jf.flynote_id = descendant.id
 WHERE ancestor.path LIKE '01LR%'
 GROUP BY ancestor.id
;
                                                                            QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Insert on peachjam_flynotedocumentcount  (cost=87.46..87.56 rows=0 width=0)
   ->  Subquery Scan on "*SELECT*"  (cost=87.46..87.56 rows=3 width=20)
         ->  GroupAggregate  (cost=87.46..87.51 rows=3 width=16)
               Group Key: ancestor.id
               ->  Sort  (cost=87.46..87.47 rows=3 width=16)
                     Sort Key: ancestor.id
                     ->  Nested Loop  (cost=1.51..87.43 rows=3 width=16)
                           ->  Nested Loop  (cost=1.09..37.45 rows=6 width=16)
                                 Join Filter: ((descendant.path)::text ~~ ((ancestor.path)::text || '%'::text))
                                 ->  Index Scan using peachjam_flynote_path_63bd5477_like on peachjam_flynote ancestor  (cost=0.55..8.57 rows=34 width=24)
                                       Index Cond: (((path)::text ~>=~ '01LR'::text) AND ((path)::text ~<~ '01LS'::text))
                                       Filter: ((path)::text ~~ '01LR%'::text)
                                 ->  Materialize  (cost=0.55..8.74 rows=34 width=24)
                                       ->  Index Scan using peachjam_flynote_path_63bd5477_like on peachjam_flynote descendant  (cost=0.55..8.57 rows=34 width=24)
                                             Index Cond: (((path)::text ~>=~ '01LR'::text) AND ((path)::text ~<~ '01LS'::text))
                                             Filter: ((path)::text ~~ '01LR%'::text)
                           ->  Index Scan using peachjam_judgmentflynote_flynote_id_dd902eba on peachjam_judgmentflynote jf  (cost=0.42..8.32 rows=1 width=16)
                                 Index Cond: (flynote_id = descendant.id)
```