### PR TITLE
allow MNCMatcher to span lines in pdfs

### DIFF
--- a/liiweb/citations.py
+++ b/liiweb/citations.py
@@ -6,7 +6,11 @@ from docpipe.matchers import CitationMatcher, ExtractedMatch
 class MncMatcher(CitationMatcher):
     """Finds references to commonly-formatted MNCS of the form [YYYY] COURT NUM
 
-    example: [2022] ZASCA 126
+    examples:
+
+    - [2022] ZASCA 126
+    - [2022]ZASCA 126
+    - [2022] ZASCA126
     """
 
     country_codes = "|".join(
@@ -17,9 +21,9 @@ class MncMatcher(CitationMatcher):
     )
 
     pattern_re = re.compile(
-        r"\[(?P<year>\d{4})\]\s+(?P<court>("
+        r"\[(?P<year>\d{4})\]\s*(?P<court>("
         + country_codes
-        + r")[A-Z]{1,8})\s+(?P<num>\d+)\b"
+        + r")[A-Z]{1,8})\s*(?P<num>\d+)\b"
     )
     href_pattern = "/akn/{place}/judgment/{court}/{year}/{num}"
     html_candidate_xpath = ".//text()[contains(., '[') and not(ancestor::a)]"

--- a/liiweb/tests/test_mnc_matcher.py
+++ b/liiweb/tests/test_mnc_matcher.py
@@ -71,3 +71,23 @@ class MncMatcherTest(TestCase):
 </div>""",  # noqa
             lxml.html.tostring(html, encoding="unicode", pretty_print=True).strip(),
         )
+
+    def test_text_matches(self):
+        self.marker.extract_text_matches(
+            self.frbr_uri,
+            """
+In other words, what is not pleaded ought not to beconsidered by the trial or appellate court. See Parvis Gulamali
+Fazal v. National Housing Corporation (Civil Appeal No. 166 of 2018) [2021]TZCA 738 (3 December 2021, TanzLII), Maria
+Amandus Kavishe v. Nora Waziri Mzeru and Another (Civil Appeal No. 365 of 2019) [2023] TZCA 31 (20 February 2023,
+TanzLII) and Charles Richard Kombe t/a Building v. Eva rani Mtungi (Civil Appeal No. 38 of 2012) [2017] TZCA153 (24
+March 2017, TanzLII) to mention a few
+        """,
+        )
+        self.assertEqual(
+            [
+                ("[2021]TZCA 738", "/akn/tz/judgment/tzca/2021/738"),
+                ("[2023] TZCA 31", "/akn/tz/judgment/tzca/2023/31"),
+                ("[2017] TZCA153", "/akn/tz/judgment/tzca/2017/153"),
+            ],
+            [(c.text, c.href) for c in self.marker.citations],
+        )


### PR DESCRIPTION
this handles citations that cross lines and so don't have whitespace in their extracted text.

<img width="1352" height="826" alt="image" src="https://github.com/user-attachments/assets/8a86b8f7-b23a-4a51-89df-9e6a0795132e" />
