### PR TITLE
Fix Flynote.DoesNotExist error during delete

### DIFF
--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -159,9 +159,13 @@ class FlynoteDocumentCount(models.Model):
                 root.slug,
                 root.pk,
             )
-            Flynote.objects.filter(path__startswith=root_path).filter(
-                document_count_cache__isnull=True
-            ).delete()
+            empty_flynotes = list(
+                Flynote.objects.filter(path__startswith=root_path)
+                .filter(document_count_cache__isnull=True)
+                .order_by("-depth", "-path")
+            )
+            for flynote in empty_flynotes:
+                flynote.delete()
 
         log.info(
             "Refreshed document counts for flynote tree rooted at '%s' (pk=%s)",

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1515,6 +1515,27 @@ class FlynoteDocumentCountTest(TestCase):
         with self.assertRaises(ValueError):
             FlynoteDocumentCount.refresh_for_flynote(None)
 
+    def test_refresh_prunes_empty_subtree_leaf_first(self):
+        judgment = Judgment.objects.create(
+            case_name="Prune Test",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 1, 1),
+            language=Language.objects.first(),
+            flynote="Criminal law — admissibility — trial within a trial",
+        )
+        self.updater.update_for_judgment(judgment)
+
+        criminal = Flynote.objects.get(name="Criminal law")
+        self.assertTrue(Flynote.objects.filter(path__startswith=criminal.path).exists())
+
+        judgment.delete()
+        FlynoteDocumentCount.refresh_for_flynote(criminal)
+
+        self.assertFalse(
+            Flynote.objects.filter(path__startswith=criminal.path).exists()
+        )
+
 
 class FlynoteListViewTest(TestCase):
     fixtures = [


### PR DESCRIPTION
Fixed he issue of trying to delete none existing flying notes, before were bulk deleting them all together which some flying notes were not exisitng and raise an error, currently  we get all the list of empty flying notes and delete them 1 by 1 #3120 