### PR TITLE
display dedicated restricted access page for taxonomies and standardize restricted content messaging

### DIFF
--- a/peachjam/templates/peachjam/taxonomy_restricted.html
+++ b/peachjam/templates/peachjam/taxonomy_restricted.html
@@ -1,0 +1,32 @@
+{% extends 'peachjam/layouts/main.html' %}
+{% load i18n %}
+{% block title %}{{ taxonomy.name }}{% endblock %}
+{% block page-content %}
+  <div class="pb-5">
+    <div class="container py-4">
+      <h2>{% trans "Access restricted" %}</h2>
+      <p class="lead">{% trans "This collection is restricted and is not publicly available." %}</p>
+      {% if request.user.is_authenticated %}
+        <p>
+          {% trans "Your account does not currently have permission to view this collection." %}
+          {% if SUPPORT_EMAIL %}
+            {% blocktrans trimmed with email=SUPPORT_EMAIL %}
+              To request institutional access, please contact us at <a href="mailto:{{ email }}">{{ email }}</a>.
+            {% endblocktrans %}
+          {% endif %}
+        </p>
+      {% else %}
+        <p>{% trans "If your institution has access to this collection, sign in to your account to continue." %}</p>
+        <a class="btn btn-primary"
+           href="{% url 'account_login' %}?next={{ request.get_full_path|urlencode }}">{% trans "Sign in" %}</a>
+        {% if SUPPORT_EMAIL %}
+          <p class="mt-3">
+            {% blocktrans trimmed with email=SUPPORT_EMAIL %}
+              Don't have an account? To request institutional access, contact us at <a href="mailto:{{ email }}">{{ email }}</a>.
+            {% endblocktrans %}
+          </p>
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/peachjam/views/taxonomy.py
+++ b/peachjam/views/taxonomy.py
@@ -1,5 +1,5 @@
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import Http404, get_object_or_404
+from django.template.response import TemplateResponse
 from django.utils.cache import add_never_cache_headers
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
@@ -30,7 +30,12 @@ class AllowedTaxonomyMixin:
         )
         if self.taxonomy.restricted or any(is_ancestor_restricted):
             if not request.user.has_perm("peachjam.view_taxonomy", self.taxonomy):
-                raise PermissionDenied
+                return TemplateResponse(
+                    request,
+                    "peachjam/taxonomy_restricted.html",
+                    {"taxonomy": self.taxonomy},
+                    status=403,
+                )
         self.allowed_taxonomies = Taxonomy.get_allowed_taxonomies(
             request.user, root=self.taxonomy
         )


### PR DESCRIPTION
Before:
<img width="1683" height="491" alt="Screenshot 2026-03-10 at 2 11 32 PM" src="https://github.com/user-attachments/assets/4913da59-039e-4344-a78a-0ce23aa8ec5e" />


After:
<img width="1765" height="858" alt="Screenshot 2026-03-10 at 2 32 32 PM" src="https://github.com/user-attachments/assets/8cc3eaef-cdd5-4130-889d-34354f4e65d9" />
