### PR TITLE
Fixed the issue of skip to document where unnecessary

### DIFF
--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -201,9 +201,7 @@ a:visited:not(.btn, .nav-link, .dropdown-item) {
   left: -501px;
 }
 .skip-links a:focus,
-.skip-links a:focus-visible {
-  position: absolute;
-  top: 0;
+.skip-links a:focus {
   left: 0;
   z-index: 1080;
 }

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -200,7 +200,12 @@ a:visited:not(.btn, .nav-link, .dropdown-item) {
   position: absolute;
   left: -501px;
 }
-.skip-links a:focus {
+.skip-links a:visited {
+  color: var(--bs-link-color);
+}
+.skip-links a:focus,
+.skip-links a:focus-visible {
+  position: absolute;
   top: 0;
   left: 0;
   z-index: 1080;

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -200,7 +200,7 @@ a:visited:not(.btn, .nav-link, .dropdown-item) {
   position: absolute;
   left: -501px;
 }
-.skip-links a:focus,
+
 .skip-links a:focus {
   left: 0;
   z-index: 1080;

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -201,7 +201,9 @@ a:visited:not(.btn, .nav-link, .dropdown-item) {
   left: -501px;
 }
 .skip-links a:focus {
-  left: -1px;
+  top: 0;
+  left: 0;
+  z-index: 1080;
 }
 
 .breadcrumb {

--- a/peachjam/static/stylesheets/_global.scss
+++ b/peachjam/static/stylesheets/_global.scss
@@ -200,9 +200,6 @@ a:visited:not(.btn, .nav-link, .dropdown-item) {
   position: absolute;
   left: -501px;
 }
-.skip-links a:visited {
-  color: var(--bs-link-color);
-}
 .skip-links a:focus,
 .skip-links a:focus-visible {
   position: absolute;

--- a/peachjam/templates/peachjam/_document_content_sidebar.html
+++ b/peachjam/templates/peachjam/_document_content_sidebar.html
@@ -4,7 +4,8 @@ contents of #navigation-content will be placed in [data-offcanvas-body] for tabl
 and #navigation-column for desktop screensize.
 -->
 <div class="skip-links">
-  <a href="#document-content">{% trans 'Skip to document content' %}</a>
+  <a class="visually-hidden-focusable bg-white p-2"
+     href="#document-content">{% trans 'Skip to document content' %}</a>
 </div>
 <div id="navigation-content" class="d-none">
   <div class="navigation__inner">

--- a/peachjam/templates/peachjam/_document_content_sidebar.html
+++ b/peachjam/templates/peachjam/_document_content_sidebar.html
@@ -4,8 +4,7 @@ contents of #navigation-content will be placed in [data-offcanvas-body] for tabl
 and #navigation-column for desktop screensize.
 -->
 <div class="skip-links">
-  <a class="visually-hidden-focusable bg-white p-2"
-     href="#document-content">{% trans 'Skip to document content' %}</a>
+  <a href="#document-content">{% trans 'Skip to document content' %}</a>
 </div>
 <div id="navigation-content" class="d-none">
   <div class="navigation__inner">

--- a/peachjam/templates/peachjam/_header.html
+++ b/peachjam/templates/peachjam/_header.html
@@ -3,10 +3,10 @@
   {% block skip-links %}
     <div class="skip-links">
       {% if 'akn/' in request.path %}
-        <a href="#document-content">{% trans 'Skip to document content' %}</a>
+        <a class="bg-white" href="#document-content">{% trans 'Skip to document content' %}</a>
       {% endif %}
-      <a href="#main-nav">{% trans 'Skip to main menu' %}</a>
-      <a href="#header-search">{% trans 'Skip to search' %}</a>
+      <a class="bg-white" href="#main-nav">{% trans 'Skip to main menu' %}</a>
+      <a class="bg-white" href="#header-search">{% trans 'Skip to search' %}</a>
     </div>
   {% endblock %}
   {% block top-bar %}<div>Top bar content</div>{% endblock %}

--- a/peachjam/templates/peachjam/_header.html
+++ b/peachjam/templates/peachjam/_header.html
@@ -2,10 +2,12 @@
 <header>
   {% block skip-links %}
     <div class="skip-links">
-      <a class="bg-white"
-         href="{% if 'akn/' in request.path %}#document-content{% else %}#top{% endif %}">{% trans 'Skip to document content' %}</a>
-      <a class="bg-white" href="#main-nav">{% trans 'Skip to main menu' %}</a>
-      <a class="bg-white" href="#header-search">{% trans 'Skip to search' %}</a>
+      {% if 'akn/' in request.path %}
+        <a class="visually-hidden-focusable bg-white p-2"
+           href="#document-content">{% trans 'Skip to document content' %}</a>
+      {% endif %}
+      <a class="visually-hidden-focusable bg-white p-2" href="#main-nav">{% trans 'Skip to main menu' %}</a>
+      <a class="visually-hidden-focusable bg-white p-2" href="#header-search">{% trans 'Skip to search' %}</a>
     </div>
   {% endblock %}
   {% block top-bar %}<div>Top bar content</div>{% endblock %}

--- a/peachjam/templates/peachjam/_header.html
+++ b/peachjam/templates/peachjam/_header.html
@@ -3,11 +3,10 @@
   {% block skip-links %}
     <div class="skip-links">
       {% if 'akn/' in request.path %}
-        <a class="visually-hidden-focusable bg-white p-2"
-           href="#document-content">{% trans 'Skip to document content' %}</a>
+        <a href="#document-content">{% trans 'Skip to document content' %}</a>
       {% endif %}
-      <a class="visually-hidden-focusable bg-white p-2" href="#main-nav">{% trans 'Skip to main menu' %}</a>
-      <a class="visually-hidden-focusable bg-white p-2" href="#header-search">{% trans 'Skip to search' %}</a>
+      <a href="#main-nav">{% trans 'Skip to main menu' %}</a>
+      <a href="#header-search">{% trans 'Skip to search' %}</a>
     </div>
   {% endblock %}
   {% block top-bar %}<div>Top bar content</div>{% endblock %}

--- a/peachjam/tests/test_document_detail.py
+++ b/peachjam/tests/test_document_detail.py
@@ -21,6 +21,8 @@ class DocumentViewTestCase(WebTest):
         doc = Judgment.objects.first()
         response = self.app.get(doc.get_absolute_url())
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="#document-content"', html=False)
+        self.assertContains(response, "Skip to document content")
         self.assertContains(
             response,
             '<script id="citation-links" type="application/json">[]</script>',

--- a/peachjam/tests/test_views.py
+++ b/peachjam/tests/test_views.py
@@ -59,6 +59,9 @@ class PeachjamViewsTest(TestCase):
     def test_homepage(self):
         response = self.client.get(reverse("home_page"))
         self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Skip to document content")
+        self.assertContains(response, "Skip to main menu")
+        self.assertContains(response, "Skip to search")
 
         recent_judgments = [
             r_j.title for r_j in response.context.get("recent_judgments")


### PR DESCRIPTION
#3144 
In this Pr i have addressed WCAG issue and a bug, so the WCAG  issue is the skip links were not visible at all they were not visible at all especially when you zoom to 200 so i have fixed it to bivisible as below.
https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html
https://www.w3.org/TR/WCAG22/#resize-text
for the bug was that we were showing skip to document evn on the pages where we have no documents, you find it appearing to all pages


Before:
<img width="1447" height="689" alt="Screenshot 2026-04-21 at 8 09 13 PM" src="https://github.com/user-attachments/assets/d22cb61a-2351-48db-8a17-f3efa704c6a6" />
<img width="1479" height="744" alt="Screenshot 2026-04-21 at 8 09 50 PM" src="https://github.com/user-attachments/assets/1c10635d-3da1-403f-9533-698abc2f4cbd" />


After:

<img width="1475" height="738" alt="Screenshot 2026-04-21 at 8 10 14 PM" src="https://github.com/user-attachments/assets/a67d53cd-7b43-49de-a549-f5e9502c65eb" />
<img width="1483" height="673" alt="Screenshot 2026-04-21 at 8 10 33 PM" src="https://github.com/user-attachments/assets/7a1955ff-7ef5-42e7-8f84-0d998f37590f" />
