### PR TITLE
Redirect legacy signup to login when OTP is enabled

### DIFF
--- a/peachjam/tests/test_auth.py
+++ b/peachjam/tests/test_auth.py
@@ -3,8 +3,9 @@ from unittest.mock import MagicMock, patch
 from allauth.account.internal.flows.login_by_code import LoginCodeVerificationProcess
 from allauth.account.models import Login
 from allauth.account.stages import LoginByCodeStage
+from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 from peachjam.auth import _patched_finish, _patched_send_by_email
@@ -312,3 +313,15 @@ class UserAuthViewTests(TestCase):
         view = self._setup_view(request, "taken@example.com", user=user)
         response = view.post(request)
         self.assertEqual(response.status_code, 302)
+
+
+class SignupViewTests(TestCase):
+    @override_settings(PEACHJAM={**settings.PEACHJAM, "AUTH_OTP": True})
+    def test_signup_view_redirects_to_login_when_otp_enabled(self):
+        from peachjam.views.accounts import SignupView
+
+        request = RequestFactory().get(reverse("account_signup"))
+        response = SignupView.as_view()(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("account_login"))

--- a/peachjam/urls/accounts.py
+++ b/peachjam/urls/accounts.py
@@ -10,11 +10,12 @@ from peachjam.views import (
     EditAccountView,
     LoggedOutView,
 )
-from peachjam.views.accounts import OnboardView, UserAuthView
+from peachjam.views.accounts import OnboardView, SignupView, UserAuthView
 
 urlpatterns = []
 
 urlpatterns += [
+    path("signup/", SignupView.as_view(), name="account_signup"),
     path("", include("allauth.urls")),
     path("accept-terms/", AcceptTermsView.as_view(), name="account_accept_terms"),
     path(

--- a/peachjam/views/accounts.py
+++ b/peachjam/views/accounts.py
@@ -1,6 +1,8 @@
 from allauth.account.forms import ReauthenticateForm
 from allauth.account.mixins import NextRedirectMixin
 from allauth.account.views import ConfirmLoginCodeView as AllauthConfirmLoginCodeView
+from allauth.account.views import SignupView as AllauthSignupView
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -24,6 +26,13 @@ from peachjam.views.mixins import AtomicPostMixin
 from peachjam_subs.models import Subscription
 
 User = get_user_model()
+
+
+class SignupView(AllauthSignupView):
+    def dispatch(self, request, *args, **kwargs):
+        if settings.PEACHJAM["AUTH_OTP"]:
+            return redirect("account_login")
+        return super().dispatch(request, *args, **kwargs)
 
 
 class UserAuthView(AllauthConfirmLoginCodeView):


### PR DESCRIPTION
changed the legacy signup route to use a server-side redirect to login when OTP auth is
  enabled.

  Previously, the old signup page was still reachable and relied on a client-side redirect in the
  template. This meant users could still land on the legacy signup flow even though OTP login/
  signup-by-code was intended to be the only entry point.

  This PR:

  - overrides the legacy account signup view
  - redirects /accounts/signup/ to /accounts/login/ when AUTH_OTP is enabled
  - leaves the normal signup flow unchanged when AUTH_OTP is disabled
  - adds test coverage for the OTP-enabled redirect behavior

  This does not change the OTP login flow for new or existing users. New-email signup by code still
  happens through the login-by-code flow.