### PR TITLE
fix(chat): guard against non-string content in setMessageContent

### DIFF
--- a/peachjam/js/components/chat/DocumentChat.vue
+++ b/peachjam/js/components/chat/DocumentChat.vue
@@ -301,7 +301,7 @@ export default {
       return message;
     },
     setMessageContent (message, content) {
-      message.content = content || '';
+      message.content = typeof content === 'string' ? content : (content != null ? String(content) : '');
       if (message.role === 'ai' && message.content.trim().length > 0) {
         message.content_html = marked.parse(message.content);
       } else {


### PR DESCRIPTION
## Summary

Fixes #3119 — `TypeError: e.content.trim is not a function` crash in DocumentChat.

## Root Cause

`setMessageContent()` assigns `content || ''` to `message.content`, but when the SSE payload delivers a non-string value (object, number, etc.), the fallback `|| ''` doesn't catch it (since objects are truthy). The subsequent `.trim()` call then throws.

## Fix

Coerce `content` to string explicitly: use `typeof` check + `String()` fallback instead of relying on truthiness.

**Changed file:** `peachjam/js/components/chat/DocumentChat.vue` (1 line)