### PR TITLE
show flynote and blurb on saved document list

### DIFF
--- a/peachjam/templates/peachjam/saved_document/_folder_list_item.html
+++ b/peachjam/templates/peachjam/saved_document/_folder_list_item.html
@@ -1,10 +1,14 @@
 {% load i18n %}
 <div id="saved-doc-{{ saved_document.pk }}" class="border-bottom">
   <div class="py-2">
-    <div class="d-flex">
+    <div class="d-flex align-items-start">
       <div class="me-2">
         <a href="{{ saved_document.document.get_absolute_url }}">{{ saved_document.document.title }}</a>
         {% include 'peachjam/_document_labels.html' with labels=saved_document.document.labels.all %}
+        {% if saved_document.document.blurb %}<div class="my-2">{{ saved_document.document.blurb }}</div>{% endif %}
+        {% if saved_document.document.flynote %}
+          <div class="fst-italic my-2">{{ saved_document.document.flynote|linebreaksbr }}</div>
+        {% endif %}
       </div>
       <button class="btn btn-link ms-auto p-0"
               type="button"


### PR DESCRIPTION
<img width="1517" height="565" alt="image" src="https://github.com/user-attachments/assets/0295b68b-9341-4e29-afec-84f3bccd8041" />

closes https://github.com/laws-africa/peachjam/issues/3107