### PR TITLE
Fix button focus styles

### DIFF
--- a/peachjam/static/stylesheets/components/_buttons.scss
+++ b/peachjam/static/stylesheets/components/_buttons.scss
@@ -1,0 +1,22 @@
+@mixin solid-button-focus-ring {
+  outline: 3px solid $gray-900;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 0.2rem $white;
+}
+
+.btn.btn-primary:focus-visible,
+.btn.btn-secondary:focus-visible,
+.btn-check:focus-visible + .btn.btn-primary,
+.btn-check:focus-visible + .btn.btn-secondary {
+  @include solid-button-focus-ring;
+}
+
+@media (forced-colors: active) {
+  .btn.btn-primary:focus-visible,
+  .btn.btn-secondary:focus-visible,
+  .btn-check:focus-visible + .btn.btn-primary,
+  .btn-check:focus-visible + .btn.btn-secondary {
+    outline: 2px solid Highlight;
+    box-shadow: none;
+  }
+}

--- a/peachjam/static/stylesheets/components/_index.scss
+++ b/peachjam/static/stylesheets/components/_index.scss
@@ -1,5 +1,6 @@
 @import "auth";
 @import "autocomplete";
+@import "buttons";
 @import "charts";
 @import "chat";
 @import "diffs";


### PR DESCRIPTION
#3144   For this PR im trying to improve the focus around the solids buttons to allign with WCAG 2.1 AA compliannce. I have used black round ring for this coz, i wanted to use blue since other links were using blue eg advanced button but the issue is some sites are using that blue as primary color for their buttons like tanzlii so using Black waas the best option

Before:
<img width="1432" height="759" alt="Screenshot 2026-04-17 at 7 47 06 PM" src="https://github.com/user-attachments/assets/1bd2266d-90da-4fc5-bd71-1887554cc9e8" />

After:
<img width="1429" height="791" alt="Screenshot 2026-04-17 at 7 47 20 PM" src="https://github.com/user-attachments/assets/5fb20078-a1d0-49c2-9207-78ecacab7311" />
