### PR TITLE
Flynote merge

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -17,9 +17,11 @@ from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.admin import GenericStackedInline, GenericTabularInline
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.postgres.search import TrigramSimilarity
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Q
+from django.db.models.functions import Coalesce
 from django.http.response import FileResponse, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import filesizeformat
@@ -1239,6 +1241,7 @@ class TaxonomyAdmin(AccessGroupMixin, TreeAdmin):
 
 @admin.register(Flynote)
 class FlynoteAdmin(admin.ModelAdmin):
+    change_form_template = "admin/peachjam/flynote/change_form.html"
     list_display = ("name", "document_count", "depth", "deprecated")
     list_filter = ("depth", "deprecated", FlynoteDocumentCountFilter)
     search_fields = ("name",)
@@ -1257,8 +1260,160 @@ class FlynoteAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         return False
 
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["merge_url"] = reverse(
+            "admin:peachjam_flynote_merge", args=[object_id]
+        )
+        return super().change_view(request, object_id, form_url, extra_context)
+
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("document_count_cache")
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<int:object_id>/merge/",
+                self.admin_site.admin_view(self.merge_view),
+                name="peachjam_flynote_merge",
+            ),
+            path(
+                "<int:object_id>/merge/picker/",
+                self.admin_site.admin_view(self.merge_picker_view),
+                name="peachjam_flynote_merge_picker",
+            ),
+        ]
+        return custom_urls + urls
+
+    def get_merge_selected_ids(self, params):
+        selected_ids = []
+        for value in params.getlist("selected"):
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                continue
+            if value not in selected_ids:
+                selected_ids.append(value)
+        return selected_ids
+
+    def get_merge_candidates(self, target, query, selected_ids):
+        if target.is_root():
+            qs = Flynote.get_root_nodes()
+        else:
+            qs = target.get_parent().get_children()
+
+        qs = (
+            qs.exclude(pk=target.pk)
+            .exclude(pk__in=selected_ids)
+            .select_related("document_count_cache")
+            .annotate(document_total=Coalesce("document_count_cache__count", 0))
+        )
+
+        if query:
+            qs = (
+                qs.annotate(similarity=TrigramSimilarity("name", query))
+                .filter(Q(similarity__gt=0.05) | Q(name__icontains=query))
+                .order_by("-similarity", "-document_total", "name")
+            )
+        else:
+            qs = qs.order_by("-document_total", "name")
+
+        return qs[:50]
+
+    def get_merge_picker_context(self, request, target, query, selected_ids):
+        selected_flynotes = list(
+            Flynote.objects.filter(pk__in=selected_ids)
+            .select_related("document_count_cache")
+            .annotate(document_total=Coalesce("document_count_cache__count", 0))
+            .order_by("name")
+        )
+        selected_ids = [flynote.pk for flynote in selected_flynotes]
+
+        return {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "original": target,
+            "target_flynote": target,
+            "query": query,
+            "selected_ids": selected_ids,
+            "selected_flynotes": selected_flynotes,
+            "search_results": self.get_merge_candidates(target, query, selected_ids),
+            "picker_url": reverse(
+                "admin:peachjam_flynote_merge_picker", args=[target.pk]
+            ),
+            "merge_url": reverse("admin:peachjam_flynote_merge", args=[target.pk]),
+        }
+
+    def merge_view(self, request, object_id):
+        target = get_object_or_404(
+            Flynote.objects.select_related("document_count_cache"), pk=object_id
+        )
+        params = request.GET
+
+        if request.method == "POST":
+            selected_ids = self.get_merge_selected_ids(request.POST)
+            selected_flynotes = list(Flynote.objects.filter(pk__in=selected_ids))
+            try:
+                target.merge_sources_into(selected_flynotes)
+            except ValidationError as exc:
+                self.message_user(
+                    request,
+                    "; ".join(exc.messages),
+                    messages.ERROR,
+                )
+            else:
+                self.message_user(
+                    request,
+                    _("Merged %(count)s flynotes into %(target)s.")
+                    % {"count": len(selected_ids), "target": target.name},
+                    messages.SUCCESS,
+                )
+                return HttpResponseRedirect(
+                    reverse("admin:peachjam_flynote_merge", args=[target.pk])
+                )
+            params = request.POST
+
+        query = params.get("q", target.name).strip()
+        context = self.get_merge_picker_context(
+            request,
+            target,
+            query,
+            self.get_merge_selected_ids(params),
+        )
+        context["title"] = _("Merge flynotes into: %(target)s") % {
+            "target": target.name
+        }
+        return TemplateResponse(request, "admin/peachjam/flynote/merge.html", context)
+
+    def merge_picker_view(self, request, object_id):
+        target = get_object_or_404(Flynote, pk=object_id)
+        selected_ids = self.get_merge_selected_ids(request.GET)
+        query = request.GET.get("q", target.name).strip()
+
+        add_id = request.GET.get("add")
+        remove_id = request.GET.get("remove")
+        if add_id:
+            try:
+                add_id = int(add_id)
+            except (TypeError, ValueError):
+                add_id = None
+            if add_id and add_id not in selected_ids:
+                selected_ids.append(add_id)
+        if remove_id:
+            try:
+                remove_id = int(remove_id)
+            except (TypeError, ValueError):
+                remove_id = None
+            if remove_id in selected_ids:
+                selected_ids.remove(remove_id)
+
+        context = self.get_merge_picker_context(request, target, query, selected_ids)
+        return TemplateResponse(
+            request,
+            "admin/peachjam/flynote/_merge_picker.html",
+            context,
+        )
 
     def get_action_queryset_roots(self, queryset):
         selected_paths = set(queryset.values_list("path", flat=True))

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -9,6 +9,7 @@ from django_lifecycle import AFTER_SAVE, LifecycleModelMixin
 from treebeard.mp_tree import MP_Node
 
 from peachjam.models.lifecycle import on_attribute_changed
+from peachjam.tasks import refresh_flynote_document_count
 
 log = logging.getLogger(__name__)
 
@@ -128,6 +129,99 @@ class Flynote(LifecycleModelMixin, MP_Node):
                 child.save()
             else:
                 child.cascade_deprecated()
+
+    def merge_sources_into(self, sources):
+        """Merge sibling flynotes into this flynote.
+
+        Direct judgment links on each source move to this flynote. Source
+        children are re-parented under this flynote. Source flynotes are then
+        deleted explicitly, and document counts are refreshed in background.
+        """
+        from peachjam.analysis.flynotes import FlynoteParser
+
+        source_ids = []
+        for source in sources:
+            if source.pk and source.pk != self.pk and source.pk not in source_ids:
+                source_ids.append(source.pk)
+
+        if not source_ids:
+            return
+
+        with transaction.atomic():
+            target = Flynote.objects.select_for_update().get(pk=self.pk)
+            sources = list(
+                Flynote.objects.select_for_update()
+                .filter(pk__in=source_ids)
+                .order_by("path")
+            )
+
+            if len(sources) != len(source_ids):
+                raise ValidationError(
+                    _("One or more selected flynotes no longer exist.")
+                )
+
+            target_parent = target.get_parent()
+            target_parent_id = target_parent.pk if target_parent else None
+
+            for source in sources:
+                source_parent = source.get_parent()
+                source_parent_id = source_parent.pk if source_parent else None
+                if source.depth != target.depth or source_parent_id != target_parent_id:
+                    raise ValidationError(
+                        _(
+                            "Flynotes can only be merged into a sibling at the same level."
+                        )
+                    )
+
+            existing_child_names = {
+                FlynoteParser.normalise_name(child.name): child.name
+                for child in target.get_children()
+                if FlynoteParser.normalise_name(child.name)
+            }
+            duplicate_child_names = set()
+
+            for source in sources:
+                for child in source.get_children():
+                    normalised = FlynoteParser.normalise_name(child.name)
+                    if not normalised:
+                        continue
+                    if normalised in existing_child_names:
+                        duplicate_child_names.add(child.name)
+                    else:
+                        existing_child_names[normalised] = child.name
+
+            if duplicate_child_names:
+                duplicates = ", ".join(sorted(duplicate_child_names))
+                raise ValidationError(
+                    _(
+                        "Cannot merge because the target already has children with these names: %(duplicates)s."
+                    )
+                    % {"duplicates": duplicates}
+                )
+
+            log.info(f"Merging flynotes into {self}: {sources}")
+            for source in sources:
+                for judgment_flynote in list(source.judgments.select_for_update()):
+                    duplicate = JudgmentFlynote.objects.filter(
+                        document_id=judgment_flynote.document_id,
+                        flynote=target,
+                    ).exists()
+                    if duplicate:
+                        judgment_flynote.delete()
+                    else:
+                        judgment_flynote.flynote = target
+                        judgment_flynote.save(update_fields=["flynote"])
+
+                for child in list(source.get_children()):
+                    # moving nodes updates path attributes, so always work with latest info from db
+                    child.refresh_from_db()
+                    target.refresh_from_db()
+                    child.move(target, pos="sorted-child")
+
+                source.delete()
+
+            refresh_flynote_document_count(target.get_root().pk)
+            log.info("Finished merging flynotes")
 
     @classmethod
     def flynotes_to_string(cls, judgment_flynotes):

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -717,7 +717,7 @@ class Judgment(CoreDocument):
         """The flynote_raw field has changed, copy it to flynote and populate the flynote tree (if configured)."""
         self.flynote = self.flynote_raw
 
-        if settings.PEACHJAM["SUMMARISE_USE_FLYNOTE_TREE"]:
+        if settings.PEACHJAM["SUMMARISE_USE_FLYNOTE_TREE"] and self.pk:
             # This will eventually update both flynote and flynote_raw to match the flynote tree.
             # We set flynote above since this background task may take a while to run.
             update_flynote_taxonomy(self.pk)

--- a/peachjam/templates/admin/base.html
+++ b/peachjam/templates/admin/base.html
@@ -1,4 +1,5 @@
 {% extends 'admin/base.html' %}
+{% load static %}
 {% block messages %}
   {% for message in messages %}
     <div class="alert alert-{{ message.tags }} alert-dismissible">
@@ -7,3 +8,12 @@
     </div>
   {% endfor %}
 {% endblock messages %}
+{% block extrajs %}
+  {{ block.super }}
+  <script>
+    // app-prod.js uses Bootstrap 5, but jazzmin uses Bootstrap 4. So tell Bootstrap 5 not to integrate with jquery,
+    // so that it doesn't conflict with Bootstrap 4.
+    document.body.setAttribute('data-bs-no-jquery', 'true');
+  </script>
+  <script defer src="{% static 'js/app-prod.js' %}"></script>
+{% endblock %}

--- a/peachjam/templates/admin/change_form.html
+++ b/peachjam/templates/admin/change_form.html
@@ -37,12 +37,6 @@
   {% endblock %}
 {% endblock %}
 {% block content %}
-  <script>
-  // app-prod.js uses Bootstrap 5, but jazzmin uses Bootstrap 4. So tell Bootstrap 5 not to integrate with jquery,
-  // so that it doesn't conflict with Bootstrap 4.
-  document.body.setAttribute('data-bs-no-jquery', 'true');
-  </script>
-  <script defer src="{% static 'js/app-prod.js' %}"></script>
   {{ block.super }}
   {% if original %}
     <!-- actual comment form, outside of main form; this will be updated with hx-oob-swap when a comment is posted -->

--- a/peachjam/templates/admin/peachjam/flynote/_merge_picker.html
+++ b/peachjam/templates/admin/peachjam/flynote/_merge_picker.html
@@ -1,0 +1,85 @@
+{% load i18n %}
+<div id="merge-picker">
+  <form method="post" action="{{ merge_url }}">
+    {% csrf_token %}
+    <input type="hidden" name="q" value="{{ query }}" />
+    <div class="card">
+      <h4 class="card-header">{% trans "Selected flynotes to merge into this one" %}</h4>
+      <div class="card-body">
+        {% if selected_flynotes %}
+          <ul class="list-unstyled">
+            {% for flynote in selected_flynotes %}
+              <li class="d-flex mb-2">
+                <button type="button"
+                        class="btn btn-danger btn-sm mr-3"
+                        hx-get="{{ picker_url }}"
+                        hx-target="#merge-picker"
+                        hx-swap="outerHTML"
+                        hx-include="#merge-search-form"
+                        hx-vals='{"remove":"{{ flynote.pk }}"}'>
+                  {% trans "Remove" %}
+                </button>
+                <input type="hidden" name="selected" value="{{ flynote.pk }}" />
+                <div class="flex-grow-1">
+                  <a href="{% url 'admin:peachjam_flynote_change' flynote.pk %}"
+                     target="_blank">{{ flynote.name }}</a>
+                  <span class="badge badge-secondary ml-2">{{ flynote.document_total }} {% trans "documents" %}</span>
+                </div>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p>{% trans "No flynotes selected yet." %}</p>
+        {% endif %}
+      </div>
+      <div class="card-footer">
+        <input type="submit"
+               class="btn btn-primary"
+               data-confirm="{% trans 'Are you sure? This cannot be undone.' %}"
+               value="{% trans 'Merge these flynotes' %}"
+               {% if not selected_flynotes %}disabled{% endif %}/>
+      </div>
+    </div>
+  </form>
+  <form id="merge-search-form"
+        method="get"
+        hx-get="{{ picker_url }}"
+        hx-target="#merge-picker"
+        hx-swap="outerHTML"
+        hx-trigger="input changed delay:300ms from:#id_q, search from:#id_q">
+    <h2>{% trans "Find sibling flynotes to merge" %}</h2>
+    {% for flynote in selected_flynotes %}<input type="hidden" name="selected" value="{{ flynote.pk }}" />{% endfor %}
+    <div>
+      <label for="id_q" class="form-label">{% trans "Search" %}</label>
+      <input id="id_q"
+             type="search"
+             name="q"
+             value="{{ query }}"
+             class="form-control"/>
+    </div>
+  </form>
+  {% if search_results %}
+    <ul class="list-unstyled mt-3">
+      {% for flynote in search_results %}
+        <li class="d-flex mb-2">
+          <button type="button"
+                  class="btn btn-primary btn-sm mr-3"
+                  hx-get="{{ picker_url }}"
+                  hx-target="#merge-picker"
+                  hx-swap="outerHTML"
+                  hx-include="#merge-search-form"
+                  hx-vals='{"add":"{{ flynote.pk }}"}'>
+            {% trans "Add" %}
+          </button>
+          <div class="flex-grow-1">
+            <a href="{% url 'admin:peachjam_flynote_change' flynote.pk %}"
+               target="_blank">{{ flynote.name }}</a>
+            <span class="badge badge-secondary ml-2">{{ flynote.document_total }} {% trans "documents" %}</span>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>{% trans "No matching sibling flynotes found." %}</p>
+  {% endif %}
+</div>

--- a/peachjam/templates/admin/peachjam/flynote/change_form.html
+++ b/peachjam/templates/admin/peachjam/flynote/change_form.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+{% block object-tools-items %}
+  {{ block.super }}
+  {% if change and not is_popup %}
+    <li>
+      <a href="{{ merge_url }}">{% trans "Merge other flynotes into this one" %}</a>
+    </li>
+  {% endif %}
+{% endblock %}

--- a/peachjam/templates/admin/peachjam/flynote/change_form.html
+++ b/peachjam/templates/admin/peachjam/flynote/change_form.html
@@ -1,10 +1,8 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 {% block object-tools-items %}
-  {{ block.super }}
   {% if change and not is_popup %}
-    <li>
-      <a href="{{ merge_url }}">{% trans "Merge other flynotes into this one" %}</a>
-    </li>
+    <a href="{{ merge_url }}" class="btn btn-block btn-secondary">{% trans "Merge other flynotes into this one" %}</a>
   {% endif %}
+  {{ block.super }}
 {% endblock %}

--- a/peachjam/templates/admin/peachjam/flynote/merge.html
+++ b/peachjam/templates/admin/peachjam/flynote/merge.html
@@ -1,0 +1,30 @@
+{% extends "admin/base.html" %}
+{% load i18n %}
+{% block breadcrumbs %}
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+    </li>
+    <li class="breadcrumb-item">
+      <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    </li>
+    <li class="breadcrumb-item">
+      <a href="{% url 'admin:peachjam_flynote_changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    </li>
+    <li class="breadcrumb-item">
+      <a href="{% url 'admin:peachjam_flynote_change' original.pk %}">{{ original }}</a>
+    </li>
+    <li class="breadcrumb-item">{% trans "Merge flynotes" %}</li>
+  </ol>
+{% endblock %}
+{% block content %}
+  <div id="content-main">
+    <h1>{{ title }}</h1>
+    <p>
+      {% blocktrans trimmed with target=target_flynote.name %}
+        Choose sibling flynotes to merge into “{{ target }}”.
+      {% endblocktrans %}
+    </p>
+    {% include "admin/peachjam/flynote/_merge_picker.html" %}
+  </div>
+{% endblock %}

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1716,7 +1716,10 @@ class FlynoteMergeTest(TestCase):
             language=Language.objects.first(),
         )
 
-    def test_merge_moves_direct_judgments_and_reparents_children(self):
+    @patch("peachjam.signals.serialise_judgment_flynote_tree")
+    def test_merge_moves_direct_judgments_and_reparents_children(
+        self, mock_serialise_judgment_flynote_tree
+    ):
         root = Flynote.add_root(name="Civil procedure")
         target = root.add_child(name="Stay of execution")
         source = root.add_child(name="Stays of execution")
@@ -1728,6 +1731,7 @@ class FlynoteMergeTest(TestCase):
         JudgmentFlynote.objects.create(
             document=descendant_judgment, flynote=source_child
         )
+        mock_serialise_judgment_flynote_tree.reset_mock()
 
         target.merge_sources_into([source])
 
@@ -1747,6 +1751,7 @@ class FlynoteMergeTest(TestCase):
                 flynote=source_child,
             ).exists()
         )
+        mock_serialise_judgment_flynote_tree.assert_called_once_with(direct_judgment.pk)
 
     def test_merge_rejects_duplicate_child_names_under_target(self):
         root = Flynote.add_root(name="Civil procedure")

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1704,6 +1704,64 @@ class FlynoteDeprecationTest(TestCase):
         )
 
 
+class FlynoteMergeTest(TestCase):
+    fixtures = ["tests/countries", "tests/courts", "tests/languages"]
+
+    def make_judgment(self, case_name):
+        return Judgment.objects.create(
+            case_name=case_name,
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 1, 1),
+            language=Language.objects.first(),
+        )
+
+    def test_merge_moves_direct_judgments_and_reparents_children(self):
+        root = Flynote.add_root(name="Civil procedure")
+        target = root.add_child(name="Stay of execution")
+        source = root.add_child(name="Stays of execution")
+        source_child = source.add_child(name="Urgent applications")
+
+        direct_judgment = self.make_judgment("Direct source judgment")
+        descendant_judgment = self.make_judgment("Descendant source judgment")
+        JudgmentFlynote.objects.create(document=direct_judgment, flynote=source)
+        JudgmentFlynote.objects.create(
+            document=descendant_judgment, flynote=source_child
+        )
+
+        target.merge_sources_into([source])
+
+        self.assertTrue(
+            JudgmentFlynote.objects.filter(
+                document=direct_judgment,
+                flynote=target,
+            ).exists()
+        )
+        self.assertFalse(Flynote.objects.filter(pk=source.pk).exists())
+
+        source_child.refresh_from_db()
+        self.assertEqual(source_child.get_parent().pk, target.pk)
+        self.assertTrue(
+            JudgmentFlynote.objects.filter(
+                document=descendant_judgment,
+                flynote=source_child,
+            ).exists()
+        )
+
+    def test_merge_rejects_duplicate_child_names_under_target(self):
+        root = Flynote.add_root(name="Civil procedure")
+        target = root.add_child(name="Stay of execution")
+        source = root.add_child(name="Stays of execution")
+        target.add_child(name="Urgent applications")
+        source.add_child(name="Urgent applications")
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "Cannot merge because the target already has children with these names: Urgent applications.",
+        ):
+            target.merge_sources_into([source])
+
+
 class FlynoteListViewTest(TestCase):
     fixtures = [
         "tests/countries",


### PR DESCRIPTION
Adds a mechanism for an editor to safely merge flynotes.

<img width="1908" height="1712" alt="image" src="https://github.com/user-attachments/assets/bdef75b3-8d6d-486f-a8cd-a4785693ca85" />

* the user can search for similar flynotes to merge into the current one, and choose which ones should be  merged in
* the flynotes are updated, all linked judgments are updated, and the old flynotes (and their entire trees) are deleted