### PR TITLE
Flynote functionality improvements

### DIFF
--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -26,7 +26,7 @@ from time import perf_counter
 from django.db import IntegrityError, transaction
 from django.utils.text import slugify
 
-from peachjam.models.flynote import Flynote, JudgmentFlynote
+from peachjam.models.flynote import Flynote, FlynoteDocumentCount, JudgmentFlynote
 
 log = logging.getLogger(__name__)
 
@@ -2668,9 +2668,10 @@ class FlynoteUpdater:
         updater.update_for_judgment(judgment)
     """
 
-    def __init__(self, assume_clean=True):
+    def __init__(self, assume_clean=True, update_counts=True):
         self.parser = FlynoteParser(assume_clean=assume_clean)
         self.node_cache = {}
+        self.update_counts = update_counts
 
     def get_or_create_node(self, parent, name):
         """Find an existing Flynote whose normalised sibling name matches, or create a new one.
@@ -2813,6 +2814,9 @@ class FlynoteUpdater:
         )
         link_ms = (perf_counter() - link_start) * 1000
 
+        if self.update_counts:
+            self.quick_refresh_counts(leaf_flynotes)
+
         log.info(
             "Linked judgment %s to %s flynote topics (parse=%.2fms, nodes=%.2fms, links=%.2fms, total=%.2fms).",
             judgment.pk,
@@ -2823,3 +2827,23 @@ class FlynoteUpdater:
             (perf_counter() - overall_start) * 1000,
         )
         return affected_root_ids
+
+    def quick_refresh_counts(self, leaf_flynotes):
+        """Optimistically refresh linked leaves and ancestors.
+
+        Leaves are refreshed first so that immediate parent estimates can use
+        fresh child counts. Ancestors then run deepest-to-root for the same
+        reason.
+        """
+        flynotes = {}
+        for leaf in leaf_flynotes:
+            flynotes[leaf.pk] = leaf
+            for ancestor in leaf.get_ancestors():
+                flynotes[ancestor.pk] = ancestor
+
+        for flynote in sorted(
+            flynotes.values(),
+            key=lambda item: item.depth,
+            reverse=True,
+        ):
+            FlynoteDocumentCount.quick_refresh_for_single_flynote(flynote)

--- a/peachjam/management/commands/update_flynote_taxonomies.py
+++ b/peachjam/management/commands/update_flynote_taxonomies.py
@@ -46,7 +46,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write("Using Flynote model (no taxonomy root required)")
 
-        updater = FlynoteUpdater(assume_clean=options["assume_clean"])
+        updater = FlynoteUpdater(
+            assume_clean=options["assume_clean"],
+            update_counts=False,
+        )
         skip_counts = options["skip_counts"]
 
         if options["judgment_id"]:

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -6,6 +6,8 @@ from django.db import connection, models, transaction
 from django.db.models import Exists, OuterRef
 from django.db.models.deletion import ProtectedError
 from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from django_lifecycle import AFTER_SAVE, LifecycleModelMixin
 from treebeard.mp_tree import MP_Node
@@ -79,9 +81,41 @@ class Flynote(LifecycleModelMixin, MP_Node):
                 }
             )
 
+    def validate_unique_sibling_name(self):
+        """Prevent admin edits from creating duplicate sibling/root names."""
+        if not self.pk:
+            return
+
+        name = self.name.strip()
+        if self.is_root():
+            siblings = Flynote.get_root_nodes()
+        else:
+            siblings = self.get_parent().get_children()
+
+        duplicate = siblings.exclude(pk=self.pk).filter(name__iexact=name).first()
+        if not duplicate:
+            return
+
+        merge_url = "{}?{}".format(
+            reverse("admin:peachjam_flynote_merge", args=[duplicate.pk]),
+            urlencode({"selected": self.pk, "q": name}),
+        )
+        raise ValidationError(
+            {
+                "name": format_html(
+                    _(
+                        "A sibling flynote already has this name. "
+                        '<a href="{}">Merge this flynote into that one</a> instead.'
+                    ),
+                    merge_url,
+                )
+            }
+        )
+
     def clean(self):
         super().clean()
         self.validate_deprecated_invariant()
+        self.validate_unique_sibling_name()
 
     @on_attribute_changed(AFTER_SAVE, ["name", "path"], [])
     def serialise_linked_judgments(self):

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -231,6 +231,66 @@ class Flynote(LifecycleModelMixin, MP_Node):
         source.delete()
         FlynoteDocumentCount.quick_refresh_for_single_flynote(self)
 
+    def prune_empty_descendants(self):
+        """Delete empty flynotes under this flynote.
+
+        Locks the tree root before pruning so concurrent tree/count updates for
+        the same tree are serialised, even when pruning only a subtree.
+        """
+        flynote_id = self.pk
+
+        with transaction.atomic():
+            flynote = Flynote.objects.filter(pk=flynote_id).first()
+            if not flynote:
+                log.info(
+                    "No flynote with id %s exists while pruning empty descendants, ignoring.",
+                    flynote_id,
+                )
+                return
+
+            tree_root = (
+                Flynote.objects.select_for_update()
+                .filter(pk=flynote.get_root().pk)
+                .first()
+            )
+            if not tree_root:
+                log.info(
+                    "No flynote root exists for %s while pruning empty descendants, ignoring.",
+                    flynote_id,
+                )
+                return
+
+            flynote.refresh_from_db()
+            root_path = flynote.path
+
+            # Stale count rows can briefly make a linked flynote look empty, so
+            # only consider nodes with no linked judgments anywhere in their
+            # subtree and still guard against races during delete.
+            log.info("Pruning empty flynotes under %s", flynote)
+            linked_judgments = JudgmentFlynote.objects.filter(
+                flynote__path__startswith=OuterRef("path")
+            )
+            empty_flynotes = list(
+                Flynote.objects.filter(path__startswith=root_path)
+                .filter(document_count_cache__isnull=True)
+                .annotate(has_linked_judgments=Exists(linked_judgments))
+                .filter(has_linked_judgments=False)
+                .order_by("-depth", "-path")
+            )
+            for empty_flynote in empty_flynotes:
+                try:
+                    empty_flynote.delete()
+                except Flynote.DoesNotExist:
+                    log.warning(
+                        "Skipping prune of flynote %s because it was already deleted.",
+                        empty_flynote.pk,
+                    )
+                except ProtectedError:
+                    log.warning(
+                        "Skipping prune of flynote %s because linked judgments still protect it.",
+                        empty_flynote.pk,
+                    )
+
     @classmethod
     def flynotes_to_string(cls, judgment_flynotes):
         """Convert a queryset of JudgmentFlynote to a string representation."""
@@ -414,34 +474,7 @@ class FlynoteDocumentCount(models.Model):
                     [root_path + "%", root_path + "%"],
                 )
 
-            # Stale count rows can briefly make a linked flynote look empty, so
-            # only consider nodes with no linked judgments anywhere in their
-            # subtree and still guard against races during delete.
-            log.info("Pruning empty flynotes under %s", flynote)
-            linked_judgments = JudgmentFlynote.objects.filter(
-                flynote__path__startswith=OuterRef("path")
-            )
-            empty_flynotes = list(
-                Flynote.objects.filter(path__startswith=root_path)
-                .filter(document_count_cache__isnull=True)
-                .annotate(has_linked_judgments=Exists(linked_judgments))
-                .filter(has_linked_judgments=False)
-                .order_by("-depth", "-path")
-            )
-            for empty_flynote in empty_flynotes:
-                try:
-                    empty_flynote.delete()
-                except Flynote.DoesNotExist:
-                    log.warning(
-                        "Skipping prune of flynote %s because it was already deleted.",
-                        empty_flynote.pk,
-                    )
-                except ProtectedError:
-                    log.warning(
-                        "Skipping prune of flynote %s because linked judgments still protect it.",
-                        empty_flynote.pk,
-                    )
-
+        flynote.prune_empty_descendants()
         log.info("Refreshed document counts for flynote tree under %s", flynote)
 
     @classmethod

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -166,6 +166,8 @@ class Flynote(LifecycleModelMixin, MP_Node):
 
             target_parent = target.get_parent()
             target_parent_id = target_parent.pk if target_parent else None
+            source_parents = []
+            source_parent_ids = set()
 
             for source in sources:
                 source_parent = source.get_parent()
@@ -176,12 +178,18 @@ class Flynote(LifecycleModelMixin, MP_Node):
                             "Flynotes can only be merged into a sibling at the same level."
                         )
                     )
+                if source_parent_id and source_parent_id not in source_parent_ids:
+                    source_parents.append(source_parent)
+                    source_parent_ids.add(source_parent_id)
 
             log.info(f"Merging flynotes into {self}: {sources}")
             for source in sources:
                 target._merge_other_into(source)
 
-            refresh_flynote_document_count(target.get_root().pk)
+            for source_parent in source_parents:
+                if Flynote.objects.filter(pk=source_parent.pk).exists():
+                    source_parent.refresh_from_db()
+                    FlynoteDocumentCount.quick_refresh_for_single_flynote(source_parent)
             log.info("Finished merging flynotes")
 
     def _merge_other_into(self, source):
@@ -221,6 +229,7 @@ class Flynote(LifecycleModelMixin, MP_Node):
                 child.move(self, pos="sorted-child")
 
         source.delete()
+        FlynoteDocumentCount.quick_refresh_for_single_flynote(self)
 
     @classmethod
     def flynotes_to_string(cls, judgment_flynotes):
@@ -306,31 +315,73 @@ class FlynoteDocumentCount(models.Model):
         return f"{self.flynote.name}: {self.count}"
 
     @classmethod
-    def refresh_for_flynote(cls, root):
-        """Recompute document counts for flynotes under *root*.
+    def quick_refresh_for_single_flynote(cls, flynote, limit=1000):
+        """Refresh counts for one flynote now if it is cheap. Always queues a background refresh of the root.
+
+        Child counts are assumed to already be correct. The estimate is used
+        only as a cheap threshold check; refresh_for_flynote() still computes
+        the exact count if the subtree is small enough.
+        """
+        flynote.refresh_from_db(fields=["path", "numchild"])
+        direct_count = (
+            JudgmentFlynote.objects.filter(flynote=flynote)
+            .values("document_id")
+            .distinct()
+            .count()
+        )
+        child_count = sum(
+            cls.objects.filter(flynote__in=flynote.get_children()).values_list(
+                "count", flat=True
+            )
+        )
+
+        estimated_count = direct_count + child_count
+        if estimated_count < limit:
+            cls.refresh_for_flynote(flynote)
+
+        # always queue up a refresh of the root (if this not a root)
+        if flynote.depth > 1:
+            refresh_flynote_document_count(flynote.get_root().pk)
+
+    @classmethod
+    def refresh_for_flynote(cls, flynote):
+        """Recompute document counts for flynotes under *flynote*, which could be a root or just a subtree.
 
         Each node's count includes documents linked directly to it plus
         documents linked to any of its descendants. Uses treebeard's
         materialised path to walk ancestors efficiently in a single SQL
         query, following the same pattern as TaxonomyDocumentCount.
         """
-        if root is None:
-            raise ValueError("refresh_for_flynote requires a root flynote node")
+        if flynote is None:
+            raise ValueError("refresh_for_flynote requires a flynote node")
 
-        root_id = root.pk
+        flynote_id = flynote.pk
 
         with transaction.atomic():
-            root = Flynote.objects.select_for_update().filter(pk=root_id).first()
-            if not root:
+            flynote = Flynote.objects.filter(pk=flynote_id).first()
+            if not flynote:
                 log.info(
-                    "No flynote root with id %s exists while refreshing counts, ignoring.",
-                    root_id,
+                    "No flynote with id %s exists while refreshing counts, ignoring.",
+                    flynote_id,
                 )
                 return
 
-            root_path = root.path
+            tree_root = (
+                Flynote.objects.select_for_update()
+                .filter(pk=flynote.get_root().pk)
+                .first()
+            )
+            if not tree_root:
+                log.info(
+                    "No flynote root exists for %s while refreshing counts, ignoring.",
+                    flynote_id,
+                )
+                return
+
+            flynote.refresh_from_db()
+            root_path = flynote.path
             with connection.cursor() as cursor:
-                log.info("Deleting cached flynote counts under root %s", root)
+                log.info("Deleting cached flynote counts under %s", flynote)
                 cursor.execute(
                     """
                     DELETE FROM peachjam_flynotedocumentcount
@@ -342,7 +393,7 @@ class FlynoteDocumentCount(models.Model):
                     [root_path + "%"],
                 )
 
-                log.info("Rebuilding cached flynote counts under root %s", root)
+                log.info("Rebuilding cached flynote counts under %s", flynote)
                 cursor.execute(
                     """
                     INSERT INTO peachjam_flynotedocumentcount (flynote_id, count)
@@ -366,7 +417,7 @@ class FlynoteDocumentCount(models.Model):
             # Stale count rows can briefly make a linked flynote look empty, so
             # only consider nodes with no linked judgments anywhere in their
             # subtree and still guard against races during delete.
-            log.info("Pruning empty flynotes under root %s", root)
+            log.info("Pruning empty flynotes under %s", flynote)
             linked_judgments = JudgmentFlynote.objects.filter(
                 flynote__path__startswith=OuterRef("path")
             )
@@ -377,21 +428,21 @@ class FlynoteDocumentCount(models.Model):
                 .filter(has_linked_judgments=False)
                 .order_by("-depth", "-path")
             )
-            for flynote in empty_flynotes:
+            for empty_flynote in empty_flynotes:
                 try:
-                    flynote.delete()
+                    empty_flynote.delete()
                 except Flynote.DoesNotExist:
                     log.warning(
                         "Skipping prune of flynote %s because it was already deleted.",
-                        flynote.pk,
+                        empty_flynote.pk,
                     )
                 except ProtectedError:
                     log.warning(
                         "Skipping prune of flynote %s because linked judgments still protect it.",
-                        flynote.pk,
+                        empty_flynote.pk,
                     )
 
-        log.info("Refreshed document counts for flynote tree rooted at %s", root)
+        log.info("Refreshed document counts for flynote tree under %s", flynote)
 
     @classmethod
     def refresh_for_all_flynotes(cls):

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -136,10 +136,12 @@ class Flynote(LifecycleModelMixin, MP_Node):
         """Merge sibling flynotes into this flynote.
 
         Direct judgment links on each source move to this flynote. Source
-        children are re-parented under this flynote. Source flynotes are then
-        deleted explicitly.
+        children are merged into matching children on this flynote, or
+        re-parented under this flynote. Source flynotes are then deleted
+        explicitly.
         """
-        from peachjam.analysis.flynotes import FlynoteParser
+        if not all(isinstance(source, Flynote) for source in sources):
+            raise TypeError("merge_sources_into expects a list of Flynote objects")
 
         source_ids = []
         for source in sources:
@@ -175,55 +177,50 @@ class Flynote(LifecycleModelMixin, MP_Node):
                         )
                     )
 
-            existing_child_names = {
-                FlynoteParser.normalise_name(child.name): child.name
-                for child in target.get_children()
-                if FlynoteParser.normalise_name(child.name)
-            }
-            duplicate_child_names = set()
-
-            for source in sources:
-                for child in source.get_children():
-                    normalised = FlynoteParser.normalise_name(child.name)
-                    if not normalised:
-                        continue
-                    if normalised in existing_child_names:
-                        duplicate_child_names.add(child.name)
-                    else:
-                        existing_child_names[normalised] = child.name
-
-            if duplicate_child_names:
-                duplicates = ", ".join(sorted(duplicate_child_names))
-                raise ValidationError(
-                    _(
-                        "Cannot merge because the target already has children with these names: %(duplicates)s."
-                    )
-                    % {"duplicates": duplicates}
-                )
-
             log.info(f"Merging flynotes into {self}: {sources}")
             for source in sources:
-                for judgment_flynote in list(source.judgments.select_for_update()):
-                    duplicate = JudgmentFlynote.objects.filter(
-                        document_id=judgment_flynote.document_id,
-                        flynote=target,
-                    ).exists()
-                    if duplicate:
-                        judgment_flynote.delete()
-                    else:
-                        judgment_flynote.flynote = target
-                        judgment_flynote.save(update_fields=["flynote"])
-
-                for child in list(source.get_children()):
-                    # moving nodes updates path attributes, so always work with latest info from db
-                    child.refresh_from_db()
-                    target.refresh_from_db()
-                    child.move(target, pos="sorted-child")
-
-                source.delete()
+                target._merge_other_into(source)
 
             refresh_flynote_document_count(target.get_root().pk)
             log.info("Finished merging flynotes")
+
+    def _merge_other_into(self, source):
+        """Merge one corresponding source flynote into this flynote."""
+        from peachjam.analysis.flynotes import FlynoteParser
+
+        for judgment_flynote in list(source.judgments.select_for_update()):
+            duplicate = JudgmentFlynote.objects.filter(
+                document_id=judgment_flynote.document_id,
+                flynote=self,
+            ).exists()
+            if duplicate:
+                judgment_flynote.delete()
+            else:
+                judgment_flynote.flynote = self
+                judgment_flynote.save(update_fields=["flynote"])
+
+        for child in list(source.get_children()):
+            normalised = FlynoteParser.normalise_name(child.name)
+            target_child = None
+            if normalised:
+                target_child = next(
+                    (
+                        candidate
+                        for candidate in self.get_children().select_for_update()
+                        if FlynoteParser.normalise_name(candidate.name) == normalised
+                    ),
+                    None,
+                )
+
+            if target_child:
+                target_child._merge_other_into(child)
+            else:
+                # moving nodes updates path attributes, so always work with latest info from db
+                child.refresh_from_db()
+                self.refresh_from_db()
+                child.move(self, pos="sorted-child")
+
+        source.delete()
 
     @classmethod
     def flynotes_to_string(cls, judgment_flynotes):

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1990,7 +1990,50 @@ class FlynoteMergeTest(TestCase):
 
         target.merge_sources_into([source])
 
-        mock_refresh.assert_called_once_with(root.pk)
+        mock_refresh.assert_any_call(root.pk)
+
+    @patch("peachjam.models.flynote.refresh_flynote_document_count")
+    def test_merge_refreshes_small_target_count_inline(self, mock_refresh):
+        root = Flynote.add_root(name="Civil procedure")
+        target = root.add_child(name="Stay of execution")
+        source = root.add_child(name="Stays of execution")
+
+        target_judgment = self.make_judgment("Target judgment")
+        source_judgment = self.make_judgment("Source judgment")
+        JudgmentFlynote.objects.create(document=target_judgment, flynote=target)
+        JudgmentFlynote.objects.create(document=source_judgment, flynote=source)
+        FlynoteDocumentCount.objects.create(flynote=target, count=1)
+        FlynoteDocumentCount.objects.create(flynote=source, count=1)
+
+        target.merge_sources_into([source])
+
+        self.assertEqual(
+            FlynoteDocumentCount.objects.get(flynote=target).count,
+            2,
+        )
+        self.assertEqual(
+            FlynoteDocumentCount.objects.get(flynote=root).count,
+            2,
+        )
+        mock_refresh.assert_any_call(root.pk)
+
+    @patch("peachjam.models.flynote.refresh_flynote_document_count")
+    def test_merge_skips_inline_target_count_when_estimate_is_large(self, mock_refresh):
+        root = Flynote.add_root(name="Civil procedure")
+        target = root.add_child(name="Stay of execution")
+        target_child = target.add_child(name="Urgent applications")
+        source = root.add_child(name="Stays of execution")
+
+        FlynoteDocumentCount.objects.create(flynote=target, count=5001)
+        FlynoteDocumentCount.objects.create(flynote=target_child, count=5001)
+
+        target.merge_sources_into([source])
+
+        self.assertEqual(
+            FlynoteDocumentCount.objects.get(flynote=target).count,
+            5001,
+        )
+        mock_refresh.assert_any_call(root.pk)
 
     def test_merge_recursively_merges_duplicate_child_names_under_target(self):
         root = Flynote.add_root(name="Civil procedure")

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1992,18 +1992,29 @@ class FlynoteMergeTest(TestCase):
 
         mock_refresh.assert_called_once_with(root.pk)
 
-    def test_merge_rejects_duplicate_child_names_under_target(self):
+    def test_merge_recursively_merges_duplicate_child_names_under_target(self):
         root = Flynote.add_root(name="Civil procedure")
         target = root.add_child(name="Stay of execution")
         source = root.add_child(name="Stays of execution")
-        target.add_child(name="Urgent applications")
-        source.add_child(name="Urgent applications")
+        target_child = target.add_child(name="Urgent applications")
+        source_child = source.add_child(name="Urgent applications")
 
-        with self.assertRaisesMessage(
-            ValidationError,
-            "Cannot merge because the target already has children with these names: Urgent applications.",
-        ):
-            target.merge_sources_into([source])
+        source_child_judgment = self.make_judgment("Source child judgment")
+        JudgmentFlynote.objects.create(
+            document=source_child_judgment, flynote=source_child
+        )
+
+        target.merge_sources_into([source])
+
+        self.assertFalse(Flynote.objects.filter(pk=source.pk).exists())
+        self.assertFalse(Flynote.objects.filter(pk=source_child.pk).exists())
+        self.assertTrue(Flynote.objects.filter(pk=target_child.pk).exists())
+        self.assertTrue(
+            JudgmentFlynote.objects.filter(
+                document=source_child_judgment,
+                flynote=target_child,
+            ).exists()
+        )
 
 
 class FlynoteListViewTest(TestCase):

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1351,6 +1351,34 @@ class UpdateFlynoteForJudgmentTest(TestCase):
         trial = Flynote.objects.get(name="trial within a trial")
         self.assertEqual(trial.get_parent().pk, admissibility.pk)
 
+    @patch(
+        "peachjam.analysis.flynotes.FlynoteDocumentCount.quick_refresh_for_single_flynote"
+    )
+    def test_update_quick_refreshes_leaf_flynotes_and_ancestors(self, mock_refresh):
+        self.updater.update_for_judgment(self.judgment)
+
+        refreshed_names = {call.args[0].name for call in mock_refresh.call_args_list}
+        self.assertEqual(
+            refreshed_names,
+            {
+                "Criminal law",
+                "admissibility",
+                "trial within a trial",
+                "circumstantial evidence",
+                "Blom principles",
+            },
+        )
+
+    @patch(
+        "peachjam.analysis.flynotes.FlynoteDocumentCount.quick_refresh_for_single_flynote"
+    )
+    def test_update_can_skip_quick_count_refresh(self, mock_refresh):
+        updater = FlynoteUpdater(update_counts=False)
+
+        updater.update_for_judgment(self.judgment)
+
+        mock_refresh.assert_not_called()
+
     def test_clears_old_links_on_reprocess(self):
         self.updater.update_for_judgment(self.judgment)
         initial_count = JudgmentFlynote.objects.filter(document=self.judgment).count()

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -2088,6 +2088,42 @@ class FlynoteMergeTest(TestCase):
         )
 
 
+class FlynoteCleanTest(TestCase):
+    def test_rejects_duplicate_root_name(self):
+        Flynote.add_root(name="Civil procedure")
+        duplicate = Flynote.add_root(name="Civil proceedings")
+        duplicate.name = "Civil procedure"
+
+        with self.assertRaises(ValidationError) as cm:
+            duplicate.clean()
+        self.assertIn(
+            "Merge this flynote into that one",
+            cm.exception.message_dict["name"][0],
+        )
+
+    def test_rejects_duplicate_sibling_name(self):
+        root = Flynote.add_root(name="Civil procedure")
+        root.add_child(name="Costs")
+        duplicate = root.add_child(name="Cost orders")
+        duplicate.name = "Costs"
+
+        with self.assertRaises(ValidationError) as cm:
+            duplicate.clean()
+        self.assertIn(
+            "Merge this flynote into that one",
+            cm.exception.message_dict["name"][0],
+        )
+
+    def test_allows_duplicate_name_under_different_parents(self):
+        root = Flynote.add_root(name="Civil procedure")
+        root.add_child(name="Costs")
+        other_parent = root.add_child(name="Appeals")
+        flynote = other_parent.add_child(name="Cost orders")
+        flynote.name = "Costs"
+
+        flynote.clean()
+
+
 class FlynoteListViewTest(TestCase):
     fixtures = [
         "tests/countries",


### PR DESCRIPTION
* recursively merge flynotes that have common children - this makes merging nodes simpler via the admin interface
* when merging flynotes and updating judgment flynotes, optimistically update flynote counts if the number of expected documents is likely to be small (under 1000). This is likely to be quick, so this helps to keep document counts correct for small nodes (where it matters), without waiting for the root to be updated.
* refactor the pruning functionality out so it can be run manually if necessary
* raise error when flynote sibling names clash