### PR TITLE
embeddings for ghalii; separate embeddings setting from semantic search

### DIFF
--- a/ghalii/settings.py
+++ b/ghalii/settings.py
@@ -2,10 +2,13 @@ from django.utils.translation import gettext_lazy as _
 
 from liiweb.settings import *  # noqa
 
-INSTALLED_APPS = ["ghalii.apps.GhaLIIConfig"] + INSTALLED_APPS  # noqa
+INSTALLED_APPS = ["ghalii.apps.GhaLIIConfig", "peachjam_ml"] + INSTALLED_APPS  # noqa
 
 PEACHJAM["CHAT_ENABLED"] = True  # noqa
 PEACHJAM["CHAT_PUBLIC"] = True  # noqa
+
+# turn on document embeddings for document similarity without semantic search
+PEACHJAM["DOCUMENT_EMBEDDINGS"] = True  # noqa
 
 
 JAZZMIN_SETTINGS["site_title"] = "GhaLII"  # noqa

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -177,6 +177,8 @@ PEACHJAM = {
 
 PEACHJAM["ES_INDEX"] = os.environ.get("ES_INDEX", slugify(PEACHJAM["APP_NAME"]))
 PEACHJAM["MY_LII"] = f"My {PEACHJAM['APP_NAME']}"
+# tie document embeddings to semantic search, although embeddings can be enabled separately
+PEACHJAM["DOCUMENT_EMBEDDINGS"] = PEACHJAM["SEARCH_SEMANTIC"]
 
 WSGI_APPLICATION = "peachjam.wsgi.application"
 EMAIL_SUBJECT_PREFIX = f"[{PEACHJAM['APP_NAME']}] "

--- a/peachjam_ml/models.py
+++ b/peachjam_ml/models.py
@@ -171,7 +171,7 @@ class DocumentEmbedding(models.Model):
         """Refresh summary chunks and document-level embedding for a document, if they don't exist or the document
         summary has changed.
         """
-        if not settings.PEACHJAM["SEARCH_SEMANTIC"]:
+        if not settings.PEACHJAM["DOCUMENT_EMBEDDINGS"]:
             return
 
         summary_text = ContentChunk.get_summary_text(document)
@@ -204,7 +204,7 @@ class DocumentEmbedding(models.Model):
         """Refresh content chunks and document-level embedding for a document, if they don't exist or the document
         text has changed.
         """
-        if not settings.PEACHJAM["SEARCH_SEMANTIC"]:
+        if not settings.PEACHJAM["DOCUMENT_EMBEDDINGS"]:
             return
 
         text = document.get_content_as_text()


### PR DESCRIPTION
this means we can turn on embeddings and document similarity without worrying about configuring existing ES indexes for semantic search

also turn this on for ghalii