### PR TITLE
chore: Adds youtube training links to zambialii

### DIFF
--- a/zambialii/templates/zambialii/paralegals.html
+++ b/zambialii/templates/zambialii/paralegals.html
@@ -1,27 +1,31 @@
 {% extends "peachjam/layouts/main.html" %}
 {% load static i18n %}
-{% block title %}Paralegal Resources{% endblock %}
+{% block title %}
+  {% trans "Paralegal Resources" %}
+{% endblock %}
 {% block page-content %}
   <section class="py-4">
     <div class="container">
-      <h1>Paralegal Resources</h1>
+      <h1>{% trans "Paralegal Resources" %}</h1>
       <p class="lead">
-        This section of ZambiaLII brings together practical tools, training materials, and simplified legal information to support the work of paralegals across Zambia. It is designed to provide quick access to reliable, up-to-date resources for use in daily practice and professional development.
+        {% trans "This section of ZambiaLII brings together practical tools, training materials, and simplified legal information to support the work of paralegals across Zambia. It is designed to provide quick access to reliable, up-to-date resources for use in daily practice and professional development." %}
       </p>
-      <p>Explore:</p>
+      <p>{% trans "Explore:" %}</p>
       <ol>
         <li>
-          <b>Training manuals</b> – TEVET paralegal manuals, updated for quick reference.
+          <b>{% trans "Training manuals" %}</b> {% trans "- TEVET paralegal manuals, updated for quick reference." %}
         </li>
         <li>
-          <b>Guides and best practices</b> – step-by-step resources on common legal issues such as land rights, family law, and criminal justice.
+          <b>{% trans "Guides and best practices" %}</b>
+          {% trans "- step-by-step resources on common legal issues such as land rights, family law, and criminal justice." %}
         </li>
         <li>
-          <b>Legal information</b> – curated summaries of laws and court decisions most relevant to paralegal work.
+          <b>{% trans "Legal information" %}</b>
+          {% trans "- curated summaries of laws and court decisions most relevant to paralegal work." %}
         </li>
       </ol>
       <p>
-        All materials are free to access, regularly updated, and tailored to the needs of the Zambian paralegal community.
+        {% trans "All materials are free to access, regularly updated, and tailored to the needs of the Zambian paralegal community." %}
       </p>
     </div>
   </section>
@@ -29,9 +33,9 @@
     <div class="container">
       <div class="row">
         <div class="col-md-8">
-          <h2>Research when you're offline</h2>
+          <h2>{% trans "Research when you're offline" %}</h2>
           <p class="lead">
-            Enable offline access for these resources. Once enabled, you can use these resources at any time without an internet connection.
+            {% trans "Enable offline access for these resources. Once enabled, you can use these resources at any time without an internet connection." %}
           </p>
         </div>
         <div class="col-md-4">
@@ -43,8 +47,8 @@
   </section>
   <section class="py-4">
     <div class="container">
-      <h2>Training videos</h2>
-      <p class="lead">Watch short walkthroughs on using the Paralegal Hub and related materials.</p>
+      <h2>{% trans "Training videos" %}</h2>
+      <p class="lead">{% trans "Watch short walkthroughs on using the Paralegal Hub and related materials." %}</p>
       <div class="row row-cols-1 row-cols-md-2 g-4">
         {% for video in videos %}
           <div class="col">
@@ -67,20 +71,20 @@
   </section>
   <section class="py-4">
     <div class="container">
-      <h2>Resources</h2>
+      <h2>{% trans "Resources" %}</h2>
       <div class="row row-cols-1 row-cols-md-3 g-4">
         <div class="col">
           <div class="card">
             <div class="card-body d-flex flex-row">
               <div class="paralegals-card-img me-3"
                    style="background-image: url('{% static 'images/paralegals/training.png' %}')"
-                   alt="Training graphic">
+                   alt="{% trans 'Training graphic' %}">
               </div>
               <div class="flex-grow-1">
-                <h5 class="card-title">Training manuals</h5>
-                <p class="card-text">TEVET paralegal manuals, updated for quick reference.</p>
+                <h5 class="card-title">{% trans "Training manuals" %}</h5>
+                <p class="card-text">{% trans "TEVET paralegal manuals, updated for quick reference." %}</p>
                 <a href="{% url 'taxonomy_detail' 'paralegals' 'paralegals-training-manuals' %}"
-                   class="stretched-link">Training manuals →</a>
+                   class="stretched-link">{% trans "Training manuals" %} →</a>
               </div>
             </div>
           </div>
@@ -90,15 +94,15 @@
             <div class="card-body d-flex flex-row">
               <div class="paralegals-card-img me-3"
                    style="background-image: url('{% static 'images/paralegals/guides.png' %}')"
-                   alt="Guides graphic">
+                   alt="{% trans 'Guides graphic' %}">
               </div>
               <div class="flex-grow-1">
-                <h5 class="card-title">Guides and best practices</h5>
+                <h5 class="card-title">{% trans "Guides and best practices" %}</h5>
                 <p class="card-text">
-                  Step-by-step resources on common legal issues such as land rights, family law, and criminal justice.
+                  {% trans "Step-by-step resources on common legal issues such as land rights, family law, and criminal justice." %}
                 </p>
                 <a href="{% url 'taxonomy_detail' 'paralegals' 'paralegals-forms-guides-and-best-practices' %}"
-                   class="stretched-link">Guides and best practices →</a>
+                   class="stretched-link">{% trans "Guides and best practices" %} →</a>
               </div>
             </div>
           </div>
@@ -108,13 +112,13 @@
             <div class="card-body d-flex flex-row">
               <div class="paralegals-card-img me-3"
                    style="background-image: url('{% static 'images/paralegals/law.png' %}')"
-                   alt="Legal information graphic">
+                   alt="{% trans 'Legal information graphic' %}">
               </div>
               <div class="flex-grow-1">
-                <h5 class="card-title">Legal information</h5>
-                <p class="card-text">Curated summaries of laws and court decisions most relevant to paralegal work.</p>
+                <h5 class="card-title">{% trans "Legal information" %}</h5>
+                <p class="card-text">{% trans "Curated summaries of laws and court decisions most relevant to paralegal work." %}</p>
                 <a href="{% url 'taxonomy_detail' 'paralegals' 'paralegals-legal-information' %}"
-                   class="stretched-link">Legal information →</a>
+                   class="stretched-link">{% trans "Legal information" %} →</a>
               </div>
             </div>
           </div>

--- a/zambialii/views.py
+++ b/zambialii/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
 
 from peachjam.models import Taxonomy
@@ -13,19 +14,21 @@ class ParalegalsView(TemplateView):
         context["taxonomy"] = get_object_or_404(Taxonomy.objects, slug="paralegals")
         context["videos"] = [
             {
-                "title": "Accessing the Paralegal Hub & Exploring the Training Manuals",
+                "title": _(
+                    "Accessing the Paralegal Hub & Exploring the Training Manuals"
+                ),
                 "embed_url": "https://www.youtube.com/embed/eiKB3oaQDpA",
             },
             {
-                "title": "Navigating Legal Information on the Paralegal Hub",
+                "title": _("Navigating Legal Information on the Paralegal Hub"),
                 "embed_url": "https://www.youtube.com/embed/l9GxanzOk4o",
             },
             {
-                "title": "Researching When You Are Offline",
+                "title": _("Researching When You Are Offline"),
                 "embed_url": "https://www.youtube.com/embed/bRQCXmclXPs",
             },
             {
-                "title": "Exploring the Paralegal Training Manual",
+                "title": _("Exploring the Paralegal Training Manual"),
                 "embed_url": "https://www.youtube.com/embed/PZiIT3206rI",
             },
         ]


### PR DESCRIPTION
Closes https://github.com/laws-africa/peachjam/issues/3019.

## Changes

  - added a videos list to the ZambiaLII paralegals view context
  - added a new “Training videos” section to the ZambiaLII paralegals template
  - embedded 4 YouTube videos:
      - Accessing the Paralegal Hub & Exploring the Training Manuals
      - Navigating Legal Information on the Paralegal Hub
      - Researching When You Are Offline
      - Exploring the Paralegal Training Manual
      
<img width="1840" height="991" alt="Screenshot 2026-03-10 at 12 36 07" src="https://github.com/user-attachments/assets/50113363-2cf6-488d-91ba-43840f0fbcd4" />
