### PR TITLE
make update work citations trigger more granular

### DIFF
--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -1200,6 +1200,17 @@ class DocumentContent(AttributeHooksMixin, models.Model):
 
     @on_attribute_changed(
         AFTER_SAVE,
+        ["content_html"],
+        ["CoreDocument.extracted_citations"],
+    )
+    def trigger_update_extracted_citations_from_content_html(self):
+        from peachjam.tasks import update_extracted_citations_for_a_work
+
+        if self.document_id:
+            update_extracted_citations_for_a_work(self.document.work_id)
+
+    @on_attribute_changed(
+        AFTER_SAVE,
         ["content_text"],
         [
             "Judgment.blurb",

--- a/peachjam/signals.py
+++ b/peachjam/signals.py
@@ -15,6 +15,7 @@ from django_comments.signals import comment_will_be_posted
 from peachjam.customerio import get_customerio
 from peachjam.models import (
     Annotation,
+    CitationLink,
     CoreDocument,
     DocumentChatThread,
     ExtractedCitation,
@@ -70,18 +71,24 @@ def doc_deleted_update_language(sender, instance, **kwargs):
             work.update_languages()
 
 
-@receiver(signals.post_save)
-def doc_saved_update_extracted_citations(sender, instance, **kwargs):
-    """Update extracted citations when a subclass of CoreDocument is saved."""
-    if isinstance(instance, CoreDocument) and not kwargs["raw"]:
-        update_extracted_citations_for_a_work(instance.work_id)
-
-
 @receiver(signals.post_delete)
 def doc_deleted_update_extracted_citations(sender, instance, **kwargs):
-    """Update language list on related work after a subclass of CoreDocument is deleted."""
+    """Update extracted citations after a subclass of CoreDocument is deleted."""
     if isinstance(instance, CoreDocument):
         update_extracted_citations_for_a_work(instance.work_id)
+
+
+@receiver(signals.post_save, sender=CitationLink)
+def citation_link_saved_update_extracted_citations(sender, instance, raw, **kwargs):
+    """Update extracted citations when source citation links are changed."""
+    if not raw:
+        update_extracted_citations_for_a_work(instance.document.work_id)
+
+
+@receiver(signals.post_delete, sender=CitationLink)
+def citation_link_deleted_update_extracted_citations(sender, instance, **kwargs):
+    """Update extracted citations when source citation links are deleted."""
+    update_extracted_citations_for_a_work(instance.document.work_id)
 
 
 @receiver(signals.post_save, sender=ExtractedCitation)

--- a/peachjam/tests/test_document_content.py
+++ b/peachjam/tests/test_document_content.py
@@ -1,11 +1,13 @@
 import os
 from datetime import date
+from unittest.mock import patch
 
 from django.core.files.base import File
 from django.test import TestCase
 from docpipe.soffice import SOfficeError
 
 from peachjam.models import (
+    CitationLink,
     Country,
     DocumentContent,
     GenericDocument,
@@ -301,6 +303,49 @@ class DocumentContentDerivedFieldsTestCase(TestCase):
         doc_content.save()
         self.assertIsNotNone(doc_content.content_text)
         self.assertIn("Extracted text", doc_content.content_text)
+
+    def test_content_html_change_updates_extracted_citations(self):
+        """The AFTER_SAVE hook updates work extracted citations when content_html changes."""
+        doc = _make_doc("Hook extracted citations")
+        doc_content = doc.get_or_create_document_content(True)
+
+        with patch("peachjam.tasks.update_extracted_citations_for_a_work") as update:
+            doc_content.content_html = (
+                '<p><a href="/akn/za/act/2009/5">Act 5 of 2009</a></p>'
+            )
+            doc_content.save()
+
+        update.assert_called_once_with(doc.work_id)
+
+    def test_document_save_does_not_update_extracted_citations(self):
+        """A metadata-only CoreDocument save doesn't update extracted citations."""
+        doc = _make_doc("No extracted citation update")
+
+        with patch("peachjam.signals.update_extracted_citations_for_a_work") as update:
+            doc.title = "Updated"
+            doc.save()
+
+        update.assert_not_called()
+
+    def test_citation_link_changes_update_extracted_citations(self):
+        """CitationLink changes update extracted citations for the related work."""
+        doc = _make_doc("Citation link extracted citation update")
+
+        with patch("peachjam.signals.update_extracted_citations_for_a_work") as update:
+            citation_link = CitationLink.objects.create(
+                document=doc,
+                text="Act 5 of 2009",
+                url="/akn/za/act/2009/5",
+                target_id="page-1",
+                target_selectors=[],
+            )
+
+        update.assert_called_once_with(doc.work_id)
+
+        with patch("peachjam.signals.update_extracted_citations_for_a_work") as update:
+            citation_link.delete()
+
+        update.assert_called_once_with(doc.work_id)
 
     def test_toc_not_generated_for_akn(self):
         """update_toc_json_from_content_html() is a no-op for AKN documents."""


### PR DESCRIPTION
otherwise we update work citations unneccesarily on minor metadata changes, including when bulk re-generating judgment summaries.