### PR TITLE
Improve flynote topic and subtopic displays

### DIFF
--- a/peachjam/templates/peachjam/flynote/_list.html
+++ b/peachjam/templates/peachjam/flynote/_list.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load humanize i18n %}
 {% if all_topics %}
   <div class="list-group list-group-flush">
     {% for item in all_topics %}
@@ -8,7 +8,7 @@
           {{ item.topic.name }}
           {% if item.child_names %}<small class="text-muted d-block">{{ item.child_names|join:", " }}</small>{% endif %}
         </div>
-        <span class="badge bg-secondary">{{ item.count }}</span>
+        <span class="badge bg-secondary">{{ item.count|intcomma }}</span>
       </a>
     {% endfor %}
   </div>

--- a/peachjam/templates/peachjam/flynote/_popular_topics.html
+++ b/peachjam/templates/peachjam/flynote/_popular_topics.html
@@ -1,16 +1,16 @@
-{% load i18n %}
+{% load humanize i18n %}
 {% if popular_topics %}
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3 {{ row_classes|default:"mb-5" }}">
     {% for item in popular_topics %}
       <div class="col">
-        <div class="card h-100 border">
+        <div class="card h-100 border shadow-sm">
           <div class="card-body d-flex justify-content-between align-items-start gap-2">
             <div>
               <a href="{% url 'flynote_topic_detail' item.topic.slug %}"
                  class="stretched-link mb-1">{{ item.topic.name }}</a>
               {% if item.child_names %}<div class="text-muted small">{{ item.child_names|join:"; " }}</div>{% endif %}
             </div>
-            <span class="badge rounded-pill bg-secondary flex-shrink-0">{{ item.count }}</span>
+            <span class="badge rounded-pill bg-secondary flex-shrink-0">{{ item.count|intcomma }}</span>
           </div>
         </div>
       </div>
@@ -24,7 +24,12 @@
                 data-bs-target="#allSubtopicsCollapse"
                 aria-expanded="false"
                 aria-controls="allSubtopicsCollapse">
-          {% trans "Explore all subtopics" %} <i class="bi bi-chevron-down ms-1"></i>
+          {% if topic %}
+            {{ topic.name }}
+          {% else %}
+            {% trans "Explore all subtopics" %}
+          {% endif %}
+          <i class="bi bi-chevron-down ms-1"></i>
         </button>
       </div>
     {% endif %}

--- a/peachjam/templates/peachjam/flynote/detail.html
+++ b/peachjam/templates/peachjam/flynote/detail.html
@@ -1,5 +1,5 @@
 {% extends 'peachjam/layouts/document_list.html' %}
-{% load i18n %}
+{% load humanize i18n %}
 {% block title %}
   {{ topic.name }} - {% trans "Flynotes" %}
 {% endblock %}
@@ -30,13 +30,19 @@
   <div class="mb-4">
     <h1>{{ topic.name }}</h1>
     {% if popular_topics %}
-      <h2 class="h4">{% trans "Subtopics" %}</h2>
+      <h2 class="h4">
+        {% trans "Subtopics" %}
+        <span class="badge rounded-pill text-bg-secondary fs-6 ms-2 align-middle">{{ total_subtopic_count|intcomma }}</span>
+      </h2>
       {% include 'peachjam/flynote/_popular_topics.html' with show_explore_all=True row_classes="mb-4" %}
       {% if has_more_topics %}
         <div class="collapse mb-5" id="allSubtopicsCollapse">
-          <div class="card card-body">
+          <div class="card card-body shadow-sm">
             <div class="d-flex justify-content-between align-items-center mb-3">
-              <h3 class="h5 mb-0">{% trans "All subtopics" %}</h3>
+              <h3 class="h5 mb-0">
+                {{ topic.name }}
+                <span class="badge rounded-pill text-bg-secondary fs-6 ms-2 align-middle">{{ total_subtopic_count|intcomma }}</span>
+              </h3>
               {% include 'peachjam/flynote/_filter_form.html' with htmx_target='#flynote-subtopics-container' %}
             </div>
             <div id="flynote-subtopics-container">{% include 'peachjam/flynote/_list.html' %}</div>

--- a/peachjam/templates/peachjam/flynote/list.html
+++ b/peachjam/templates/peachjam/flynote/list.html
@@ -1,5 +1,5 @@
 {% extends "peachjam/layouts/main.html" %}
-{% load i18n %}
+{% load humanize i18n %}
 {% block title %}
   {% trans "Explore case law by topic" %}
 {% endblock %}
@@ -25,7 +25,10 @@
       {% include 'peachjam/flynote/_popular_topics.html' %}
     {% endif %}
     <div class="d-flex justify-content-between align-items-center mb-3">
-      <h2 class="mb-0">{% trans "All topics" %}</h2>
+      <h2 class="mb-0">
+        {% trans "All topics" %}
+        <span class="badge rounded-pill text-bg-secondary fs-6 ms-2 align-middle">{{ total_topic_count|intcomma }}</span>
+      </h2>
       {% include 'peachjam/flynote/_filter_form.html' with htmx_target='#flynote-all-list-container' %}
     </div>
     <div id="flynote-all-list-container">{% include 'peachjam/flynote/_list.html' %}</div>

--- a/peachjam/views/judgment.py
+++ b/peachjam/views/judgment.py
@@ -145,6 +145,7 @@ class FlynoteTopicListView(FlynoteTopicMixin, ListView):
             for t in page_topics
         ]
 
+        context["total_topic_count"] = Flynote.get_root_nodes().count()
         context["total_judgment_count"] = FlynoteDocumentCount.objects.filter(
             flynote__in=Flynote.get_root_nodes()
         ).aggregate(total=Coalesce(Sum("count"), Value(0)))["total"]
@@ -226,6 +227,7 @@ class FlynoteTopicDetailView(FlynoteTopicMixin, FilteredDocumentListView):
 
         context["topic"] = self.flynote
         context["ancestors"] = self.flynote.get_ancestors()
+        context["total_subtopic_count"] = total_children
         context["root"] = None
 
         return context


### PR DESCRIPTION
Improve flynote topic and subtopic displays with formatted counts and total count badges.

Before:
<img width="2115" height="858" alt="Screenshot 2026-03-17 at 8 02 08 PM" src="https://github.com/user-attachments/assets/9cc26d4e-13b8-47ac-a79e-c3a3fa2277d4" />
<img width="1790" height="922" alt="Screenshot 2026-03-17 at 8 03 25 PM" src="https://github.com/user-attachments/assets/f9e6c2d6-a228-4229-8834-38ed26693233" />


After:
<img width="1900" height="853" alt="Screenshot 2026-03-17 at 8 01 44 PM" src="https://github.com/user-attachments/assets/17d1db75-c471-47cf-b4ba-18a72444f992" />

<img width="1987" height="842" alt="Screenshot 2026-03-17 at 8 03 00 PM" src="https://github.com/user-attachments/assets/37c7f56d-d418-41ee-a66d-2326a86a4e59" />

