### PR TITLE
handling target blank links

### DIFF
--- a/africanlii/templates/africanlii/_lii_info.html
+++ b/africanlii/templates/africanlii/_lii_info.html
@@ -7,7 +7,7 @@
       {% endblocktrans %}
     </div>
     <div>
-      <a href="{{ lii.url }}" target="_blank">{{ lii.domain }}</a>
+      <a href="{{ lii.url }}">{{ lii.domain }}</a>
     </div>
   {% endif %}
 {% endfor %}

--- a/africanlii/templates/africanlii/au_detail_page.html
+++ b/africanlii/templates/africanlii/au_detail_page.html
@@ -28,7 +28,7 @@
       </p>
       <p>
         {%blocktrans trimmed %}
-        For more information, visit the <a href="https://au.int/" target="_blank" rel="noreferrer noopener">official African Union website</a> and the <a href="https://au.int/agenda2063/overview">Agenda 2063 portal.</a>
+        For more information, visit the <a href="https://au.int/" target="_blank" rel="noreferrer noopener">official African Union website<span class="visually-hidden">opens in new tab</span></a> and the <a href="https://au.int/agenda2063/overview">Agenda 2063 portal.</a>
         {% endblocktrans %}
       </p>
     </div>
@@ -99,8 +99,7 @@
                    alt="{{ member_state.name }}"
                    class="mb-3"/>
               <h5 class="card-title">
-                <a href="{% url 'member_state_detail_view' member_state.country.iso %}"
-                   target="_blank">{{ member_state.country }}</a>
+                <a href="{% url 'member_state_detail_view' member_state.country.iso %}">{{ member_state.country }}</a>
               </h5>
               {% include 'africanlii/_lii_info.html' %}
             </div>

--- a/africanlii/templates/peachjam/_footer.html
+++ b/africanlii/templates/peachjam/_footer.html
@@ -8,7 +8,7 @@
       AfricanLII is an open-access research platform for African law jointly operated by the AfricanLII programme of
       the University of Cape Town and Laws.Africa. AfricanLII publishes the law and policy of the African Union and
       federates search across all open access African national law available through the
-      <a class="text-primary" href="https://www.openlawafrica.org/" target="_blank" rel="noreferrer">Open Law Africa</a>
+      <a class="text-primary" href="https://www.openlawafrica.org/" target="_blank" rel="noreferrer">Open Law Africa<span class="visually-hidden">opens in new tab</span></a>
       community of LIIs.
     {% endblocktrans %}
   </p>
@@ -16,7 +16,7 @@
     {% blocktrans trimmed %}
       The publication of the African Union material is co-sponsored by the European Union and is part of the
       <a class="text-primary" href="https://dataforgovernance.africa/" target="_blank" rel="noreferrer">Data for
-        Governance Alliance project</a>.
+        Governance Alliance project<span class="visually-hidden">opens in new tab</span></a>.
     {% endblocktrans %}
   </p>
   <div>
@@ -35,18 +35,26 @@
   <div>
     <a href="https://www.sigrid-rausing-trust.org/"
        target="_blank"
-       rel="noreferrer">Sigrid Rausing Trust</a>
+       rel="noreferrer">Sigrid Rausing Trust
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://indigotrust.org.uk/" target="_blank" rel="noreferrer">Indigo Trust</a>
+    <a href="https://indigotrust.org.uk/" target="_blank" rel="noreferrer">Indigo Trust
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://www.eeas.europa.eu/" target="_blank" rel="noreferrer">{% trans 'European Union' %}</a>
+    <a href="https://www.eeas.europa.eu/" target="_blank" rel="noreferrer">{% trans 'European Union' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://www.openlawafrica.org/"
        target="_blank"
-       rel="noreferrer">{% trans 'Open Law Africa' %}</a>
+       rel="noreferrer">{% trans 'Open Law Africa' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block third-content-column %}
@@ -54,64 +62,104 @@
     <strong>{% trans 'Other African Legal Information Institutions' %}</strong>
   </div>
   <div>
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://ghalii.org/" target="_blank" rel="noreferrer">GhaLII</a>
+    <a href="https://ghalii.org/" target="_blank" rel="noreferrer">GhaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="http://kenyalaw.org/" target="_blank" rel="noreferrer">Kenya Law</a>
+    <a href="http://kenyalaw.org/" target="_blank" rel="noreferrer">Kenya Law
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://lawlibrary.org.za/" target="_blank" rel="noreferrer">LawLibrary ZA</a>
+    <a href="https://lawlibrary.org.za/" target="_blank" rel="noreferrer">LawLibrary ZA
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://lesotholii.org/" target="_blank" rel="noreferrer">LesothoLII</a>
+    <a href="https://lesotholii.org/" target="_blank" rel="noreferrer">LesothoLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="http://liberlii.org/" target="_blank" rel="noreferrer">LiberLII</a>
+    <a href="http://liberlii.org/" target="_blank" rel="noreferrer">LiberLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://malawilii.org/" target="_blank" rel="noreferrer">MalawiLII</a>
+    <a href="https://malawilii.org/" target="_blank" rel="noreferrer">MalawiLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://mauritiuslii.org/" target="_blank" rel="noreferrer">MauritiusLII</a>
+    <a href="https://mauritiuslii.org/" target="_blank" rel="noreferrer">MauritiusLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://namiblii.org/" target="_blank" rel="noreferrer">NamibLII</a>
+    <a href="https://namiblii.org/" target="_blank" rel="noreferrer">NamibLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://nigerialii.org/" target="_blank" rel="noreferrer">NigeriaLII</a>
+    <a href="https://nigerialii.org/" target="_blank" rel="noreferrer">NigeriaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://openbylaws.org.za/" target="_blank" rel="noreferrer">OpenbyLaws ZA</a>
+    <a href="https://openbylaws.org.za/" target="_blank" rel="noreferrer">OpenbyLaws ZA
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://rwandalii.org/" target="_blank" rel="noreferrer">RwandaLII</a>
+    <a href="https://rwandalii.org/" target="_blank" rel="noreferrer">RwandaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://seylii.org/" target="_blank" rel="noreferrer">SeyLII</a>
+    <a href="https://seylii.org/" target="_blank" rel="noreferrer">SeyLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://sierralii.org/" target="_blank" rel="noreferrer">SieraLII</a>
+    <a href="https://sierralii.org/" target="_blank" rel="noreferrer">SieraLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://eswatinilii.org/" target="_blank" rel="noreferrer">eSwatiniLII</a>
+    <a href="https://eswatinilii.org/" target="_blank" rel="noreferrer">eSwatiniLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://tanzlii.org/" target="_blank" rel="noreferrer">TanzLII</a>
+    <a href="https://tanzlii.org/" target="_blank" rel="noreferrer">TanzLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://ulii.org/" target="_blank" rel="noreferrer">UgandaLII</a>
+    <a href="https://ulii.org/" target="_blank" rel="noreferrer">UgandaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://zambialii.org/" target="_blank" rel="noreferrer">ZambiaLII</a>
+    <a href="https://zambialii.org/" target="_blank" rel="noreferrer">ZambiaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://zanzibarlii.org/" target="_blank" rel="noreferrer">ZanzibarLII</a>
+    <a href="https://zanzibarlii.org/" target="_blank" rel="noreferrer">ZanzibarLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://zimlii.org/" target="_blank" rel="noreferrer">ZimLII</a>
+    <a href="https://zimlii.org/" target="_blank" rel="noreferrer">ZimLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block footer-logos %}
@@ -122,6 +170,7 @@
        rel="noreferrer">
       <img src="{% static 'images/uct-logo.svg' %}"
            alt="{% trans 'University of Cape Town' %}"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://laws.africa/"
@@ -129,12 +178,14 @@
        rel="noreferrer">
       <img src="{% static 'images/laws-africa-logo-horizontal-white.png' %}"
            alt="Laws.Africa"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://www.indigotrust.org.uk/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/indigo-trust-logo.jpg' %}" alt="Indigo Trust"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://european-union.europa.eu/select-language?destination=/node/1"
@@ -142,12 +193,14 @@
        rel="noreferrer">
       <img src="{% static 'images/eu_logo.jpg' %}"
            alt="{% trans 'European Union' %}"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://www.sigrid-rausing-trust.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/srt-logo.jpg' %}" alt="Sigrid Rausing Trust"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://www.giz.de/de"
@@ -155,6 +208,7 @@
        rel="noreferrer">
       <img src="{% static 'images/cooperation-logo-ger-ger-giz.jpg' %}"
            alt="{% trans 'GIZ' %}"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://www.openlawafrica.org/"
@@ -162,6 +216,7 @@
        rel="noreferrer">
       <img src="{% static 'images/open-law-africa-inverted.png' %}"
            alt="{% trans 'Open Law Africa' %}"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
   </div>
 {% endblock %}

--- a/africanlii/templates/peachjam/_header.html
+++ b/africanlii/templates/peachjam/_header.html
@@ -10,6 +10,7 @@
         <img class="top-bar-logo d4ga-logo"
              src="{% static 'images/cso-agp-logo-horizontal.png' %}"
              alt="Data for Governance Alliance"/>
+        {% include 'peachjam/_opens_in_new_tab.html' %}
       </a>
       <a href="https://www.openlawafrica.org/"
          target="_blank"
@@ -17,6 +18,7 @@
         <img class="top-bar-logo ola-logo"
              src="{% static 'images/open-law-africa-inverted.png' %}"
              alt="{% trans 'Open Law Africa' %}"/>
+        {% include 'peachjam/_opens_in_new_tab.html' %}
       </a>
     </div>
   </div>
@@ -135,6 +137,8 @@
     </a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="https://docs.africanlii.org/" target="_blank">{% trans 'Help' %}</a>
+    <a class="nav-link" href="https://docs.africanlii.org/" target="_blank">{% trans 'Help' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </li>
 {% endblock %}

--- a/africanlii/templates/peachjam/about.html
+++ b/africanlii/templates/peachjam/about.html
@@ -40,44 +40,44 @@
   </ul>
   <p>
     {% blocktrans trimmed %}
-      This platform is developed and maintained jointly by <a href="https://africanlii.org/" target="_blank">AfricanLII</a> and
-      <a href="https://laws.africa/" target="_blank">Laws.Africa</a> with funds from the European Union,
+      This platform is developed and maintained jointly by <a href="https://africanlii.org/" target="_blank">AfricanLII<span class="visually-hidden">opens in new tab</span></a> and
+      <a href="https://laws.africa/" target="_blank">Laws.Africa<span class="visually-hidden">opens in new tab</span></a> with funds from the European Union,
       the Indigo Trust and the Sigrid Rausing Trust. The initial phase of the project runs from 2021 to 2024.
     {% endblocktrans %}
   </p>
   <h2 class="mb-4">{% trans 'Platform developers' %}</h2>
   <p>
     {% blocktrans trimmed %}
-      <a href="https://africanlii.org/" target="_blank">AfricanLII</a> is a programme of the Democratic Governance and Rights Unit at the Department of Public Law, University
-      of Cape Town. <a href="https://africanlii.org/" target="_blank">AfricanLII</a> helps governments, academia and non-profit organisations publish the law of African
-      countries for sustainable open access. <a href="https://africanlii.org/" target="_blank">AfricanLII</a> hosts curated collections on various subjects of African law,
+      <a href="https://africanlii.org/" target="_blank">AfricanLII<span class="visually-hidden">opens in new tab</span></a> is a programme of the Democratic Governance and Rights Unit at the Department of Public Law, University
+      of Cape Town. <a href="https://africanlii.org/" target="_blank">AfricanLII<span class="visually-hidden">opens in new tab</span></a> helps governments, academia and non-profit organisations publish the law of African
+      countries for sustainable open access. <a href="https://africanlii.org/" target="_blank">AfricanLII<span class="visually-hidden">opens in new tab</span></a> hosts curated collections on various subjects of African law,
       such as human rights, the environment, commercial law and finance.
     {% endblocktrans %}
   </p>
   <p>
     {% blocktrans trimmed %}
-      <a href="https://africanlii.org/" target="_blank">AfricanLII</a> convenes a network of 16 African LIIs - a collaborative group of governments, organizations, and
+      <a href="https://africanlii.org/" target="_blank">AfricanLII<span class="visually-hidden">opens in new tab</span></a> convenes a network of 16 African LIIs - a collaborative group of governments, organizations, and
       individuals in Africa, dedicated to free access to law on our continent.
     {% endblocktrans %}
   </p>
   <p>
     {% blocktrans trimmed %}
-      <a href="https://laws.africa/" target="_blank">Laws.Africa</a> helps African governments to sustainably digitise their legal information for public use, through open
-      law software, capacity-building, training, partnerships and support. <a href="https://laws.africa/" target="_blank">Laws.Africa’s</a> Open Law Technology solutions
+      <a href="https://laws.africa/" target="_blank">Laws.Africa<span class="visually-hidden">opens in new tab</span></a> helps African governments to sustainably digitise their legal information for public use, through open
+      law software, capacity-building, training, partnerships and support. <a href="https://laws.africa/" target="_blank">Laws.Africa’s<span class="visually-hidden">opens in new tab</span></a> Open Law Technology solutions
       lower the cost of digitisation, archival and publication of primary legal information, and create opportunities for
       rich interactivity, advanced research and justice sector innovation.
     {% endblocktrans %}
   </p>
   <p class="mb-4">
     {% blocktrans trimmed %}
-      <a href="https://africanlii.org/" target="_blank">AfricanLII</a> and <a href="https://laws.africa/" target="_blank">Laws.Africa</a> collaborate in unlocking the value of African digital legal information in support
+      <a href="https://africanlii.org/" target="_blank">AfricanLII<span class="visually-hidden">opens in new tab</span></a> and <a href="https://laws.africa/" target="_blank">Laws.Africa<span class="visually-hidden">opens in new tab</span></a> collaborate in unlocking the value of African digital legal information in support
       of the rule of law, access to justice, and innovation.
     {% endblocktrans %}
   </p>
   <h2 class="mb-4">{% trans 'Find out more' %}</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-      Visit <a href="https://openlawafrica.org/" target="_blank">openlawafrica.org</a>
+      Visit <a href="https://openlawafrica.org/" target="_blank">openlawafrica.org<span class="visually-hidden">opens in new tab</span></a>
       or contact us on <a href="mailto:info@laws.africa">info@laws.africa</a> for more information.
     {% endblocktrans %}
   </p>
@@ -90,6 +90,7 @@
         <img src="{% static 'images/laws-africa-logo.png' %}"
              height="140px"
              alt="Laws.Africa logo"/>
+        {% include 'peachjam/_opens_in_new_tab.html' %}
       </a>
     </div>
     <div class="col-md-3 mt-3 text-center">
@@ -97,6 +98,7 @@
         <img src="{% static 'images/africanlii-logo.svg' %}"
              height="140px"
              alt="AfricanLII logo"/>
+        {% include 'peachjam/_opens_in_new_tab.html' %}
       </a>
     </div>
   </div>

--- a/africanlii/templates/peachjam/home.html
+++ b/africanlii/templates/peachjam/home.html
@@ -188,7 +188,7 @@
                 <div>
                   {{ lii.name }}
                 </div>
-                <a href="{{ lii.url }}" class="stretched-link" target="_blank">{{ lii.domain }}</a>
+                <a href="{{ lii.url }}" class="stretched-link">{{ lii.domain }}</a>
               </div>
             </div>
           </div>

--- a/civlii/templates/peachjam/about.html
+++ b/civlii/templates/peachjam/about.html
@@ -9,8 +9,8 @@
   <h2 class="mb-4">AfricanLII</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer noopener">AfricanLII</a> is a part of the
-    <a href="http://www.dgru.uct.ac.za/" target="_blank" rel="noreferrer noopener">Democratic
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer noopener">AfricanLII<span class="visually-hidden">opens in new tab</span></a> is a part of the
+    <a href="http://www.dgru.uct.ac.za/" target="_blank" rel="noreferrer noopener">Democratic<span class="visually-hidden">opens in new tab</span>
       Governance and Rights Unit</a> at the Faculty of Law, University of Cape Town
     (UCT), South Africa. AfricanLII helps individuals, organizations, and governments build and maintain sustainable
     free access to law portals, and reach the people of Africa and beyond.
@@ -19,7 +19,7 @@
   <h2 class="mb-4">Laws.Africa</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-    <a href="https://laws.africa/" target="_blank" rel="noreferrer noopener">Laws.Africa</a> is a South Africa
+    <a href="https://laws.africa/" target="_blank" rel="noreferrer noopener">Laws.Africa<span class="visually-hidden">opens in new tab</span></a> is a South Africa
     non-profit organisation that digitises African legal information for public use.
     Open access to digital African legal information helps communities to thrive, businesses to succeed, and judicial
     officers and civil servants to deliver services efficiently and effectively.

--- a/gazettes/templates/peachjam/_footer.html
+++ b/gazettes/templates/peachjam/_footer.html
@@ -8,71 +8,75 @@
             <a href="{% url 'home_page' %}">Gazettes.Africa</a>
           </h6>
           <p>
-            Gazettes.Africa is a project of <a href="https://laws.africa/" target="_blank">Laws.Africa</a>
-            and <a href="https://africanlii.org/" target="_blank">AfricanLII</a>.
-          </p>
-          <p>
-            <span class="me-2">🔥</span>
-            A fire destroyed hundreds of thousands of African gazettes. We're asking librarians and funders to help preserve Gazettes before more are lost.
-          </p>
-          <p>
-            <a href="https://drive.google.com/file/d/1XPTFNkQh5ytpTQoutx4GEU5wNV4fqWbl/view"
-               class="btn btn-primary btn-sm d-block d-md-inline">How you can help</a>
-          </p>
-          <p>
-            We welcome donations of gazette collections. We will scan and digitise gazettes for free. Please <a href="mailto:info@laws.africa">get in touch</a> to donate gazettes.
-          </p>
-          <img src="{% static 'images/logo.png' %}"
-               alt="Gazettes.Africa logo"
-               width="200"/>
-        </div>
-        <div class="col-md-3 mb-3">
-          <h6>National Gazettes</h6>
-          <ul class="list-unstyled">
-            {% for juri in jurisdictions %}
-              {% if not juri.parent_code %}
-                <li>
-                  <a href="{% url 'jurisdiction' juri.code %}">{{ juri.name }}</a>
-                </li>
-              {% endif %}
-            {% endfor %}
-          </ul>
-        </div>
-        <div class="col-md-3 mb-3">
-          <h6>Contact Us</h6>
-          <ul class="list-unstyled">
+            Gazettes.Africa is a project of <a href="https://laws.africa/" target="_blank">Laws.Africa
+            {% include 'peachjam/_opens_in_new_tab.html' %}
+          </a>
+          and <a href="https://africanlii.org/" target="_blank">AfricanLII
+          {% include 'peachjam/_opens_in_new_tab.html' %}
+        </a>.
+      </p>
+      <p>
+        <span class="me-2">🔥</span>
+        A fire destroyed hundreds of thousands of African gazettes. We're asking librarians and funders to help preserve Gazettes before more are lost.
+      </p>
+      <p>
+        <a href="https://drive.google.com/file/d/1XPTFNkQh5ytpTQoutx4GEU5wNV4fqWbl/view"
+           class="btn btn-primary btn-sm d-block d-md-inline">How you can help</a>
+      </p>
+      <p>
+        We welcome donations of gazette collections. We will scan and digitise gazettes for free. Please <a href="mailto:info@laws.africa">get in touch</a> to donate gazettes.
+      </p>
+      <img src="{% static 'images/logo.png' %}"
+           alt="Gazettes.Africa logo"
+           width="200"/>
+    </div>
+    <div class="col-md-3 mb-3">
+      <h6>National Gazettes</h6>
+      <ul class="list-unstyled">
+        {% for juri in jurisdictions %}
+          {% if not juri.parent_code %}
             <li>
-              <a href="mailto:info@laws.africa">info@laws.africa</a>
+              <a href="{% url 'jurisdiction' juri.code %}">{{ juri.name }}</a>
             </li>
-          </ul>
-        </div>
-      </div>
-      <hr class="my-3"/>
-      <div class="row">
-        <div class="col-lg-6">
-          <p>
-            <small><a href="https://laws.africa">Laws.Africa</a> is a non-profit organisation registered with the South African Department of Social Development, registration number 216-824 NPO.</small>
-          </p>
-          <p>
-            <small><a href="https://africanlii.org">AfricanLII</a> is a programme of the Democratic Governance and Rights Unit (DGRU) at the University of Cape Town.</small>
-          </p>
-        </div>
-        <div class="col-lg-3 mt-3 text-center">
-          <a href="https://laws.africa">
-            <img src="{% static 'img/lawsafrica-logo.png' %}"
-                 style="max-width: 200px"
-                 alt="Laws.Africa logo"/>
-          </a>
-        </div>
-        <div class="col-lg-3 mt-3 text-center">
-          <a href="https://africanlii.org">
-            <img src="{% static 'img/africanlii-logo.svg' %}"
-                 style="max-width: 200px"
-                 alt="AfricanLII logo"/>
-          </a>
-        </div>
-      </div>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="col-md-3 mb-3">
+      <h6>Contact Us</h6>
+      <ul class="list-unstyled">
+        <li>
+          <a href="mailto:info@laws.africa">info@laws.africa</a>
+        </li>
+      </ul>
     </div>
   </div>
-  <div class="site-footer__bottom-redline"></div>
+  <hr class="my-3"/>
+  <div class="row">
+    <div class="col-lg-6">
+      <p>
+        <small><a href="https://laws.africa">Laws.Africa</a> is a non-profit organisation registered with the South African Department of Social Development, registration number 216-824 NPO.</small>
+      </p>
+      <p>
+        <small><a href="https://africanlii.org">AfricanLII</a> is a programme of the Democratic Governance and Rights Unit (DGRU) at the University of Cape Town.</small>
+      </p>
+    </div>
+    <div class="col-lg-3 mt-3 text-center">
+      <a href="https://laws.africa">
+        <img src="{% static 'img/lawsafrica-logo.png' %}"
+             style="max-width: 200px"
+             alt="Laws.Africa logo"/>
+      </a>
+    </div>
+    <div class="col-lg-3 mt-3 text-center">
+      <a href="https://africanlii.org">
+        <img src="{% static 'img/africanlii-logo.svg' %}"
+             style="max-width: 200px"
+             alt="AfricanLII logo"/>
+      </a>
+    </div>
+  </div>
+</div>
+</div>
+<div class="site-footer__bottom-redline"></div>
 </footer>

--- a/liiweb/templates/peachjam/_footer.html
+++ b/liiweb/templates/peachjam/_footer.html
@@ -39,73 +39,117 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
+    <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block third-content-column %}
   <h5>{% trans 'Other African Legal Information Institutions' %}</h5>
   <div>
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://ghalii.org/" target="_blank" rel="noreferrer">GhaLII</a>
+    <a href="https://ghalii.org/" target="_blank" rel="noreferrer">GhaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="http://kenyalaw.org/" target="_blank" rel="noreferrer">Kenya Law</a>
+    <a href="http://kenyalaw.org/" target="_blank" rel="noreferrer">Kenya Law
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://lawlibrary.org.za/" target="_blank" rel="noreferrer">LawLibrary ZA</a>
+    <a href="https://lawlibrary.org.za/" target="_blank" rel="noreferrer">LawLibrary ZA
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://lesotholii.org/" target="_blank" rel="noreferrer">LesothoLII</a>
+    <a href="https://lesotholii.org/" target="_blank" rel="noreferrer">LesothoLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="http://liberlii.org/" target="_blank" rel="noreferrer">LiberLII</a>
+    <a href="http://liberlii.org/" target="_blank" rel="noreferrer">LiberLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://malawilii.org/" target="_blank" rel="noreferrer">MalawiLII</a>
+    <a href="https://malawilii.org/" target="_blank" rel="noreferrer">MalawiLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://mauritiuslii.org/" target="_blank" rel="noreferrer">MauritiusLII</a>
+    <a href="https://mauritiuslii.org/" target="_blank" rel="noreferrer">MauritiusLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://namiblii.org/" target="_blank" rel="noreferrer">NamibLII</a>
+    <a href="https://namiblii.org/" target="_blank" rel="noreferrer">NamibLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://nigerialii.org/" target="_blank" rel="noreferrer">NigeriaLII</a>
+    <a href="https://nigerialii.org/" target="_blank" rel="noreferrer">NigeriaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://openbylaws.org.za/" target="_blank" rel="noreferrer">OpenbyLaws ZA</a>
+    <a href="https://openbylaws.org.za/" target="_blank" rel="noreferrer">OpenbyLaws ZA
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://rwandalii.org/" target="_blank" rel="noreferrer">RwandaLII</a>
+    <a href="https://rwandalii.org/" target="_blank" rel="noreferrer">RwandaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://seylii.org/" target="_blank" rel="noreferrer">SeyLII</a>
+    <a href="https://seylii.org/" target="_blank" rel="noreferrer">SeyLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://sierralii.org/" target="_blank" rel="noreferrer">SieraLII</a>
+    <a href="https://sierralii.org/" target="_blank" rel="noreferrer">SieraLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://eswatinilii.org/" target="_blank" rel="noreferrer">eSwatiniLII</a>
+    <a href="https://eswatinilii.org/" target="_blank" rel="noreferrer">eSwatiniLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://tanzlii.org/" target="_blank" rel="noreferrer">TanzLII</a>
+    <a href="https://tanzlii.org/" target="_blank" rel="noreferrer">TanzLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://ulii.org/" target="_blank" rel="noreferrer">UgandaLII</a>
+    <a href="https://ulii.org/" target="_blank" rel="noreferrer">UgandaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://zambialii.org/" target="_blank" rel="noreferrer">ZambiaLII</a>
+    <a href="https://zambialii.org/" target="_blank" rel="noreferrer">ZambiaLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://zanzibarlii.org/" target="_blank" rel="noreferrer">ZanzibarLII</a>
+    <a href="https://zanzibarlii.org/" target="_blank" rel="noreferrer">ZanzibarLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://zimlii.org/" target="_blank" rel="noreferrer">ZimLII</a>
+    <a href="https://zimlii.org/" target="_blank" rel="noreferrer">ZimLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block footer-logos %}
@@ -115,12 +159,14 @@
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/laws-africa-logo.png' %}" alt="Laws.Africa"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
   </div>
 {% endblock %}

--- a/malawilii/templates/peachjam/_footer.html
+++ b/malawilii/templates/peachjam/_footer.html
@@ -10,24 +10,34 @@
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://namati.org/network/organization/the-gender-and-justice-unit/"
        target="_blank"
-       rel="noreferrer">Gender and Justice Unit</a>
+       rel="noreferrer">Gender and Justice Unit
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
+    <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <h6 class="mt-4">{% trans 'With support from' %}</h6>
   <div>
-    <a href="https://www.ned.org/" target="_blank" rel="noreferrer">{% trans 'National Endowment for Democracy' %}</a>
+    <a href="https://www.ned.org/" target="_blank" rel="noreferrer">{% trans 'National Endowment for Democracy' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://www.indigotrust.org.uk/"
        target="_blank"
-       rel="noreferrer">{% trans 'The Indigo Trust' %}</a>
+       rel="noreferrer">{% trans 'The Indigo Trust' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block footer-logos %}
@@ -37,24 +47,28 @@
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/ned-logo.png' %}" alt="NED logo" />
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://laws.africa/"
        target="_blank"
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/laws-africa-logo.png' %}" alt="Laws.Africa"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://namati.org/network/organization/the-gender-and-justice-unit/"
        target="_blank"
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/gju.jpg' %}" alt="Gender and Justice Unit" />
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://macdonaldanddon.com/"
        target="_blank"
@@ -62,6 +76,7 @@
        class="footer-logos__item">
       <img src="{% static 'images/macdonald.png' %}"
            alt="Gender and Justice Unit"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://www.indigotrust.org.uk/"
        target="_blank"
@@ -69,6 +84,7 @@
        class="footer-logos__item">
       <img src="{% static 'images/indigo-trust-logo.jpg' %}"
            alt="The Indigo Trust"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
   </div>
 {% endblock %}

--- a/malawilii/templates/peachjam/about.html
+++ b/malawilii/templates/peachjam/about.html
@@ -19,8 +19,8 @@
   <h2 class="mb-4">AfricanLII</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-      <a href="https://africanlii.org/" target="_blank" rel="noreferrer noopener">AfricanLII</a> is a part of the
-      <a href="http://www.dgru.uct.ac.za/" target="_blank" rel="noreferrer noopener">Democratic
+      <a href="https://africanlii.org/" target="_blank" rel="noreferrer noopener">AfricanLII<span class="visually-hidden">opens in new tab</span></a> is a part of the
+      <a href="http://www.dgru.uct.ac.za/" target="_blank" rel="noreferrer noopener">Democratic<span class="visually-hidden">opens in new tab</span>
         Governance and Rights Unit</a> at the Faculty of Law, University of Cape Town
       (UCT), South Africa. AfricanLII helps individuals, organizations, and governments build and maintain sustainable
       free access to law portals, and reach the people of Africa and beyond.
@@ -29,7 +29,7 @@
   <h2 class="mb-4">Laws.Africa</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-    <a href="https://laws.africa/" target="_blank" rel="noreferrer noopener">Laws.Africa</a> is a South Africa
+    <a href="https://laws.africa/" target="_blank" rel="noreferrer noopener">Laws.Africa<span class="visually-hidden">opens in new tab</span></a> is a South Africa
     non-profit organisation that digitises African legal information for public use.
     Open access to digital African legal information helps communities to thrive, businesses to succeed, and judicial
     officers and civil servants to deliver services efficiently and effectively.

--- a/open_by_laws/templates/open_by_laws/home.html
+++ b/open_by_laws/templates/open_by_laws/home.html
@@ -28,44 +28,46 @@
             <img alt="Laws.Africa"
                  class="me-3"
                  src="{% static 'images/lawlibrary-logo.png' %}"/>
-            Part of <a href="https://lawlibrary.org.za" target="_blank">LawLibrary.org.za</a>.
-          </h5>
-        </div>
+            Part of <a href="https://lawlibrary.org.za" target="_blank">LawLibrary.org.za
+            {% include 'peachjam/_opens_in_new_tab.html' %}
+          </a>.
+        </h5>
       </div>
-    </section>
-    <section class="py-5 hero-search">
-      <div class="container">
-        {% block hero-search %}
-          <div class="row justify-content-center">
-            <div class="col col-md-10 col-lg-8">
-              <form method="get" action="{% url 'search:search' %}" class="d-flex mb-2">
-                <input type="text"
-                       class="form-control form-control-lg flex-grow-1"
-                       placeholder="{% blocktrans %}Search {{ APP_NAME }}{% endblocktrans %}"
-                       aria-label="{% blocktrans %}Search {{ APP_NAME }}{% endblocktrans %}"
-                       aria-describedby="button-addon2"
-                       autofocus=""
-                       name="q"/>
-                <input type="submit"
-                       class="btn btn-primary ms-2 btn-lg"
-                       value="{% trans 'Search' %}"/>
-              </form>
-              <a href="{% url 'search:search' %}?show-advanced-tab=1">{% trans 'Advanced search' %}</a>
-            </div>
+    </div>
+  </section>
+  <section class="py-5 hero-search">
+    <div class="container">
+      {% block hero-search %}
+        <div class="row justify-content-center">
+          <div class="col col-md-10 col-lg-8">
+            <form method="get" action="{% url 'search:search' %}" class="d-flex mb-2">
+              <input type="text"
+                     class="form-control form-control-lg flex-grow-1"
+                     placeholder="{% blocktrans %}Search {{ APP_NAME }}{% endblocktrans %}"
+                     aria-label="{% blocktrans %}Search {{ APP_NAME }}{% endblocktrans %}"
+                     aria-describedby="button-addon2"
+                     autofocus=""
+                     name="q"/>
+              <input type="submit"
+                     class="btn btn-primary ms-2 btn-lg"
+                     value="{% trans 'Search' %}"/>
+            </form>
+            <a href="{% url 'search:search' %}?show-advanced-tab=1">{% trans 'Advanced search' %}</a>
           </div>
-        {% endblock %}
-      </div>
-    </section>
-    <section class="municipalities py-5">
-      <div class="container">
-        {% with object_list=municipalities %}
-          {% include "open_by_laws/_municipalities.html" %}
-        {% endwith %}
-        <h4>Official municipal partners</h4>
-        {% with object_list=microsites %}
-          {% include "open_by_laws/_municipalities.html" %}
-        {% endwith %}
-      </div>
-    </section>
-  </div>
+        </div>
+      {% endblock %}
+    </div>
+  </section>
+  <section class="municipalities py-5">
+    <div class="container">
+      {% with object_list=municipalities %}
+        {% include "open_by_laws/_municipalities.html" %}
+      {% endwith %}
+      <h4>Official municipal partners</h4>
+      {% with object_list=microsites %}
+        {% include "open_by_laws/_municipalities.html" %}
+      {% endwith %}
+    </div>
+  </section>
+</div>
 {% endblock %}

--- a/open_by_laws/templates/peachjam/_footer.html
+++ b/open_by_laws/templates/peachjam/_footer.html
@@ -26,57 +26,79 @@
   <div>
     <a href="https://bergrivier.openbylaws.org.za/"
        target="_blank"
-       rel="noreferrer">Bergrivier</a>
+       rel="noreferrer">Bergrivier
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://capeagulhas.openbylaws.org.za/"
        target="_blank"
-       rel="noreferrer">Cape Agulhas</a>
+       rel="noreferrer">Cape Agulhas
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://openbylaws.org.za/za-cpt/eng/"
        target="_blank"
-       rel="noreferrer">Cape Town</a>
+       rel="noreferrer">Cape Town
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://cederberg.openbylaws.org.za/"
        target="_blank"
-       rel="noreferrer">Cederberg</a>
+       rel="noreferrer">Cederberg
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://openbylaws.org.za/za-wc023/eng/"
        target="_blank"
-       rel="noreferrer">Drakenstein</a>
+       rel="noreferrer">Drakenstein
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://openbylaws.org.za/za-jhb/eng/"
        target="_blank"
-       rel="noreferrer">Johannesburg</a>
+       rel="noreferrer">Johannesburg
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://openbylaws.org.za/za-wc041/eng/"
        target="_blank"
-       rel="noreferrer">Kannaland</a>
+       rel="noreferrer">Kannaland
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://matzikama.openbylaws.org.za/"
        target="_blank"
-       rel="noreferrer">Matzikama</a>
+       rel="noreferrer">Matzikama
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://mbizana.openbylaws.org.za/"
        target="_blank"
-       rel="noreferrer">Mbizana</a>
+       rel="noreferrer">Mbizana
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://openbylaws.org.za/za-wc015/eng/"
        target="_blank"
-       rel="noreferrer">Swartland</a>
+       rel="noreferrer">Swartland
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://openbylaws.org.za/za-eth/eng/"
        target="_blank"
-       rel="noreferrer">eThekwini</a>
+       rel="noreferrer">eThekwini
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block third-content-column %}{% endblock %}
@@ -89,18 +111,21 @@
       <img height="40"
            src="{% static 'images/lawlibrary-logo.png' %}"
            alt="LawLibrary"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a class="footer-logos__item"
        href="https://africanlii.org/"
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://laws.africa/"
        target="_blank"
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/laws-africa-logo.png' %}" alt="Laws.Africa"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
   </div>
 {% endblock %}

--- a/open_by_laws/templates/peachjam/_header.html
+++ b/open_by_laws/templates/peachjam/_header.html
@@ -28,7 +28,9 @@
     </ul>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="https://lawlibrary.org.za" target="_blank">LawLibrary</a>
+    <a class="nav-link" href="https://lawlibrary.org.za" target="_blank">LawLibrary
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </li>
   <li class="nav-item">
     <a class="nav-link {% if view.navbar_link == 'about' %}active{% endif %}"

--- a/peachjam/js/components/Annotations/Annotation.vue
+++ b/peachjam/js/components/Annotations/Annotation.vue
@@ -211,7 +211,7 @@ export default {
       const domainPattern = /([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?=\s|$)/g;
 
       text = text.replace(urlPattern, (url) => {
-        return `<a href="${url}" target="_blank">${url}</a>`;
+        return `<a href="${url}" target="_blank">${url}<span class="visually-hidden">opens in new tab</span></a>`;
       });
 
       text = text.replace(emailPattern, (email) => {
@@ -219,7 +219,7 @@ export default {
       });
 
       text = text.replace(domainPattern, (domain) => {
-        return `<a href="http://${domain}" target="_blank">${domain}</a>`;
+        return `<a href="http://${domain}" target="_blank">${domain}<span class="visually-hidden">opens in new tab</span></a>`;
       });
 
       return text;

--- a/peachjam/js/components/DocumentContent/CitationLinkGutterItem.vue
+++ b/peachjam/js/components/DocumentContent/CitationLinkGutterItem.vue
@@ -16,6 +16,12 @@
         <div>
           <a :href="link.url" target="_blank">
             {{ link.url }}
+            <span
+              v-if="link.is_external"
+              class="visually-hidden"
+            >
+              {{ $t('opens in new tab') }}
+            </span>
           </a>
           <span
             v-if="link.is_external"

--- a/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
+++ b/peachjam/js/components/DocumentContent/ShareSelectionModal.vue
@@ -31,7 +31,7 @@
               target="_blank"
               data-track-event="Document | Social share | WhatsApp"
               @click="modal.hide()"
-            ><i class="bi bi-whatsapp whatsapp-forecolor share-icon" />
+            ><span class="visually-hidden">{{ $t('Share this selection on WhatsApp opens in new tab') }}</span><i class="bi bi-whatsapp whatsapp-forecolor share-icon" />
             </a>
             <a
               :href="`https://twitter.com/intent/tweet?text=${ combined }`"
@@ -39,7 +39,7 @@
               target="_blank"
               data-track-event="Document | Social share | X"
               @click="modal.hide()"
-            ><i class="bi bi-twitter-x twitter-x-forecolor share-icon" />
+            ><span class="visually-hidden">{{ $t('Share this selection on X opens in new tab') }}</span><i class="bi bi-twitter-x twitter-x-forecolor share-icon" />
             </a>
             <a
               :href="`https://www.facebook.com/sharer/sharer.php?u=${ encodeURIComponent(url) }`"
@@ -47,7 +47,7 @@
               target="_blank"
               data-track-event="Document | Social share | Facebook"
               @click="modal.hide()"
-            ><i class="bi bi-facebook facebook-forecolor share-icon" />
+            ><span class="visually-hidden">{{ $t('Share this selection on Facebook opens in new tab') }}</span><i class="bi bi-facebook facebook-forecolor share-icon" />
             </a>
             <a
               :href="`https://www.linkedin.com/sharing/share-offsite/?url=${ encodeURIComponent(url) }`"
@@ -55,7 +55,7 @@
               target="_blank"
               data-track-event="Document | Social share | LinkedIn"
               @click="modal.hide()"
-            ><i class="bi bi-linkedin linkedin-forecolor share-icon" />
+            ><span class="visually-hidden">{{ $t('Share this selection on LinkedIn opens in new tab') }}</span><i class="bi bi-linkedin linkedin-forecolor share-icon" />
             </a>
             <a
               :href="`mailto:?subject=${emailSubject}&body=${combined}`"

--- a/peachjam/js/components/HelpBtn.vue
+++ b/peachjam/js/components/HelpBtn.vue
@@ -4,7 +4,7 @@
       :href="`${userHelpLink}${page}`"
       class="me-3"
       target="_blank"
-    ><i class="bi bi-question-circle me-1" />{{ $t('Help') }}</a>
+    ><i class="bi bi-question-circle me-1" />{{ $t('Help') }}<span class="visually-hidden"> {{ $t('opens in new tab') }}</span></a>
   </span>
 </template>
 

--- a/peachjam/templates/peachjam/_document_partner.html
+++ b/peachjam/templates/peachjam/_document_partner.html
@@ -10,8 +10,11 @@
         <img src="{{ document.work.partner.logo.get_absolute_url }}"
              alt="{{ document.work.partner.name }}"
              class="img-fluid"/>
-        {% if document.work.partner.url %}</a>{% endif %}
-      </div>
-    {% endif %}
-  </div>
+        {% if document.work.partner.url %}
+          {% include 'peachjam/_opens_in_new_tab.html' %}
+        </a>
+      {% endif %}
+    </div>
+  {% endif %}
+</div>
 </div>

--- a/peachjam/templates/peachjam/_entity_profile.html
+++ b/peachjam/templates/peachjam/_entity_profile.html
@@ -39,7 +39,9 @@
             <div>
               <strong>{% trans 'Visit website' %}</strong>
             </div>
-            <a href="{{ entity_profile.website_url }}" target="_blank">{{ entity_profile.website_url }}</a>
+            <a href="{{ entity_profile.website_url }}" target="_blank">{{ entity_profile.website_url }}
+              {% include 'peachjam/_opens_in_new_tab.html' %}
+            </a>
           </div>
         {% endif %}
       </div>

--- a/peachjam/templates/peachjam/_help_button.html
+++ b/peachjam/templates/peachjam/_help_button.html
@@ -3,6 +3,8 @@
   <div class="mb-3">
     <a href="{{ PEACHJAM_SETTINGS.user_help_link }}{{ help_link }}"
        target="_blank"
-       rel="noopener noreferrer"><i class="bi bi-question-circle me-1"></i>{% trans 'Help' %}</a>
+       rel="noopener noreferrer"><i class="bi bi-question-circle me-1"></i>{% trans 'Help' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endif %}

--- a/peachjam/templates/peachjam/_open_law_africa.html
+++ b/peachjam/templates/peachjam/_open_law_africa.html
@@ -8,6 +8,7 @@
       <img src="{% static 'images/open-law-africa-inverted.png' %}"
            alt="{% trans 'Open Law Africa' %}"
            class="top-bar-logo ola-logo"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
   </div>
 </div>

--- a/peachjam/templates/peachjam/_opens_in_new_tab.html
+++ b/peachjam/templates/peachjam/_opens_in_new_tab.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<span class="visually-hidden">{% trans 'opens in new tab' %}</span>

--- a/peachjam/templates/peachjam/_social_media.html
+++ b/peachjam/templates/peachjam/_social_media.html
@@ -14,7 +14,7 @@
             <a href="{{ PEACHJAM_SETTINGS.facebook_link }}"
                target="_blank"
                rel="noreferrer">
-              <span class="visually-hidden">{% trans 'Visit our Facebook Page' %}</span>
+              <span class="visually-hidden">{% trans 'Visit our Facebook Page' %} {% trans 'opens in new tab' %}</span>
               <i class="h2 facebook-forecolor bi bi-facebook"></i>
             </a>
           </li>
@@ -24,7 +24,7 @@
             <a href="{{ PEACHJAM_SETTINGS.twitter_link }}"
                target="_blank"
                rel="noreferrer">
-              <span class="visually-hidden">{% trans 'Visit our Twitter/X profile' %}</span>
+              <span class="visually-hidden">{% trans 'Visit our Twitter/X profile' %} {% trans 'opens in new tab' %}</span>
               <i class="h2 twitter-x-forecolor bi bi-twitter-x"></i>
             </a>
           </li>
@@ -34,7 +34,7 @@
             <a href="{{ PEACHJAM_SETTINGS.linkedin_link }}"
                target="_blank"
                rel="noreferrer">
-              <span class="visually-hidden">{% trans 'Visit our Linked In profile' %}</span>
+              <span class="visually-hidden">{% trans 'Visit our Linked In profile' %} {% trans 'opens in new tab' %}</span>
               <i class="h2 linkedin-forecolor bi bi-linkedin"></i>
             </a>
           </li>
@@ -44,7 +44,7 @@
             <a href="{{ PEACHJAM_SETTINGS.youtube_link }}"
                target="_blank"
                rel="noreferrer">
-              <span class="visually-hidden">{% trans 'Visit our YouTube channel' %}</span>
+              <span class="visually-hidden">{% trans 'Visit our YouTube channel' %} {% trans 'opens in new tab' %}</span>
               <i class="h2 youtube-forecolor bi bi-youtube"></i>
             </a>
           </li>

--- a/peachjam/templates/peachjam/_survey_banner_lg.html
+++ b/peachjam/templates/peachjam/_survey_banner_lg.html
@@ -15,10 +15,12 @@
         </div>
       </div>
       <div class=" col-xl-6 col-lg-6 col-md-12 text-lg-center pt-6">
-        <a target="_blank"
-           href="{{ PEACHJAM_SETTINGS.survey_link }}"
-           class="text-white btn btn-lg btn-danger"><span class="fw-bold">{% trans 'Take the survey' %}</span></a>
-      </div>
-    </div>
+      <a target="_blank"
+         href="{{ PEACHJAM_SETTINGS.survey_link }}"
+         class="text-white btn btn-lg btn-danger"><span class="fw-bold">{% trans 'Take the survey' %}</span>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
+</div>
+</div>
 </div>

--- a/peachjam/templates/peachjam/_survey_banner_sm.html
+++ b/peachjam/templates/peachjam/_survey_banner_sm.html
@@ -12,10 +12,12 @@
         </div>
       </div>
       <div class=" col-xl-6 col-lg-6 col-md-12 text-lg-center pt-6">
-        <a target="_blank"
-           href="{{ PEACHJAM_SETTINGS.survey_link }}"
-           class="text-white btn btn-danger"><span class="fw-bold">{% trans 'Take the survey' %}</span></a>
-      </div>
-    </div>
+      <a target="_blank"
+         href="{{ PEACHJAM_SETTINGS.survey_link }}"
+         class="text-white btn btn-danger"><span class="fw-bold">{% trans 'Take the survey' %}</span>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
+</div>
+</div>
 </div>

--- a/peachjam/templates/peachjam/article/detail.html
+++ b/peachjam/templates/peachjam/article/detail.html
@@ -40,16 +40,19 @@
           <a href="https://api.whatsapp.com/send?text={{ request.build_absolute_uri }}"
              class="btn btn-link share-link"
              target="_blank">
+            <span class="visually-hidden">{% trans 'Share this article on WhatsApp opens in new tab' %}</span>
             <i class="bi bi-whatsapp whatsapp-forecolor share-icon"></i>
           </a>
           <a href="https://twitter.com/intent/tweet?text={{ request.build_absolute_uri }}"
              class="btn btn-link share-link"
              target="_blank">
+            <span class="visually-hidden">{% trans 'Share this article on X opens in new tab' %}</span>
             <i class="bi bi-twitter-x twitter-x-forecolor share-icon"></i>
           </a>
           <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}"
              class="btn btn-link share-link"
              target="_blank">
+            <span class="visually-hidden">{% trans 'Share this article on Facebook opens in new tab' %}</span>
             <i class="bi bi-facebook facebook-forecolor share-icon"></i>
           </a>
           <a href="mailto:?subject={% trans 'Take a look at this article from' %} {{ APP_NAME }}: {{ article.title|truncatewords:7|escape }}&body={{ request.build_absolute_uri }}"

--- a/peachjam/templates/peachjam/layouts/document_detail.html
+++ b/peachjam/templates/peachjam/layouts/document_detail.html
@@ -47,32 +47,32 @@
               <a href="https://api.whatsapp.com/send?text={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
                  data-track-event="Document | Social share | WhatsApp"
-                 aria-label="{% trans 'Share this document on WhatsApp' %}"
                  target="_blank">
+                <span class="visually-hidden">{% trans 'Share this document on WhatsApp opens in new tab' %}</span>
                 <i class="bi bi-whatsapp whatsapp-forecolor share-icon"
                    aria-hidden="true"></i>
               </a>
               <a href="https://twitter.com/intent/tweet?text={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
                  data-track-event="Document | Social share | X"
-                 aria-label="{% trans 'Share this document on X' %}"
                  target="_blank">
+                <span class="visually-hidden">{% trans 'Share this document on X opens in new tab' %}</span>
                 <i class="bi bi-twitter-x twitter-x-forecolor share-icon"
                    aria-hidden="true"></i>
               </a>
               <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
                  data-track-event="Document | Social share | Facebook"
-                 aria-label="{% trans 'Share this document on Facebook' %}"
                  target="_blank">
+                <span class="visually-hidden">{% trans 'Share this document on Facebook opens in new tab' %}</span>
                 <i class="bi bi-facebook facebook-forecolor share-icon"
                    aria-hidden="true"></i>
               </a>
               <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ request.build_absolute_uri }}"
                  class="btn btn-link share-link"
                  data-track-event="Document | Social share | LinkedIn"
-                 aria-label="{% trans 'Share this document on LinkedIn' %}"
                  target="_blank">
+                <span class="visually-hidden">{% trans 'Share this document on LinkedIn opens in new tab' %}</span>
                 <i class="bi bi-linkedin linkedin-forecolor share-icon"
                    aria-hidden="true"></i>
               </a>
@@ -81,8 +81,8 @@
                  class="btn btn-link share-link"
                  target="_blank"
                  data-track-event="Document | Social share | Email"
-                 aria-label="{% trans 'Share this document by email' %}"
                  data-subject="{% trans 'Take a look at this document from' %} {{ APP_NAME }}: {{ document.title|truncatewords:7|escape }}">
+                <span class="visually-hidden">{% trans 'Share this document by email' %}</span>
                 <i class="bi bi-envelope-at-fill envelope-at-fill-forecolor share-icon"
                    aria-hidden="true"></i>
               </a>
@@ -507,7 +507,9 @@
                  id="related-tab"
                  role="tabpanel"
                  aria-labelledby="related-tab">
-              <div class="container">{% include 'peachjam/_related_documents.html' %}</div>
+              <div class="container">
+                {% include 'peachjam/_related_documents.html' %}
+              </div>
             </div>
           {% endif %}
         {% endblock %}
@@ -517,7 +519,9 @@
                  id="unconstitutional-provisions-tab"
                  role="tabpanel"
                  aria-labelledby="unconstitutional-provisions-tab">
-              <div class="container">{% include 'peachjam/document/_unconstitutional_provisions.html' %}</div>
+              <div class="container">
+                {% include 'peachjam/document/_unconstitutional_provisions.html' %}
+              </div>
             </div>
           {% endif %}
         {% endblock %}
@@ -527,7 +531,9 @@
                  id="uncommenced-provisions-tab"
                  role="tabpanel"
                  aria-labelledby="uncommenced-provisions-tab">
-              <div class="container">{% include 'peachjam/document/_uncommenced_provisions.html' %}</div>
+              <div class="container">
+                {% include 'peachjam/document/_uncommenced_provisions.html' %}
+              </div>
             </div>
           {% endif %}
         {% endblock %}
@@ -536,7 +542,8 @@
                id="citations-tab"
                role="tabpanel"
                aria-labelledby="citations-tab">
-            <div class="spinner-when-empty"></div>
+            <div class="spinner-when-empty">
+            </div>
           </div>
         {% endif %}
         {% if document.work.ratification %}
@@ -544,7 +551,9 @@
                id="ratifications-tab"
                role="tabpanel"
                aria-labelledby="ratifications-tab">
-            <div class="container">{% include 'peachjam/_ratifications.html' with ratification=document.work.ratification %}</div>
+            <div class="container">
+              {% include 'peachjam/_ratifications.html' with ratification=document.work.ratification %}
+            </div>
           </div>
         {% endif %}
       {% endblock %}

--- a/peachjam/tests/test_forms.py
+++ b/peachjam/tests/test_forms.py
@@ -362,3 +362,39 @@ class BaseDocumentFilterFormTestCase(TestCase):
         )
         self.assertIn('aria-label="Show provision details"', uncommenced_detail_html)
         self.assertIn('aria-hidden="true"', uncommenced_table_html)
+
+    def test_external_links_announce_new_tab_and_search_result_links_do_not_force_it(
+        self,
+    ):
+        request = RequestFactory().get("/documents/")
+
+        help_html = render_to_string(
+            "peachjam/_help_button.html",
+            {
+                "request": request,
+                "PEACHJAM_SETTINGS": SimpleNamespace(
+                    user_help_link="https://docs.example.com/"
+                ),
+                "help_link": "guide",
+            },
+            request=request,
+        )
+        lii_info_html = render_to_string(
+            "africanlii/_lii_info.html",
+            {
+                "request": request,
+                "liis": [
+                    SimpleNamespace(
+                        country="Kenya",
+                        name="KenyaLII",
+                        url="https://kenyalii.example.com/",
+                        domain="kenyalii.example.com",
+                    )
+                ],
+                "member_state": SimpleNamespace(country=SimpleNamespace(name="Kenya")),
+            },
+            request=request,
+        )
+
+        self.assertIn("opens in new tab", help_html)
+        self.assertNotIn('target="_blank"', lii_info_html)

--- a/peachjam_search/templates/peachjam_search/_search_hit.html
+++ b/peachjam_search/templates/peachjam_search/_search_hit.html
@@ -5,7 +5,6 @@
     <div class="card-body">
       <h5 class="card-title">
         <a class="h5 text-primary"
-           target="_blank"
            href="{{ hit.document.get_absolute_url }}"
            data-frbr-uri="{{ hit.document.expression_frbr_uri }}"
            data-position="{{ hit.position }}">
@@ -111,8 +110,7 @@
           <a href="{{ hit.document.get_absolute_url }}#page-{{ page.page_num }}"
              data-frbr-uri="{{ hit.document.expression_frbr_uri }}"
              data-position="{{ hit.position }}"
-             data-portion="page-{{ page.page_num }}"
-             target="_blank">{% trans "Page" %} {{ page.page_num }}</a>:
+             data-portion="page-{{ page.page_num }}">{% trans "Page" %} {{ page.page_num }}</a>:
           {% if page.highlight.pages_body %}
             <span>[...] {{ page.highlight.pages_body|safeseq|join:" ... " }} [...]</span>
           {% endif %}

--- a/peachjam_search/templates/peachjam_search/_search_hit_provision.html
+++ b/peachjam_search/templates/peachjam_search/_search_hit_provision.html
@@ -1,14 +1,12 @@
 <div class="mb-1">
   {% if parents %}
     <a href="{{ hit.document.get_absolute_url }}#{{ parents.0.id }}"
-       target="_blank"
        data-frbr-uri="{{ hit.document.expression_frbr_uri }}"
        data-position="{{ hit.position }}"
        data-portion="{{ parents.0.id }}">{{ parents.0.title }}</a>
     <div class="ms-3">{% include "peachjam_search/_search_hit_provision.html" with parents=parents|slice:"1:" %}</div>
   {% else %}
     <a href="{{ hit.document.get_absolute_url }}#{{ provision.id }}"
-       target="_blank"
        data-frbr-uri="{{ hit.document.expression_frbr_uri }}"
        data-position="{{ hit.position }}"
        data-portion="{{ provision.id }}">{{ provision.title }}</a>

--- a/peachjam_search/tests/test_views.py
+++ b/peachjam_search/tests/test_views.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from elasticsearch_dsl import Search
@@ -143,6 +144,48 @@ class SearchViewsTest(TestCase):
         response = self.client.get(reverse("search:search_documents") + "?search=test")
         self.assertEqual(response.status_code, 200)
         self.assertIn("max-age=900", response.headers["Cache-Control"])
+
+    def test_search_hit_links_open_in_same_tab(self):
+        request = RequestFactory().get("/search/?search=test")
+        doc = CoreDocument.objects.first()
+        hit = {
+            "document": doc,
+            "position": 1,
+            "best_match": False,
+            "highlight": {},
+            "pages": [
+                {
+                    "page_num": 3,
+                    "highlight": {"pages_body": ["example"]},
+                }
+            ],
+            "provisions": [
+                {
+                    "id": "sec_1",
+                    "title": "Section 1",
+                    "highlight": {"provisions_body": ["example"]},
+                    "parents": [],
+                }
+            ],
+        }
+
+        html = render_to_string(
+            "peachjam_search/_search_hit.html",
+            {
+                "request": request,
+                "hit": hit,
+                "show_jurisdiction": False,
+                "can_debug": False,
+            },
+            request=request,
+        )
+
+        self.assertNotIn(
+            f'target="_blank"\n           href="{doc.get_absolute_url}"',
+            html,
+        )
+        self.assertNotIn(f'target="_blank">{doc.get_absolute_url}#page-3', html)
+        self.assertNotIn(f'target="_blank">{doc.get_absolute_url}#sec_1', html)
 
 
 class PortionSearchViewTest(TestCase):

--- a/zambialii/templates/liiweb/home.html
+++ b/zambialii/templates/liiweb/home.html
@@ -54,7 +54,7 @@
   </p>
   <p>
     {% blocktrans trimmed %}
-      <a href="https://drive.google.com/file/d/1FRH3SqmlgeJAtTNPv0wemSGmltM5pwYy/view" target="_blank" rel="noreferrer">View the ZambiaLII Brochure</a>
+      <a href="https://drive.google.com/file/d/1FRH3SqmlgeJAtTNPv0wemSGmltM5pwYy/view" target="_blank" rel="noreferrer">View the ZambiaLII Brochure<span class="visually-hidden">opens in new tab</span></a>
     {% endblocktrans %}
   </p>
 {% endblock %}

--- a/zambialii/templates/peachjam/_footer.html
+++ b/zambialii/templates/peachjam/_footer.html
@@ -4,35 +4,45 @@
   <p>
     {% blocktrans trimmed %}
       ZambiaLII is a pioneer in the free access to law movement and serves as a reliable and timely source of judicial decisions, legislation and statutory instruments.
-      Since 2012, ZambiaLII has been hosted by the <a href="https://saipar.org/" target="_blank" rel="noreferrer">Southern African Institute for Policy and Research (SAIPAR)</a>, an independent, educational and development-oriented research centre.
+      Since 2012, ZambiaLII has been hosted by the <a href="https://saipar.org/" target="_blank" rel="noreferrer">Southern African Institute for Policy and Research (SAIPAR)<span class="visually-hidden">opens in new tab</span></a>, an independent, educational and development-oriented research centre.
       AfricanLII provides technical support to ZambiaLII.
     {% endblocktrans %}
   </p>
   <p>
     {% blocktrans trimmed %}
-      <a href="https://drive.google.com/file/d/1FRH3SqmlgeJAtTNPv0wemSGmltM5pwYy/view" target="_blank" rel="noreferrer">View the ZambiaLII Brochure</a>
+      <a href="https://drive.google.com/file/d/1FRH3SqmlgeJAtTNPv0wemSGmltM5pwYy/view" target="_blank" rel="noreferrer">View the ZambiaLII Brochure<span class="visually-hidden">opens in new tab</span></a>
     {% endblocktrans %}
   </p>
 {% endblock %}
 {% block second-content-column %}
   <h5>{% trans 'Our partners' %}</h5>
   <div>
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII</a>
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer">AfricanLII
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa</a>
+    <a href="https://laws.africa/" target="_blank" rel="noreferrer">Laws.Africa
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
-    <a href="https://saipar.org/" target="_blank" rel="noreferrer">Southern African Institute for Policy and Research</a>
+    <a href="https://saipar.org/" target="_blank" rel="noreferrer">Southern African Institute for Policy and Research
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <h6 class="mt-4">{% trans 'With support from' %}</h6>
   <div>
-    <a href="https://www.ned.org/" target="_blank" rel="noreferrer">{% trans 'National Endowment for Democracy' %}</a>
+    <a href="https://www.ned.org/" target="_blank" rel="noreferrer">{% trans 'National Endowment for Democracy' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
   <div>
     <a href="https://www.indigotrust.org.uk/"
        target="_blank"
-       rel="noreferrer">{% trans 'The Indigo Trust' %}</a>
+       rel="noreferrer">{% trans 'The Indigo Trust' %}
+      {% include 'peachjam/_opens_in_new_tab.html' %}
+    </a>
   </div>
 {% endblock %}
 {% block footer-logos %}
@@ -42,12 +52,14 @@
        target="_blank"
        rel="noreferrer">
       <img src="{% static 'images/africanlii-logo.svg' %}" alt="AfricanLII" />
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://www.ned.org/"
        target="_blank"
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/ned-logo.png' %}" alt="NED logo" />
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://saipar.org/"
        target="_blank"
@@ -55,12 +67,14 @@
        class="footer-logos__item">
       <img src="{% static 'images/saipar-logo.jpg' %}"
            alt="Southern African Institute for Policy and Research (SAIPAR)"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://laws.africa/"
        target="_blank"
        rel="noreferrer"
        class="footer-logos__item">
       <img src="{% static 'images/laws-africa-logo.png' %}" alt="Laws.Africa"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://www.indigotrust.org.uk/"
        target="_blank"
@@ -68,6 +82,7 @@
        class="footer-logos__item">
       <img src="{% static 'images/indigo-trust-logo.jpg' %}"
            alt="The Indigo Trust"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
     <a href="https://acc.gov.zm/"
        target="_blank"
@@ -75,6 +90,7 @@
        class="footer-logos__item">
       <img src="{% static 'images/acc.jpg' %}"
            alt="Anti-corruption Commission Zambia"/>
+      {% include 'peachjam/_opens_in_new_tab.html' %}
     </a>
   </div>
 {% endblock %}

--- a/zambialii/templates/peachjam/about.html
+++ b/zambialii/templates/peachjam/about.html
@@ -4,7 +4,7 @@
   <p class="lead mb-4">
     {% blocktrans trimmed %}
       ZambiaLII is a pioneer in the free access to law movement and serves as a reliable and timely source of judicial decisions, legislation and statutory instruments.
-      Since 2012, ZambiaLII has been hosted by the <a href="https://saipar.org/" target="_blank">Southern African Institute for Policy and Research (SAIPAR)</a>, an independent, educational and development oriented research centre.
+      Since 2012, ZambiaLII has been hosted by the <a href="https://saipar.org/" target="_blank">Southern African Institute for Policy and Research (SAIPAR)<span class="visually-hidden">opens in new tab</span></a>, an independent, educational and development oriented research centre.
     {% endblocktrans %}
   </p>
   <p class="lead mb-4">
@@ -83,8 +83,8 @@
   <h2 class="mb-4">AfricanLII</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-    <a href="https://africanlii.org/" target="_blank" rel="noreferrer noopener">AfricanLII</a> is a part of the
-    <a href="http://www.dgru.uct.ac.za/" target="_blank" rel="noreferrer noopener">Democratic
+    <a href="https://africanlii.org/" target="_blank" rel="noreferrer noopener">AfricanLII<span class="visually-hidden">opens in new tab</span></a> is a part of the
+    <a href="http://www.dgru.uct.ac.za/" target="_blank" rel="noreferrer noopener">Democratic<span class="visually-hidden">opens in new tab</span>
       Governance and Rights Unit</a> at the Faculty of Law, University of Cape Town
     (UCT), South Africa. AfricanLII helps individuals, organizations, and governments build and maintain sustainable
     free access to law portals, and reach the people of Africa and beyond.
@@ -93,7 +93,7 @@
   <h2 class="mb-4">Laws.Africa</h2>
   <p class="mb-4">
     {% blocktrans trimmed %}
-    <a href="https://laws.africa/" target="_blank" rel="noreferrer noopener">Laws.Africa</a> is a South Africa
+    <a href="https://laws.africa/" target="_blank" rel="noreferrer noopener">Laws.Africa<span class="visually-hidden">opens in new tab</span></a> is a South Africa
     non-profit organisation that digitises African legal information for public use.
     Open access to digital African legal information helps communities to thrive, businesses to succeed, and judicial
     officers and civil servants to deliver services efficiently and effectively.


### PR DESCRIPTION
This handles links that open new tabs
- by default all internal links should not open new tabs. 
- external links can open new tabs, but include a visually hidden call out for speech readers. Ideally we should also have an icon, but i've ignored that.
