### PR TITLE
absolute urls for email templates

### DIFF
--- a/peachjam/templates/peachjam/emails/_new_relationship_alert_body.html
+++ b/peachjam/templates/peachjam/emails/_new_relationship_alert_body.html
@@ -1,17 +1,17 @@
-{% load i18n %}
+{% load i18n peachjam %}
 {% for item in saved_documents %}
   {% for rel in item.relationships.values %}
     <div style="margin-top: 1rem;">
       <p>
         {{ rel.label }}
-        <a href="{{ site.domain }}{{ item.saved_document.get_absolute_url }}?utm_campaign=new_relationship&utm_source=alert&utm_medium=email">
+        <a href="{% absolute_url site item.saved_document.get_absolute_url %}?utm_campaign=new_relationship&utm_source=alert&utm_medium=email">
           <b>{{ item.saved_document.work.title }}</b>
         </a>
       </p>
       <ul>
         {% for doc in rel.documents %}
           <li style="margin-bottom: 1rem">
-            <a href="{{ site.domain }}{{ doc.get_absolute_url }}?utm_campaign=new_relationship&utm_source=alert&utm_medium=email">
+            <a href="{% absolute_url site doc.get_absolute_url %}?utm_campaign=new_relationship&utm_source=alert&utm_medium=email">
               {{ doc.title }}
             </a>
             {% if doc.blurb %}<div>{{ doc.blurb | safe }}</div>{% endif %}

--- a/peachjam/templates/peachjam/emails/layouts/alert.html
+++ b/peachjam/templates/peachjam/emails/layouts/alert.html
@@ -1,5 +1,5 @@
 {% extends 'peachjam/emails/layouts/base.html' %}
-{% load i18n %}
+{% load i18n peachjam %}
 {% block body %}
   <p>{% blocktrans with name=user.get_full_name %}Hello {{ name }}{% endblocktrans %}</p>
   {% block alert-body %}{% endblock %}
@@ -7,12 +7,13 @@
   <p>{% blocktrans %}The {{ APP_NAME }} Team{% endblocktrans %}</p>
   <p>
     <small>
-      <a href="https://{{ site.domain }}{{ manage_url_path }}?utm_campaign=following&utm_source=alert&utm_medium=email">{% trans "Manage these email alerts" %}</a>
+      <a href="{% absolute_url site manage_url_path %}?utm_campaign=following&utm_source=alert&utm_medium=email">{% trans "Manage these email alerts" %}</a>
     </small>
   </p>
 {% endblock %}
 {% block footer %}
   <p>
-    <small><a href="https://{{ site.domain }}{% url 'my_account' %}">{% blocktrans %}Manage your {{ APP_NAME }} account{% endblocktrans %}</a></small>
+    {% url 'my_account' as my_account_url %}
+    <small><a href="{% absolute_url site my_account_url %}">{% blocktrans %}Manage your {{ APP_NAME }} account{% endblocktrans %}</a></small>
   </p>
 {% endblock %}

--- a/peachjam/templates/peachjam/emails/layouts/base.html
+++ b/peachjam/templates/peachjam/emails/layouts/base.html
@@ -1,5 +1,4 @@
 {% load static i18n peachjam %}
-{% static 'images/logo.png' as static_logo_url %}
 {% block html %}
   {# djlint:off #}
   <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -133,7 +132,7 @@
                                     {% block header %}
                                       <center>
                                         {% block header-logo %}
-                                          <img src="{% absolute_url site static_logo_url %}" alt="{% trans "logo" %}" style="height: 60px" align="center" class="float-center"/>
+                                          <img src="{% absolute_static_url site 'images/logo.png' %}" alt="{% trans "logo" %}" style="height: 60px" align="center" class="float-center"/>
                                         {% endblock %}
                                       </center>
                                     {% endblock %}

--- a/peachjam/templates/peachjam/emails/layouts/base.html
+++ b/peachjam/templates/peachjam/emails/layouts/base.html
@@ -1,4 +1,5 @@
-{% load static i18n %}
+{% load static i18n peachjam %}
+{% static 'images/logo.png' as static_logo_url %}
 {% block html %}
   {# djlint:off #}
   <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -132,7 +133,7 @@
                                     {% block header %}
                                       <center>
                                         {% block header-logo %}
-                                          <img src="https://{{ site.domain }}{% static 'images/logo.png' %}" alt="{% trans "logo" %}" style="height: 60px" align="center" class="float-center"/>
+                                          <img src="{% absolute_url site static_logo_url %}" alt="{% trans "logo" %}" style="height: 60px" align="center" class="float-center"/>
                                         {% endblock %}
                                       </center>
                                     {% endblock %}

--- a/peachjam/templates/peachjam/emails/new_citation_alert.email
+++ b/peachjam/templates/peachjam/emails/new_citation_alert.email
@@ -1,5 +1,5 @@
 {% extends 'peachjam/emails/layouts/alert.html' %}
-{% load i18n %}
+{% load i18n peachjam %}
 {% block subject %}
   {% if saved_documents|length > 1 %}
     {% blocktrans trimmed with title=saved_documents.0.saved_document.title %}New citations for {{ title }} and more{% endblocktrans %}
@@ -10,12 +10,12 @@
 {% block alert-body %}
   {% for item in saved_documents %}
     <p>
-      <a href="{{ site.domain }}{{ item.saved_document.get_absolute_url }}?utm_campaign=new_citation&utm_source=alert&utm_medium=email"><b>{{ item.saved_document.title }}</b></a>
+      <a href="{% absolute_url site item.saved_document.get_absolute_url %}?utm_campaign=new_citation&utm_source=alert&utm_medium=email"><b>{{ item.saved_document.title }}</b></a>
     </p>
     <ul>
       {% for citing in item.citing_documents %}
         <li style="margin-bottom: 1rem">
-          <a href="{{ site.domain }}{{ citing.document.get_absolute_url }}?utm_campaign=new_citation&utm_source=alert&utm_medium=email">{{ citing.document.title }}</a>
+          <a href="{% absolute_url site citing.document.get_absolute_url %}?utm_campaign=new_citation&utm_source=alert&utm_medium=email">{{ citing.document.title }}</a>
           {% if citing.document.blurb %}<div>{{ citing.blurb | safe }}</div>{% endif %}
           {% if citing.document.flynote %}
             <div>

--- a/peachjam/templates/peachjam/emails/user_following_alert.email
+++ b/peachjam/templates/peachjam/emails/user_following_alert.email
@@ -1,5 +1,5 @@
 {% extends 'peachjam/emails/layouts/alert.html' %}
-{% load i18n %}
+{% load i18n peachjam %}
 {% block subject %}
   {% if followed_documents|length > 1 %}
     {% blocktrans trimmed with title=followed_documents.0.followed_object %}New documents for {{ title }} and more{% endblocktrans %}
@@ -14,7 +14,7 @@
     <ul>
       {% for doc in item.documents %}
         <li>
-          <a href="https://{{ site.domain }}{{ doc.expression_frbr_uri }}?utm_campaign=following&utm_source=alert&utm_medium=email">{{ doc.title }}</a>
+          <a href="{% absolute_url site doc.expression_frbr_uri %}?utm_campaign=following&utm_source=alert&utm_medium=email">{{ doc.title }}</a>
           {% if doc.blurb %}<div>{{ doc.blurb }}</div>{% endif %}
           {% if doc.flynote %}<div>{{ doc.flynote|linebreaksbr }}</div>{% endif %}
         </li>

--- a/peachjam/templatetags/peachjam.py
+++ b/peachjam/templatetags/peachjam.py
@@ -7,6 +7,7 @@ from django import template
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 from django.http import QueryDict
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -132,6 +133,11 @@ def absolute_url(site_or_domain, path="", protocol="https"):
 
     path = "" if path is None else str(path)
     return urljoin(base_url, path.lstrip("/"))
+
+
+@register.simple_tag
+def absolute_static_url(site_or_domain, path, protocol="https"):
+    return absolute_url(site_or_domain, static(path), protocol)
 
 
 @register.simple_tag

--- a/peachjam/templatetags/peachjam.py
+++ b/peachjam/templatetags/peachjam.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 import json
+from urllib.parse import urljoin
 
 from django import template
 from django.db.models import F, Window
@@ -15,6 +16,17 @@ from peachjam.models import DocumentChatThread
 from peachjam.xmlutils import qualify_local_refs as qualify_local_refs_html
 
 register = template.Library()
+
+
+def normalize_base_url(value, protocol="https"):
+    value = str(value or "").strip()
+    if not value:
+        return ""
+
+    if "://" not in value:
+        value = f"{protocol}://{value.lstrip('/')}"
+
+    return value.rstrip("/") + "/"
 
 
 @register.filter
@@ -109,6 +121,17 @@ def build_taxonomy_url(item, prefix="taxonomy"):
         items.append(root_slug)
     items.append(item.slug)
     return f"/{prefix}/" + "/".join(items)
+
+
+@register.simple_tag
+def absolute_url(site_or_domain, path="", protocol="https"):
+    domain = getattr(site_or_domain, "domain", site_or_domain)
+    base_url = normalize_base_url(domain, protocol)
+    if not base_url:
+        return ""
+
+    path = "" if path is None else str(path)
+    return urljoin(base_url, path.lstrip("/"))
 
 
 @register.simple_tag

--- a/peachjam/tests/test_email_templates.py
+++ b/peachjam/tests/test_email_templates.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+
+from django.template import Context, Template
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+
+
+class EmailTemplateUrlTestCase(SimpleTestCase):
+    maxDiff = None
+
+    def base_context(self, domain):
+        return {
+            "site": SimpleNamespace(domain=domain),
+            "user": SimpleNamespace(get_full_name="Test User"),
+            "APP_NAME": "Peach Jam",
+            "PRIMARY_COLOUR": "#123456",
+        }
+
+    def test_absolute_url_tag_adds_https_and_preserves_existing_scheme(self):
+        template = Template(
+            "{% load peachjam %}"
+            "{% absolute_url bare '/en/documents/' %}|"
+            "{% absolute_url secure '/en/documents/' %}"
+        )
+
+        rendered = template.render(
+            Context(
+                {
+                    "bare": SimpleNamespace(domain="example.org"),
+                    "secure": SimpleNamespace(domain="https://example.org"),
+                }
+            )
+        )
+
+        self.assertEqual(
+            rendered,
+            "https://example.org/en/documents/|https://example.org/en/documents/",
+        )
+
+    def test_alert_email_templates_render_absolute_links(self):
+        context = self.base_context("example.org")
+        context.update(
+            {
+                "manage_url_path": "/en/my/following/",
+                "saved_documents": [
+                    {
+                        "saved_document": SimpleNamespace(
+                            title="Saved document",
+                            get_absolute_url="/documents/saved/",
+                        ),
+                        "citing_documents": [
+                            {
+                                "document": SimpleNamespace(
+                                    title="Citing document",
+                                    get_absolute_url="/documents/citing/",
+                                    blurb="",
+                                    flynote="",
+                                ),
+                                "provision_citations": [],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        html = render_to_string(
+            "peachjam/emails/new_citation_alert.email",
+            context=context,
+        )
+
+        self.assertIn(
+            'href="https://example.org/en/my/following/?utm_campaign=following&utm_source=alert&utm_medium=email"',
+            html,
+        )
+        self.assertIn(
+            'href="https://example.org/en/accounts/profile/"',
+            html,
+        )
+        self.assertIn(
+            'src="https://example.org/static/images/logo.png"',
+            html,
+        )
+        self.assertIn(
+            'href="https://example.org/documents/saved/?utm_campaign=new_citation&utm_source=alert&utm_medium=email"',
+            html,
+        )
+        self.assertIn(
+            'href="https://example.org/documents/citing/?utm_campaign=new_citation&utm_source=alert&utm_medium=email"',
+            html,
+        )
+
+    def test_search_alert_email_does_not_duplicate_protocol(self):
+        context = self.base_context("https://example.org")
+        context.update(
+            {
+                "manage_url_path": "/en/search/saved-searches/",
+                "saved_search": SimpleNamespace(
+                    q="example query",
+                    get_absolute_url="/en/search/?q=example",
+                    pretty_filters="",
+                ),
+                "hits": [
+                    {
+                        "expression_frbr_uri": "/documents/hit/",
+                        "document": SimpleNamespace(
+                            title="Hit title",
+                            blurb="",
+                            flynote="",
+                        ),
+                        "highlight": {},
+                        "pages": [
+                            {"page_num": 3, "highlight": {"pages.body": ["Example"]}}
+                        ],
+                        "provisions": [],
+                    }
+                ],
+            }
+        )
+
+        html = render_to_string(
+            "peachjam/emails/search_alert.email",
+            context=context,
+        )
+
+        self.assertNotIn("https://https://example.org", html)
+        self.assertIn('href="https://example.org/en/search/?q=example"', html)
+        self.assertIn('href="https://example.org/documents/hit/"', html)
+        self.assertIn('href="https://example.org/documents/hit/#page-3"', html)

--- a/peachjam/tests/test_email_templates.py
+++ b/peachjam/tests/test_email_templates.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from django.template import Context, Template
 from django.template.loader import render_to_string
 from django.test import SimpleTestCase
+from templated_email import get_templated_mail
 
 
 class EmailTemplateUrlTestCase(SimpleTestCase):
@@ -64,10 +65,13 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
             }
         )
 
-        html = render_to_string(
-            "peachjam/emails/new_citation_alert.email",
+        message = get_templated_mail(
+            template_name="new_citation_alert",
+            from_email="test@example.org",
+            to=["user@example.org"],
             context=context,
         )
+        html = message.alternatives[0][0] if message.alternatives else message.body
 
         self.assertIn(
             'href="https://example.org/en/my/following/?utm_campaign=following&utm_source=alert&utm_medium=email"',

--- a/peachjam_search/templates/peachjam/emails/search_alert.email
+++ b/peachjam_search/templates/peachjam/emails/search_alert.email
@@ -4,13 +4,13 @@
 {% block alert-body %}
   <p>{% trans "We have found new documents that match your search alert:" %}</p>
   <p>
-    <strong><a href="https://{{ site.domain }}{{ saved_search.get_absolute_url }}">{{ saved_search.q }}</a></strong>
+    <strong><a href="{% absolute_url site saved_search.get_absolute_url %}">{{ saved_search.q }}</a></strong>
   </p>
   <p>{{ saved_search.pretty_filters }}</p>
   <ul>
     {% for hit in hits %}
       <li>
-        <a href="https://{{ site.domain }}{{ hit.expression_frbr_uri }}">{% if hit.highlight.title %} {{ hit.highlight.title|first|safe }} {% else %} {{ hit.document.title }} {% endif %}</a>
+        <a href="{% absolute_url site hit.expression_frbr_uri %}">{% if hit.highlight.title %} {{ hit.highlight.title|first|safe }} {% else %} {{ hit.document.title }} {% endif %}</a>
         {% if hit.document.blurb %}<div>{{ hit.document.blurb }}</div>{% endif %}
         {% if hit.document.flynote %}<em>{{ hit.document.flynote|safe }}</em>{% endif %}
         <div>
@@ -19,7 +19,7 @@
           {% elif hit.pages|length %}
             {% for page in hit.pages %}
               <div>
-                <a href="https://{{ site.domain }}{{hit.expression_frbr_uri}}#page-{{page.page_num}}"
+                <a href="{% absolute_url site hit.expression_frbr_uri %}#page-{{ page.page_num }}"
                 >{% trans 'Page' %} {{ page.page_num }}</a>:
                 <span>{{ page.highlight|get_dotted_key_value:'pages.body'|safeseq|join:' ... ' }}</span>
               </div>
@@ -27,7 +27,7 @@
           {% elif hit.provisions|length %}
             {% for provision in hit.provisions %}
               <div>
-                <a href="https://{{ site.domain }}{{hit.expression_frbr_uri}}#{{provision.id}}"
+                <a href="{% absolute_url site hit.expression_frbr_uri %}#{{ provision.id }}"
                 >{{ provision.title }}</a>
                 <span>{{ provision.highlight|get_dotted_key_value:'provisions.body'|safeseq|join:' ... ' }}</span>
               </div>


### PR DESCRIPTION
This ensures links in emails have full urls.