### PR TITLE
more granular language and summary triggers

### DIFF
--- a/peachjam/models/core_document.py
+++ b/peachjam/models/core_document.py
@@ -693,12 +693,19 @@ class CoreDocument(AttributeHooksMixin, PolymorphicModel):
         if self.decorator:
             self.decorator.post_save(self)
 
+    @on_attribute_changed(AFTER_SAVE, ["language"], ["Work.languages"])
+    def trigger_update_work_languages_from_language(self):
+        self.work.update_languages()
+
     def save(self, *args, **kwargs):
         # give ourselves and subclasses a chance to pre-populate derived fields before saving,
         # in case full_clean() has not yet been called
+        is_new = self._state.adding
         self.pre_save()
         super().save(*args, **kwargs)
         self.post_save()
+        if is_new:
+            self.work.update_languages()
 
     def extract_citations(self):
         """Run citation extraction on this document. If the document has content_html,

--- a/peachjam/signals.py
+++ b/peachjam/signals.py
@@ -31,7 +31,6 @@ from peachjam.models import (
 from peachjam.models.core_document import DocumentContent
 from peachjam.tasks import (
     extract_criminal_data,
-    generate_judgment_summary,
     refresh_flynote_document_count,
     serialise_judgment_flynote_tree,
     update_extracted_citations_for_a_work,
@@ -52,13 +51,6 @@ def user_saved(sender, instance, created, **kwargs):
     if created:
         # ensure a user profile exists
         UserProfile.objects.get_or_create(user=instance)
-
-
-@receiver(signals.post_save)
-def doc_saved_update_language(sender, instance, **kwargs):
-    """Update language list on related work when a subclass of CoreDocument is saved."""
-    if isinstance(instance, CoreDocument) and not kwargs["raw"]:
-        instance.work.update_languages()
 
 
 @receiver(signals.post_delete)
@@ -215,24 +207,6 @@ def password_reset_started_customerio(sender, request, user, **kwargs):
 @receiver(allauth_signals.password_reset, sender=User)
 def password_reset_customerio(sender, request, user, **kwargs):
     get_customerio().track_password_reset(user)
-
-
-@receiver(signals.post_save, sender=DocumentContent)
-def judgment_content_changed_generate_summary(sender, instance, raw, **kwargs):
-    if raw:
-        return
-
-    if not instance.document.doc_type == "judgment":
-        return
-    judgment = instance.document
-    should_generate = (
-        not judgment.case_summary  # No summary at all
-        or judgment.summary_ai_generated  # Summary exists but is AI-generated
-    ) and (
-        not judgment.must_be_anonymised or judgment.anonymised  # Anonymization OK
-    )
-    if should_generate:
-        generate_judgment_summary(judgment.pk)
 
 
 @receiver(signals.pre_save, sender=DocumentContent)

--- a/peachjam/tests/test_document_content.py
+++ b/peachjam/tests/test_document_content.py
@@ -327,6 +327,20 @@ class DocumentContentDerivedFieldsTestCase(TestCase):
 
         update.assert_not_called()
 
+    def test_language_change_updates_work_languages(self):
+        """The CoreDocument AFTER_SAVE hook updates work languages when language changes."""
+        doc = _make_doc("Hook work languages")
+        work = doc.work
+
+        self.assertEqual(["eng"], work.languages)
+
+        doc.track_changes()
+        doc.language = Language.objects.get(pk="fr")
+        doc.save()
+        work.refresh_from_db()
+
+        self.assertEqual(["fra"], work.languages)
+
     def test_citation_link_changes_update_extracted_citations(self):
         """CitationLink changes update extracted citations for the related work."""
         doc = _make_doc("Citation link extracted citation update")


### PR DESCRIPTION
* Update work languages inline when it changes, and on first creation of a document.
* Remove legacy blunt summary trigger on DocumentContent change