### PR TITLE
override jazzmin messages so that MESSAGE_TAGS is obeyed

### DIFF
--- a/peachjam/templates/admin/base.html
+++ b/peachjam/templates/admin/base.html
@@ -1,0 +1,9 @@
+{% extends 'admin/base.html' %}
+{% block messages %}
+  {% for message in messages %}
+    <div class="alert alert-{{ message.tags }} alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+      {{ message|capfirst }}
+    </div>
+  {% endfor %}
+{% endblock messages %}


### PR DESCRIPTION
otherwise it just skips the message if the tag is not one of a predefined list.

<img width="2628" height="954" alt="image" src="https://github.com/user-attachments/assets/2d95c964-febc-4810-b137-fd91a7424c8d" />
