### PR TITLE
Fix flynote update failures

### DIFF
--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -2656,22 +2656,58 @@ class FlynoteUpdater:
             self.node_cache[expected_slug] = existing
             return existing
 
-        try:
-            if parent:
-                # Treebeard uses parent state such as numchild when adding a child.
-                # Cached parent instances can go stale across multiple judgments,
-                # so refresh before inserting under an existing node.
-                parent.refresh_from_db(fields=["path", "depth", "numchild"])
-                node = parent.add_child(name=name, slug=expected_slug)
-            else:
+        if not parent:
+            try:
                 node = Flynote.add_root(name=name, slug=expected_slug)
-            self.node_cache[expected_slug] = node
-            return node
-        except IntegrityError:
-            existing = Flynote.objects.filter(slug=expected_slug).first()
-            if existing:
-                self.node_cache[expected_slug] = existing
-            return existing
+                self.node_cache[expected_slug] = node
+                return node
+            except IntegrityError:
+                existing = Flynote.objects.filter(slug=expected_slug).first()
+                if existing:
+                    self.node_cache[expected_slug] = existing
+                return existing
+
+        for attempt in range(1, 4):
+            locked_parent = (
+                Flynote.objects.select_for_update()
+                .filter(pk=parent.pk)
+                .only("id", "slug", "path", "depth", "numchild")
+                .first()
+            )
+            if not locked_parent:
+                log.warning(
+                    "Skipping flynote node creation for slug '%s' because parent %s no longer exists.",
+                    expected_slug,
+                    parent.pk,
+                )
+                return None
+
+            try:
+                node = locked_parent.add_child(name=name, slug=expected_slug)
+                self.node_cache[expected_slug] = node
+                return node
+            except IntegrityError:
+                existing = Flynote.objects.filter(slug=expected_slug).first()
+                if existing:
+                    self.node_cache[expected_slug] = existing
+                return existing
+            except AttributeError as exc:
+                if "add_sibling" not in str(exc):
+                    raise
+
+                existing = Flynote.objects.filter(slug=expected_slug).first()
+                if existing:
+                    self.node_cache[expected_slug] = existing
+                    return existing
+
+                if attempt == 3:
+                    log.warning(
+                        "Skipping flynote node creation for slug '%s' after %s Treebeard retries.",
+                        expected_slug,
+                        attempt,
+                        exc_info=True,
+                    )
+                    return None
 
     @transaction.atomic
     def update_for_judgment(self, judgment, refresh_counts=False):
@@ -2685,11 +2721,22 @@ class FlynoteUpdater:
         Does nothing if the flynote text cannot be parsed (plain prose, empty, etc.).
         """
         overall_start = perf_counter()
-        JudgmentFlynote.objects.filter(document=judgment).delete()
 
         parse_start = perf_counter()
-        paths = self.parser.parse(judgment.flynote)
+        try:
+            paths = self.parser.parse(judgment.flynote)
+        except IndexError:
+            log.warning(
+                "Skipping flynote update for judgment %s because parsing hit an indexing error. Flynote excerpt: %r",
+                judgment.pk,
+                (judgment.flynote or "")[:200],
+                exc_info=True,
+            )
+            return
         parse_ms = (perf_counter() - parse_start) * 1000
+
+        JudgmentFlynote.objects.filter(document=judgment).delete()
+
         if not paths:
             log.info(
                 "Linked judgment %s to 0 flynote topics (parse=%.2fms, nodes=0.00ms, links=0.00ms, total=%.2fms).",

--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -32,6 +32,10 @@ from peachjam.tasks import refresh_flynote_document_count
 log = logging.getLogger(__name__)
 
 
+class FlynoteUpdateDeferred(Exception):
+    """Raised when flynote relinking should be retried later."""
+
+
 class FlynoteParser:
     """Parses raw flynote text into structured paths.
 
@@ -2675,12 +2679,10 @@ class FlynoteUpdater:
                 .first()
             )
             if not locked_parent:
-                log.warning(
-                    "Skipping flynote node creation for slug '%s' because parent %s no longer exists.",
-                    expected_slug,
-                    parent.pk,
+                raise FlynoteUpdateDeferred(
+                    "parent %s no longer exists while creating '%s'"
+                    % (parent.pk, expected_slug)
                 )
-                return None
 
             try:
                 node = locked_parent.add_child(name=name, slug=expected_slug)
@@ -2701,21 +2703,18 @@ class FlynoteUpdater:
                     return existing
 
                 if attempt == 3:
-                    log.warning(
-                        "Skipping flynote node creation for slug '%s' after %s Treebeard retries.",
-                        expected_slug,
-                        attempt,
-                        exc_info=True,
-                    )
-                    return None
+                    raise FlynoteUpdateDeferred(
+                        "Treebeard could not safely create '%s' after %s retries"
+                        % (expected_slug, attempt)
+                    ) from exc
 
     @transaction.atomic
     def update_for_judgment(self, judgment, refresh_counts=False):
         """Parse a judgment's flynote and sync its Flynote links.
 
-        1. Deletes all existing ``JudgmentFlynote`` links for this judgment.
-        2. Parses ``judgment.flynote`` into hierarchical paths.
-        3. For each path, walks (or creates) ``Flynote`` nodes from root to leaf.
+        1. Parses ``judgment.flynote`` into hierarchical paths.
+        2. For each path, walks (or creates) ``Flynote`` nodes from root to leaf.
+        3. Replaces existing ``JudgmentFlynote`` links with the rebuilt leaf set.
         4. Links the judgment to the leaf node of every path.
 
         Does nothing if the flynote text cannot be parsed (plain prose, empty, etc.).
@@ -2735,9 +2734,8 @@ class FlynoteUpdater:
             return
         parse_ms = (perf_counter() - parse_start) * 1000
 
-        JudgmentFlynote.objects.filter(document=judgment).delete()
-
         if not paths:
+            JudgmentFlynote.objects.filter(document=judgment).delete()
             log.info(
                 "Linked judgment %s to 0 flynote topics (parse=%.2fms, nodes=0.00ms, links=0.00ms, total=%.2fms).",
                 judgment.pk,
@@ -2749,21 +2747,33 @@ class FlynoteUpdater:
         node_start = perf_counter()
         leaf_flynotes = set()
         roots_to_refresh = set()
-        for path in paths:
-            parent = None
-            root_id = None
-            for index, name in enumerate(path):
-                node = self.get_or_create_node(parent, name)
-                if node is None:
-                    break
-                if index == 0:
-                    root_id = node.pk
-                parent = node
-            else:
-                leaf_flynotes.add(node)
-                if root_id is not None:
-                    roots_to_refresh.add(root_id)
+        try:
+            for path in paths:
+                parent = None
+                root_id = None
+                for index, name in enumerate(path):
+                    node = self.get_or_create_node(parent, name)
+                    if node is None:
+                        break
+                    if index == 0:
+                        root_id = node.pk
+                    parent = node
+                else:
+                    leaf_flynotes.add(node)
+                    if root_id is not None:
+                        roots_to_refresh.add(root_id)
+        except FlynoteUpdateDeferred as exc:
+            log.warning(
+                "Skipping flynote update for judgment %s because tree rebuilding could not be completed safely: %s",
+                judgment.pk,
+                exc,
+                exc_info=True,
+            )
+            transaction.set_rollback(True)
+            return
         node_ms = (perf_counter() - node_start) * 1000
+
+        JudgmentFlynote.objects.filter(document=judgment).delete()
 
         link_start = perf_counter()
         JudgmentFlynote.objects.bulk_create(

--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -32,10 +32,6 @@ from peachjam.tasks import refresh_flynote_document_count
 log = logging.getLogger(__name__)
 
 
-class FlynoteUpdateDeferred(Exception):
-    """Raised when flynote relinking should be retried later."""
-
-
 class FlynoteParser:
     """Parses raw flynote text into structured paths.
 
@@ -2640,11 +2636,13 @@ class FlynoteUpdater:
 
         *parent* is the parent Flynote node, or None for top-level.
 
-        Returns ``None`` if the name produces an empty slug.
+        Returns ``(node, defer_reason)`` where ``defer_reason`` is set when the
+        whole relink should be retried later. ``node`` is ``None`` when the
+        name produces an empty slug and the current path should be skipped.
         """
         normalised = FlynoteParser.normalise_name(name)
         if not normalised:
-            return None
+            return None, None
 
         if parent:
             expected_slug = f"{parent.slug}-{normalised}"
@@ -2653,23 +2651,23 @@ class FlynoteUpdater:
 
         cached = self.node_cache.get(expected_slug)
         if cached is not None:
-            return cached
+            return cached, None
 
         existing = Flynote.objects.filter(slug=expected_slug).first()
         if existing:
             self.node_cache[expected_slug] = existing
-            return existing
+            return existing, None
 
         if not parent:
             try:
                 node = Flynote.add_root(name=name, slug=expected_slug)
                 self.node_cache[expected_slug] = node
-                return node
+                return node, None
             except IntegrityError:
                 existing = Flynote.objects.filter(slug=expected_slug).first()
                 if existing:
                     self.node_cache[expected_slug] = existing
-                return existing
+                return existing, None
 
         for attempt in range(1, 4):
             locked_parent = (
@@ -2679,20 +2677,21 @@ class FlynoteUpdater:
                 .first()
             )
             if not locked_parent:
-                raise FlynoteUpdateDeferred(
+                return (
+                    None,
                     "parent %s no longer exists while creating '%s'"
-                    % (parent.pk, expected_slug)
+                    % (parent.pk, expected_slug),
                 )
 
             try:
                 node = locked_parent.add_child(name=name, slug=expected_slug)
                 self.node_cache[expected_slug] = node
-                return node
+                return node, None
             except IntegrityError:
                 existing = Flynote.objects.filter(slug=expected_slug).first()
                 if existing:
                     self.node_cache[expected_slug] = existing
-                return existing
+                return existing, None
             except AttributeError as exc:
                 if "add_sibling" not in str(exc):
                     raise
@@ -2700,13 +2699,14 @@ class FlynoteUpdater:
                 existing = Flynote.objects.filter(slug=expected_slug).first()
                 if existing:
                     self.node_cache[expected_slug] = existing
-                    return existing
+                    return existing, None
 
                 if attempt == 3:
-                    raise FlynoteUpdateDeferred(
+                    return (
+                        None,
                         "Treebeard could not safely create '%s' after %s retries"
-                        % (expected_slug, attempt)
-                    ) from exc
+                        % (expected_slug, attempt),
+                    )
 
     @transaction.atomic
     def update_for_judgment(self, judgment, refresh_counts=False):
@@ -2747,30 +2747,29 @@ class FlynoteUpdater:
         node_start = perf_counter()
         leaf_flynotes = set()
         roots_to_refresh = set()
-        try:
-            for path in paths:
-                parent = None
-                root_id = None
-                for index, name in enumerate(path):
-                    node = self.get_or_create_node(parent, name)
-                    if node is None:
-                        break
-                    if index == 0:
-                        root_id = node.pk
-                    parent = node
-                else:
-                    leaf_flynotes.add(node)
-                    if root_id is not None:
-                        roots_to_refresh.add(root_id)
-        except FlynoteUpdateDeferred as exc:
-            log.warning(
-                "Skipping flynote update for judgment %s because tree rebuilding could not be completed safely: %s",
-                judgment.pk,
-                exc,
-                exc_info=True,
-            )
-            transaction.set_rollback(True)
-            return
+        for path in paths:
+            parent = None
+            root_id = None
+            for index, name in enumerate(path):
+                node, defer_reason = self.get_or_create_node(parent, name)
+                if defer_reason:
+                    log.warning(
+                        "Skipping flynote update for judgment %s because "
+                        "tree rebuilding could not be completed safely: %s",
+                        judgment.pk,
+                        defer_reason,
+                    )
+                    transaction.set_rollback(True)
+                    return
+                if node is None:
+                    break
+                if index == 0:
+                    root_id = node.pk
+                parent = node
+            else:
+                leaf_flynotes.add(node)
+                if root_id is not None:
+                    roots_to_refresh.add(root_id)
         node_ms = (perf_counter() - node_start) * 1000
 
         JudgmentFlynote.objects.filter(document=judgment).delete()

--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -30,6 +30,7 @@ from peachjam.models.flynote import Flynote, JudgmentFlynote
 from peachjam.tasks import refresh_flynote_document_count
 
 log = logging.getLogger(__name__)
+DEFER_FLYNOTE_UPDATE = object()
 
 
 class FlynoteParser:
@@ -2636,13 +2637,11 @@ class FlynoteUpdater:
 
         *parent* is the parent Flynote node, or None for top-level.
 
-        Returns ``(node, defer_reason)`` where ``defer_reason`` is set when the
-        whole relink should be retried later. ``node`` is ``None`` when the
-        name produces an empty slug and the current path should be skipped.
+        Returns ``None`` if the name produces an empty slug.
         """
         normalised = FlynoteParser.normalise_name(name)
         if not normalised:
-            return None, None
+            return None
 
         if parent:
             expected_slug = f"{parent.slug}-{normalised}"
@@ -2651,23 +2650,23 @@ class FlynoteUpdater:
 
         cached = self.node_cache.get(expected_slug)
         if cached is not None:
-            return cached, None
+            return cached
 
         existing = Flynote.objects.filter(slug=expected_slug).first()
         if existing:
             self.node_cache[expected_slug] = existing
-            return existing, None
+            return existing
 
         if not parent:
             try:
                 node = Flynote.add_root(name=name, slug=expected_slug)
                 self.node_cache[expected_slug] = node
-                return node, None
+                return node
             except IntegrityError:
                 existing = Flynote.objects.filter(slug=expected_slug).first()
                 if existing:
                     self.node_cache[expected_slug] = existing
-                return existing, None
+                return existing
 
         for attempt in range(1, 4):
             locked_parent = (
@@ -2677,21 +2676,22 @@ class FlynoteUpdater:
                 .first()
             )
             if not locked_parent:
-                return (
-                    None,
-                    "parent %s no longer exists while creating '%s'"
-                    % (parent.pk, expected_slug),
+                log.warning(
+                    "Deferring flynote update because parent %s no longer exists while creating '%s'.",
+                    parent.pk,
+                    expected_slug,
                 )
+                return DEFER_FLYNOTE_UPDATE
 
             try:
                 node = locked_parent.add_child(name=name, slug=expected_slug)
                 self.node_cache[expected_slug] = node
-                return node, None
+                return node
             except IntegrityError:
                 existing = Flynote.objects.filter(slug=expected_slug).first()
                 if existing:
                     self.node_cache[expected_slug] = existing
-                return existing, None
+                return existing
             except AttributeError as exc:
                 if "add_sibling" not in str(exc):
                     raise
@@ -2699,14 +2699,15 @@ class FlynoteUpdater:
                 existing = Flynote.objects.filter(slug=expected_slug).first()
                 if existing:
                     self.node_cache[expected_slug] = existing
-                    return existing, None
+                    return existing
 
                 if attempt == 3:
-                    return (
-                        None,
-                        "Treebeard could not safely create '%s' after %s retries"
-                        % (expected_slug, attempt),
+                    log.warning(
+                        "Deferring flynote update because Treebeard could not safely create '%s' after %s retries.",
+                        expected_slug,
+                        attempt,
                     )
+                    return DEFER_FLYNOTE_UPDATE
 
     @transaction.atomic
     def update_for_judgment(self, judgment, refresh_counts=False):
@@ -2751,13 +2752,12 @@ class FlynoteUpdater:
             parent = None
             root_id = None
             for index, name in enumerate(path):
-                node, defer_reason = self.get_or_create_node(parent, name)
-                if defer_reason:
+                node = self.get_or_create_node(parent, name)
+                if node is DEFER_FLYNOTE_UPDATE:
                     log.warning(
                         "Skipping flynote update for judgment %s because "
-                        "tree rebuilding could not be completed safely: %s",
+                        "tree rebuilding could not be completed safely.",
                         judgment.pk,
-                        defer_reason,
                     )
                     transaction.set_rollback(True)
                     return

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1471,6 +1471,41 @@ class UpdateFlynoteForJudgmentTest(TestCase):
             existing_links,
         )
 
+    def test_exhausted_tree_retries_preserve_existing_judgment_links(self):
+        self.judgment.flynote = "Criminal law \u2014 admissibility"
+        self.judgment.save()
+        self.updater.update_for_judgment(self.judgment)
+        existing_links = list(
+            JudgmentFlynote.objects.filter(document=self.judgment).values_list(
+                "flynote__name", flat=True
+            )
+        )
+
+        original_add_child = Flynote.add_child
+
+        def broken_add_child(node, *args, **kwargs):
+            if node.slug == "criminal-law":
+                raise AttributeError("'NoneType' object has no attribute 'add_sibling'")
+            return original_add_child(node, *args, **kwargs)
+
+        self.judgment.flynote = "Criminal law \u2014 sentencing"
+        self.judgment.save()
+
+        with patch.object(
+            Flynote, "add_child", autospec=True, side_effect=broken_add_child
+        ):
+            self.updater.update_for_judgment(self.judgment)
+
+        self.assertEqual(
+            list(
+                JudgmentFlynote.objects.filter(document=self.judgment).values_list(
+                    "flynote__name", flat=True
+                )
+            ),
+            existing_links,
+        )
+        self.assertFalse(Flynote.objects.filter(name="sentencing").exists())
+
 
 class FlynoteDocumentCountTest(TestCase):
     fixtures = ["tests/countries", "tests/courts", "tests/languages"]

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1417,6 +1417,60 @@ class UpdateFlynoteForJudgmentTest(TestCase):
         criminal = Flynote.objects.get(name="Criminal law")
         mock_refresh.assert_called_once_with(criminal.pk, schedule=30 * 60)
 
+    def test_retries_transient_treebeard_child_insert_error(self):
+        criminal = Flynote.add_root(name="Criminal law", slug="criminal-law")
+        original_add_child = Flynote.add_child
+        attempts = {"count": 0}
+
+        def flaky_add_child(node, *args, **kwargs):
+            if node.pk == criminal.pk and attempts["count"] == 0:
+                attempts["count"] += 1
+                raise AttributeError("'NoneType' object has no attribute 'add_sibling'")
+            return original_add_child(node, *args, **kwargs)
+
+        self.judgment.flynote = "Criminal law \u2014 admissibility"
+        self.judgment.save()
+
+        with patch.object(
+            Flynote, "add_child", autospec=True, side_effect=flaky_add_child
+        ):
+            self.updater.update_for_judgment(self.judgment)
+
+        self.assertEqual(attempts["count"], 1)
+        self.assertTrue(Flynote.objects.filter(name="admissibility").exists())
+        self.assertEqual(
+            list(
+                JudgmentFlynote.objects.filter(document=self.judgment).values_list(
+                    "flynote__name", flat=True
+                )
+            ),
+            ["admissibility"],
+        )
+
+    def test_parser_index_error_preserves_existing_judgment_links(self):
+        self.updater.update_for_judgment(self.judgment)
+        existing_links = list(
+            JudgmentFlynote.objects.filter(document=self.judgment).values_list(
+                "flynote__name", flat=True
+            )
+        )
+
+        with patch.object(
+            self.updater.parser,
+            "parse",
+            side_effect=IndexError("list index out of range"),
+        ):
+            self.updater.update_for_judgment(self.judgment)
+
+        self.assertEqual(
+            list(
+                JudgmentFlynote.objects.filter(document=self.judgment).values_list(
+                    "flynote__name", flat=True
+                )
+            ),
+            existing_links,
+        )
+
 
 class FlynoteDocumentCountTest(TestCase):
     fixtures = ["tests/countries", "tests/courts", "tests/languages"]


### PR DESCRIPTION
so in this branch im fixing 2 issues, @longhotsummer  i havent addressed child-first pruning coz this i had already done, so in this i have addressed only the 'NoneType' / 'add_sibling' error, whereby i refetch and lock the parent node before calling add_child() and retry transient tree-state failures instead of crashing immediately and for the second error the update_for_judgment() now parses first and only deletes existing JudgmentFlynote links after parsing succeeds. If parsing raises IndexError, we log the judgment id and a short flynote excerpt, then return early.