### PR TITLE
Solves IntegrityError: duplicate key value violates unique constraint "unique_judgment_offence_judgment_offence"

### DIFF
--- a/peachjam/analysis/criminal_data/extractor.py
+++ b/peachjam/analysis/criminal_data/extractor.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from django.db import transaction
+from django.db import OperationalError, transaction
 
 from peachjam.models import (
     CaseTag,
@@ -31,8 +31,21 @@ class CriminalDataExtractor:
         if not os.environ.get("OPENAI_API_KEY"):
             raise ValueError("OPENAI_API_KEY is not configured.")
 
+    def lock_judgment_for_extraction(self, judgment_id: int) -> Judgment:
+        return Judgment.objects.select_for_update(nowait=True).get(pk=judgment_id)
+
     @transaction.atomic
     def extract(self, judgment: Judgment):
+        judgment_id = judgment.pk
+        try:
+            judgment = self.lock_judgment_for_extraction(judgment_id)
+        except OperationalError:
+            log.info(
+                "Skipping criminal data extraction for judgment %s because another extraction is running.",
+                judgment_id,
+            )
+            return None
+
         judgment_text = judgment.get_content_as_text()
         meta_out = extract_case_type_filing_year(judgment_text)
 

--- a/peachjam/analysis/criminal_data/extractor.py
+++ b/peachjam/analysis/criminal_data/extractor.py
@@ -124,7 +124,7 @@ class CriminalDataExtractor:
                     missing_case_tags,
                 )
 
-            jo = JudgmentOffence.objects.create(
+            jo, _ = JudgmentOffence.objects.get_or_create(
                 judgment=judgment,
                 offence=offence,
             )

--- a/peachjam/tests/test_criminal_data_extraction.py
+++ b/peachjam/tests/test_criminal_data_extraction.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 from countries_plus.models import Country
-from django.db import IntegrityError, connections
+from django.db import IntegrityError, OperationalError, connections
 from django.test import TransactionTestCase as TestCase
 from languages_plus.models import Language
 
@@ -523,6 +523,33 @@ class CriminalDataExtractorTests(TestCase):
             name="Sentence reduced",
             description="The sentence is reduced or varied downward.",
         )
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False)
+    @patch(
+        "peachjam.analysis.criminal_data.extractor.CriminalDataExtractor.lock_judgment_for_extraction"
+    )
+    @patch("peachjam.analysis.criminal_data.extractor.extract_outcomes")
+    @patch("peachjam.analysis.criminal_data.extractor.extract_offences_and_sentences")
+    @patch("peachjam.analysis.criminal_data.extractor.extract_case_type_filing_year")
+    @patch("peachjam.models.core_document.CoreDocument.get_content_as_text")
+    def test_extractor_skips_when_judgment_lock_is_busy(
+        self,
+        mock_get_content_as_text,
+        mock_extract_case_type_filing_year,
+        mock_extract_offences_and_sentences,
+        mock_extract_outcomes,
+        mock_lock_judgment_for_extraction,
+    ):
+        mock_lock_judgment_for_extraction.side_effect = OperationalError(
+            "could not obtain lock on row"
+        )
+
+        CriminalDataExtractor().extract(self.judgment)
+
+        self.assertFalse(mock_get_content_as_text.called)
+        self.assertFalse(mock_extract_case_type_filing_year.called)
+        self.assertFalse(mock_extract_offences_and_sentences.called)
+        self.assertFalse(mock_extract_outcomes.called)
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False)
     @patch("peachjam.analysis.criminal_data.extractor.extract_outcomes")

--- a/peachjam/tests/test_criminal_data_extraction.py
+++ b/peachjam/tests/test_criminal_data_extraction.py
@@ -38,6 +38,7 @@ from peachjam.models import (
     OffenceCategory,
     OffenceTag,
     Outcome,
+    Sentence,
     Work,
 )
 
@@ -687,6 +688,67 @@ class CriminalDataExtractorTests(TestCase):
             any("dropping invalid case tags" in message for message in logs.output)
         )
         self.assertTrue(any("with case tags" in message for message in logs.output))
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False)
+    @patch("peachjam.analysis.criminal_data.extractor.extract_outcomes")
+    @patch("peachjam.analysis.criminal_data.extractor.extract_offences_and_sentences")
+    @patch("peachjam.analysis.criminal_data.extractor.extract_case_type_filing_year")
+    @patch("peachjam.models.core_document.CoreDocument.get_content_as_text")
+    def test_extractor_merges_duplicate_offence_ids_in_single_run(
+        self,
+        mock_get_content_as_text,
+        mock_extract_case_type_filing_year,
+        mock_extract_offences_and_sentences,
+        mock_extract_outcomes,
+    ):
+        mock_get_content_as_text.return_value = "Criminal appeal text"
+        mock_extract_case_type_filing_year.return_value = CaseMetaExtraction(
+            case_type="criminal",
+            filing_year=2019,
+        )
+        mock_extract_offences_and_sentences.return_value = JudgmentOffenceExtraction(
+            offences=[
+                OffenceExtraction(
+                    offence_id=self.robbery.id,
+                    extracted_offence="robbery with violence",
+                    case_tags=["weapon-used"],
+                    sentences=[
+                        SentenceExtraction(
+                            sentence_type=Sentence.SentenceType.IMPRISONMENT,
+                            duration_months=120,
+                            fine_amount=None,
+                            suspended=False,
+                            mandatory_minimum=None,
+                        )
+                    ],
+                ),
+                OffenceExtraction(
+                    offence_id=self.robbery.id,
+                    extracted_offence="robbery with violence",
+                    case_tags=["group-offending"],
+                    sentences=[
+                        SentenceExtraction(
+                            sentence_type=Sentence.SentenceType.FINE,
+                            duration_months=None,
+                            fine_amount=5000,
+                            suspended=False,
+                            mandatory_minimum=None,
+                        )
+                    ],
+                ),
+            ]
+        )
+        mock_extract_outcomes.return_value = JudgmentOutcomeExtraction(outcomes=[])
+
+        CriminalDataExtractor().extract(self.judgment)
+
+        self.assertEqual(self.judgment.judgment_offence.count(), 1)
+        self.assertEqual(self.judgment.sentences.count(), 2)
+        jo = self.judgment.judgment_offence.get()
+        self.assertCountEqual(
+            list(jo.tags.values_list("name", flat=True)),
+            ["group-offending"],
+        )
 
 
 class CriminalDataVocabularyTests(TestCase):


### PR DESCRIPTION
Closes #3141 
The most likely cause I could think of is that there are matches in offence_out.offences with the same offence id, and that throws the error when we try creating a JudgmentOffence that already exists. To solve this, I used get_or_create instead.

I also implemented select_for_update on the judgment to prevent cases where concurrent tasks or multiple content updates occur at a time.