### PR TITLE
generate summary immediately

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -1970,7 +1970,9 @@ class JudgmentAdmin(ImportExportMixin, DocumentAdmin):
     def generate_summary_view(self, request, object_id):
         if request.user.has_perm("peachjam.can_generate_judgment_summary"):
             message = _("Generating summary for judgment with ID: {}").format(object_id)
-            generate_judgment_summary(object_id)
+            doc = self.model.objects.get(pk=object_id)
+            doc.track_changes()
+            doc.generate_summary()
             self.message_user(request, message)
         else:
             message = _("You do not have permission to generate judgment summaries.")

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -1246,13 +1246,20 @@ class FlynoteAdmin(admin.ModelAdmin):
     list_filter = ("depth", "deprecated", FlynoteDocumentCountFilter)
     search_fields = ("name",)
     ordering = ("name",)
-    readonly_fields = ("numchild", "ancestors_links", "children_links", "depth")
+    readonly_fields = (
+        "numchild",
+        "ancestors_links",
+        "children_links",
+        "depth",
+        "document_count",
+    )
     fields = (
         "ancestors_links",
         "name",
         "deprecated",
         "depth",
         "numchild",
+        "document_count",
         "children_links",
     )
     actions = ("refresh_document_counts_now", "mark_deprecated", "mark_active")

--- a/peachjam/analysis/summariser.py
+++ b/peachjam/analysis/summariser.py
@@ -215,7 +215,7 @@ class JudgmentSummariser:
     match_flynotes_to_db = settings.PEACHJAM["SUMMARISE_USE_FLYNOTE_TREE"]
     agent: Optional[Agent] = None
     run_result: Optional[RunResult] = None
-    max_top_level_flynotes = 50
+    max_top_level_flynotes = 100
 
     def __init__(self):
         self.summary_language = settings.PEACHJAM["SUMMARISER_LANGUAGE"]

--- a/peachjam/tasks.py
+++ b/peachjam/tasks.py
@@ -359,7 +359,11 @@ def send_new_relationship_email_alert(user_id):
     log.info("New relationship email alerts sent")
 
 
-@background(queue="peachjam", schedule=5 * 60, remove_existing_tasks=True)
+@background(
+    queue="peachjam",
+    remove_existing_tasks=True,
+    schedule={"run_at": 5 * 60, "priority": -1},
+)
 @transaction.atomic
 def generate_judgment_summary(doc_id):
     from peachjam.models import Judgment


### PR DESCRIPTION
this is useful when an editor wants to force a new summary and review it

also:
* summary task priority = -1
* show num documents in flynote admin