### PR TITLE
fix bug on mobile where offcanvas prevents interaction

### DIFF
--- a/peachjam/js/components/document-filter-form.ts
+++ b/peachjam/js/components/document-filter-form.ts
@@ -5,6 +5,10 @@ export default class DocumentFilterForm {
   constructor (root: HTMLElement) {
     this.root = root;
 
+    // ensure the bootstrap offcanvas element is closed before htmx swaps the content, otherwise it can end up in a
+    // broken state
+    this.root.addEventListener('htmx:beforeSwap', () => this.cleanupOffcanvas());
+
     // setup a resize observer to move the filters when the window is resized
     const observer = new ResizeObserver(() => this.moveFilters());
     observer.observe(this.root);
@@ -45,6 +49,16 @@ export default class DocumentFilterForm {
         });
       }
     }
+  }
+
+  cleanupOffcanvas () {
+    const offcanvasElement = this.root.querySelector('#document-list-filters-offcanvas') as HTMLElement | null;
+    if (!offcanvasElement) {
+      return;
+    }
+
+    const offcanvas = window.bootstrap?.Offcanvas?.getInstance(offcanvasElement);
+    offcanvas?.hide();
   }
 
   setupFacetSearch () {


### PR DESCRIPTION
with document list when a filter is updated.

otherwise, the offcanvas element wasn't closed properly when htmx swapped in new content, meaning we couldn't interact with the page after choosing a facet.