### PR TITLE
group the flynote into a nested display tree for detail and listing views

### DIFF
--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -11,9 +11,10 @@ This module converts that notation into paths and keeps the
 Django ``Flynote`` / ``JudgmentFlynote`` tables in sync with each judgment's
 flynote field.
 
-Two classes are exposed:
+Three classes are exposed:
 
 * **FlynoteParser** – stateless text-to-paths converter.
+* **FlynoteDisplayGrouper** – groups flat flynote lines for nested display.
 * **FlynoteUpdater** – creates/reuses ``Flynote`` nodes and links
   them to a ``Judgment`` via ``JudgmentFlynote``.
 """
@@ -29,6 +30,106 @@ from django.utils.text import slugify
 from peachjam.models.flynote import Flynote, FlynoteDocumentCount, JudgmentFlynote
 
 log = logging.getLogger(__name__)
+
+
+class FlynoteDisplayGrouper:
+    """Group flat flynote lines into nested structures for template rendering.
+
+    This is intentionally narrower than ``FlynoteParser``. It treats only
+    spaced dash variants as hierarchy separators so citation ranges such as
+    ``12(1)(a)–(c)`` remain intact in display-only flynote text.
+    """
+
+    PATH_SEPARATOR_RE = re.compile(r"\s+[—–\-\u2010\u2011\u2012]\s+")
+
+    def __init__(self, lines):
+        self.lines = lines or []
+
+    def group(self):
+        paths = []
+        seen = set()
+
+        for line in self.lines:
+            path = self.split_path(line)
+            if path and path not in seen:
+                seen.add(path)
+                paths.append(path)
+
+        if not paths:
+            return []
+
+        return self.build_groups(paths)
+
+    @classmethod
+    def split_path(cls, line):
+        return tuple(
+            component.strip()
+            for component in cls.PATH_SEPARATOR_RE.split(line)
+            if component.strip()
+        )
+
+    @staticmethod
+    def common_path_prefix(paths):
+        if not paths:
+            return ()
+
+        prefix = []
+        for components in zip(*paths):
+            if len(set(components)) != 1:
+                break
+            prefix.append(components[0])
+
+        return tuple(prefix)
+
+    @staticmethod
+    def group_paths_by_head(paths):
+        groups = []
+        for path in paths:
+            head = path[0]
+            if not groups or groups[-1][0] != head:
+                groups.append((head, [path]))
+            else:
+                groups[-1][1].append(path)
+        return [group for _, group in groups]
+
+    @classmethod
+    def build_groups(cls, paths, inherited_prefix=()):
+        if not paths:
+            return []
+
+        if len(paths) == 1:
+            return [{"text": " — ".join(inherited_prefix + paths[0]), "children": []}]
+
+        prefix = cls.common_path_prefix(paths)
+        if not prefix:
+            grouped_paths = []
+            for group in cls.group_paths_by_head(paths):
+                grouped_paths.extend(cls.build_groups(group, inherited_prefix))
+            return grouped_paths
+
+        combined_prefix = inherited_prefix + prefix
+        remainders = [path[len(prefix) :] for path in paths]
+        descendant_paths = [remainder for remainder in remainders if remainder]
+
+        if not descendant_paths:
+            return [{"text": " — ".join(combined_prefix), "children": []}]
+
+        child_groups = cls.group_paths_by_head(descendant_paths)
+        if len(descendant_paths) != len(paths) or all(
+            len(group) == 1 for group in child_groups
+        ):
+            return [
+                {
+                    "text": " — ".join(combined_prefix),
+                    "children": cls.build_groups(descendant_paths),
+                }
+            ]
+
+        grouped_paths = []
+        for group in child_groups:
+            grouped_paths.extend(cls.build_groups(group, combined_prefix))
+
+        return grouped_paths
 
 
 class FlynoteParser:

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -17,6 +17,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import override as lang_override
 from django_lifecycle import AFTER_SAVE, BEFORE_SAVE
 
+from peachjam.analysis.flynotes import FlynoteDisplayGrouper
 from peachjam.analysis.summariser import JudgmentSummariser
 from peachjam.decorators import CauseListDecorator, JudgmentDecorator
 from peachjam.helpers import current_year
@@ -505,6 +506,10 @@ class Judgment(CoreDocument):
         if not self.flynote:
             return []
         return [line.strip() for line in self.flynote.splitlines() if line.strip()]
+
+    @property
+    def grouped_flynote_lines(self):
+        return FlynoteDisplayGrouper(self.flynote_lines).group()
 
     def assign_mnc(self):
         """Assign an MNC to this judgment, if one hasn't already been assigned or if details have changed."""

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -17,7 +17,6 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import override as lang_override
 from django_lifecycle import AFTER_SAVE, BEFORE_SAVE
 
-from peachjam.analysis.flynotes import FlynoteDisplayGrouper
 from peachjam.analysis.summariser import JudgmentSummariser
 from peachjam.decorators import CauseListDecorator, JudgmentDecorator
 from peachjam.helpers import current_year
@@ -506,10 +505,6 @@ class Judgment(CoreDocument):
         if not self.flynote:
             return []
         return [line.strip() for line in self.flynote.splitlines() if line.strip()]
-
-    @property
-    def grouped_flynote_lines(self):
-        return FlynoteDisplayGrouper(self.flynote_lines).group()
 
     def assign_mnc(self):
         """Assign an MNC to this judgment, if one hasn't already been assigned or if details have changed."""

--- a/peachjam/templates/peachjam/judgment/_blurb_and_flynotes.html
+++ b/peachjam/templates/peachjam/judgment/_blurb_and_flynotes.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n peachjam %}
 {% if document.blurb %}<div class="my-2">{{ document.blurb|default_if_none:"" }}</div>{% endif %}
 {% if document.flynote_lines %}
   {% if show_flynote_heading %}
     <h6 class="mb-1 fw-bold">{% trans 'Flynote' %}</h6>
   {% endif %}
-  {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=document.grouped_flynote_lines %}
+  {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=document.flynote_lines|group_flynote_lines %}
 {% elif document.flynote %}
   <div class="fst-italic my-2">{{ document.flynote|linebreaksbr }}</div>
 {% endif %}

--- a/peachjam/templates/peachjam/judgment/_blurb_and_flynotes.html
+++ b/peachjam/templates/peachjam/judgment/_blurb_and_flynotes.html
@@ -4,9 +4,7 @@
   {% if show_flynote_heading %}
     <h6 class="mb-1 fw-bold">{% trans 'Flynote' %}</h6>
   {% endif %}
-  <ul class="list-unstyled flynotes my-2">
-    {% for flynote_line in document.flynote_lines %}<li>{{ flynote_line }}</li>{% endfor %}
-  </ul>
+  {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=document.grouped_flynote_lines %}
 {% elif document.flynote %}
   <div class="fst-italic my-2">{{ document.flynote|linebreaksbr }}</div>
 {% endif %}

--- a/peachjam/templates/peachjam/judgment/_flynote_groups.html
+++ b/peachjam/templates/peachjam/judgment/_flynote_groups.html
@@ -1,0 +1,11 @@
+<ul class="{% if nested %}list-unstyled flynotes{% else %}list-unstyled flynotes my-2{% endif %}">
+  {% for item in flynote_groups %}
+    <li>
+      {% if nested %}—{% endif %}
+      {{ item.text }}
+      {% if item.children %}
+        {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>

--- a/peachjam/templates/peachjam/judgment/_flynote_groups.html
+++ b/peachjam/templates/peachjam/judgment/_flynote_groups.html
@@ -1,8 +1,11 @@
 <ul class="{% if nested %}list-unstyled flynotes{% else %}list-unstyled flynotes my-2{% endif %}">
   {% for item in flynote_groups %}
     <li>
-      {% if nested %}—{% endif %}
-      {{ item.text }}
+      {% if nested %}
+        — {{ item.text }}
+      {% else %}
+        {{ item.text }}
+      {% endif %}
       {% if item.children %}
         {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
       {% endif %}

--- a/peachjam/templatetags/peachjam.py
+++ b/peachjam/templatetags/peachjam.py
@@ -157,6 +157,13 @@ def split(value, sep=None):
 
 
 @register.filter
+def group_flynote_lines(lines):
+    from peachjam.analysis.flynotes import FlynoteDisplayGrouper
+
+    return FlynoteDisplayGrouper(lines).group()
+
+
+@register.filter
 def qualify_local_refs(value, frbr_uri):
     return qualify_local_refs_html(value, frbr_uri)
 

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -8,6 +8,7 @@ from django.template.loader import render_to_string
 from django.test import TestCase
 from languages_plus.models import Language
 
+from peachjam.analysis.flynotes import FlynoteDisplayGrouper
 from peachjam.analysis.summariser import JudgmentSummary
 from peachjam.models import (
     CaseNumber,
@@ -22,6 +23,12 @@ from peachjam.models import (
 class JudgmentTestCase(TestCase):
     fixtures = ["tests/courts", "tests/countries", "tests/languages"]
     maxDiff = None
+
+    def assertGroupedFlynotesEqual(self, expected, judgment):
+        self.assertEqual(
+            expected,
+            FlynoteDisplayGrouper(judgment.flynote_lines).group(),
+        )
 
     def make_judgment(self):
         judgment = Judgment.objects.create(
@@ -70,7 +77,7 @@ class JudgmentTestCase(TestCase):
             )
         )
 
-        self.assertEqual(
+        self.assertGroupedFlynotesEqual(
             [
                 {
                     "text": (
@@ -102,7 +109,7 @@ class JudgmentTestCase(TestCase):
                     ],
                 },
             ],
-            judgment.grouped_flynote_lines,
+            judgment,
         )
 
     def test_grouped_flynote_lines_keeps_original_order(self):
@@ -114,13 +121,13 @@ class JudgmentTestCase(TestCase):
             )
         )
 
-        self.assertEqual(
+        self.assertGroupedFlynotesEqual(
             [
                 {"text": "Zebra law — first point", "children": []},
                 {"text": "Alpha law — second point", "children": []},
                 {"text": "Beta law — third point", "children": []},
             ],
-            judgment.grouped_flynote_lines,
+            judgment,
         )
 
     def test_grouped_flynote_lines_groups_en_dash_paths(self):
@@ -136,7 +143,7 @@ class JudgmentTestCase(TestCase):
             )
         )
 
-        self.assertEqual(
+        self.assertGroupedFlynotesEqual(
             [
                 {
                     "text": "Civil procedure",
@@ -166,7 +173,7 @@ class JudgmentTestCase(TestCase):
                     "children": [],
                 },
             ],
-            judgment.grouped_flynote_lines,
+            judgment,
         )
 
     def test_grouped_flynote_lines_groups_spaced_ascii_dash_paths(self):
@@ -179,7 +186,7 @@ class JudgmentTestCase(TestCase):
             )
         )
 
-        self.assertEqual(
+        self.assertGroupedFlynotesEqual(
             [
                 {
                     "text": (
@@ -198,7 +205,7 @@ class JudgmentTestCase(TestCase):
                     ],
                 }
             ],
-            judgment.grouped_flynote_lines,
+            judgment,
         )
 
     def test_grouped_flynote_lines_groups_ancestor_with_descendants(self):
@@ -212,7 +219,7 @@ class JudgmentTestCase(TestCase):
             )
         )
 
-        self.assertEqual(
+        self.assertGroupedFlynotesEqual(
             [
                 {
                     "text": "Customs law — internal appeal jurisdiction",
@@ -228,7 +235,7 @@ class JudgmentTestCase(TestCase):
                     ],
                 }
             ],
-            judgment.grouped_flynote_lines,
+            judgment,
         )
 
     def test_blurb_and_flynotes_renders_nested_groups(self):

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from countries_plus.models import Country
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
+from django.template.loader import render_to_string
 from django.test import TestCase
 from languages_plus.models import Language
 
@@ -52,6 +53,204 @@ class JudgmentTestCase(TestCase):
     def test_flynote_lines_splits_and_trims_multiline_flynotes(self):
         judgment = Judgment(flynote=" Line one \n\nLine two\n  Line three  ")
         self.assertEqual(["Line one", "Line two", "Line three"], judgment.flynote_lines)
+
+    def test_grouped_flynote_lines_groups_maximal_common_ancestors(self):
+        judgment = Judgment(
+            flynote=(
+                "Customs law — Customs and excise act — Diesel refund scheme — "
+                "Interpretation of Note 6(f)(ii)(cc) — "
+                "joint venture as substantive authorised user\n"
+                "Customs law — Customs and excise act — Diesel refund scheme — "
+                "Interpretation of Note 6(f)(ii)(cc) — "
+                "Note 5 discretion to pay refunds to third parties on good cause shown\n"
+                "Customs law — internal appeal jurisdiction — "
+                "administrative-law duty to consider discretionary relief\n"
+                "Customs law — internal appeal jurisdiction — "
+                "NAC cannot introduce new grounds or increase original quantum"
+            )
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "text": (
+                        "Customs law — Customs and excise act — Diesel refund scheme — "
+                        "Interpretation of Note 6(f)(ii)(cc)"
+                    ),
+                    "children": [
+                        {
+                            "text": "joint venture as substantive authorised user",
+                            "children": [],
+                        },
+                        {
+                            "text": "Note 5 discretion to pay refunds to third parties on good cause shown",
+                            "children": [],
+                        },
+                    ],
+                },
+                {
+                    "text": "Customs law — internal appeal jurisdiction",
+                    "children": [
+                        {
+                            "text": "administrative-law duty to consider discretionary relief",
+                            "children": [],
+                        },
+                        {
+                            "text": "NAC cannot introduce new grounds or increase original quantum",
+                            "children": [],
+                        },
+                    ],
+                },
+            ],
+            judgment.grouped_flynote_lines,
+        )
+
+    def test_grouped_flynote_lines_keeps_original_order(self):
+        judgment = Judgment(
+            flynote=(
+                "Zebra law — first point\n"
+                "Alpha law — second point\n"
+                "Beta law — third point"
+            )
+        )
+
+        self.assertEqual(
+            [
+                {"text": "Zebra law — first point", "children": []},
+                {"text": "Alpha law — second point", "children": []},
+                {"text": "Beta law — third point", "children": []},
+            ],
+            judgment.grouped_flynote_lines,
+        )
+
+    def test_grouped_flynote_lines_groups_en_dash_paths(self):
+        judgment = Judgment(
+            flynote=(
+                "Civil procedure – Intervention (Rule 12) – requires direct and substantial interest; "
+                "non-joinder fatal\n"
+                "Civil procedure – Rule 45A – cannot be used to suspend non-executable orders or mount "
+                "collateral challenges; locus standi required\n"
+                "Insolvency law – Sequestration – Final order under s 12(1)(a)–(c) – statutory requirements "
+                "established (liquidated debt, insolvency, advantage to creditors) – court’s discretion "
+                "exercised where no special circumstances shown"
+            )
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "text": "Civil procedure",
+                    "children": [
+                        {
+                            "text": (
+                                "Intervention (Rule 12) — requires direct and substantial interest; "
+                                "non-joinder fatal"
+                            ),
+                            "children": [],
+                        },
+                        {
+                            "text": (
+                                "Rule 45A — cannot be used to suspend non-executable orders or mount "
+                                "collateral challenges; locus standi required"
+                            ),
+                            "children": [],
+                        },
+                    ],
+                },
+                {
+                    "text": (
+                        "Insolvency law — Sequestration — Final order under s 12(1)(a)–(c) — statutory "
+                        "requirements established (liquidated debt, insolvency, advantage to creditors) — "
+                        "court’s discretion exercised where no special circumstances shown"
+                    ),
+                    "children": [],
+                },
+            ],
+            judgment.grouped_flynote_lines,
+        )
+
+    def test_grouped_flynote_lines_groups_spaced_ascii_dash_paths(self):
+        judgment = Judgment(
+            flynote=(
+                "Administrative Law - Judicial Review - Legality Review - Unlawful Appointment - "
+                "Jurisdiction, Delay, Legality of Municipal Appointments\n"
+                "Administrative Law - Judicial Review - Legality Review - Unlawful Appointment - "
+                "Delay and prejudice"
+            )
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "text": (
+                        "Administrative Law — Judicial Review — Legality Review — "
+                        "Unlawful Appointment"
+                    ),
+                    "children": [
+                        {
+                            "text": "Jurisdiction, Delay, Legality of Municipal Appointments",
+                            "children": [],
+                        },
+                        {
+                            "text": "Delay and prejudice",
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+            judgment.grouped_flynote_lines,
+        )
+
+    def test_grouped_flynote_lines_groups_ancestor_with_descendants(self):
+        judgment = Judgment(
+            flynote=(
+                "Customs law — internal appeal jurisdiction\n"
+                "Customs law — internal appeal jurisdiction — "
+                "administrative-law duty to consider discretionary relief\n"
+                "Customs law — internal appeal jurisdiction — "
+                "NAC cannot introduce new grounds or increase original quantum"
+            )
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "text": "Customs law — internal appeal jurisdiction",
+                    "children": [
+                        {
+                            "text": "administrative-law duty to consider discretionary relief",
+                            "children": [],
+                        },
+                        {
+                            "text": "NAC cannot introduce new grounds or increase original quantum",
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+            judgment.grouped_flynote_lines,
+        )
+
+    def test_blurb_and_flynotes_renders_nested_groups(self):
+        judgment = Judgment(
+            blurb="Appeal dismissed.",
+            flynote=(
+                "Contract law — offer and acceptance\n" "Contract law — consideration"
+            ),
+        )
+
+        html = render_to_string(
+            "peachjam/judgment/_blurb_and_flynotes.html",
+            {"document": judgment, "show_flynote_heading": True},
+        )
+        normalized_html = " ".join(html.split())
+
+        self.assertIn("<h6", html)
+        self.assertIn("Contract law", html)
+        self.assertEqual(1, html.count("Contract law"))
+        self.assertIn("— offer and acceptance", normalized_html)
+        self.assertIn("— consideration", normalized_html)
+        self.assertGreaterEqual(html.count("<ul"), 2)
 
     def test_assign_mnc(self):
         j = Judgment(

--- a/peachjam_search/tests/test_views.py
+++ b/peachjam_search/tests/test_views.py
@@ -268,8 +268,8 @@ class SearchViewsTest(TestCase):
         )
 
         self.assertIn('<ul class="list-unstyled flynotes my-2">', html)
-        self.assertIn("<li>Line one</li>", html)
-        self.assertIn("<li>Line two</li>", html)
+        self.assertRegex(html, r"<li>\s*Line one\s*</li>")
+        self.assertRegex(html, r"<li>\s*Line two\s*</li>")
 
 
 class PortionSearchViewTest(TestCase):


### PR DESCRIPTION
I was trying to group the flynotes to reduce duplication in the UI by rendering shared ancestors once and nesting the differing parts underneath. I introduced a new helper class, FlynoteDisplayGrouper, to parse the flat flynote lines and build the nested structure used by the template. I could have reused the parser that already exists, but that one is much broader and is meant for ingestion and taxonomy parsing, while this one is intentionally narrower and focused only on safe display grouping.That keeps the template simple, preserves the original flynote order, and avoids incorrect splits in cases like citation ranges.
Before:

<img width="1303" height="325" alt="Screenshot 2026-05-06 at 2 33 54 PM" src="https://github.com/user-attachments/assets/4124bfb2-560f-4f44-925a-5febbe4f02e1" />

After:

<img width="1138" height="251" alt="Screenshot 2026-05-06 at 2 32 46 PM" src="https://github.com/user-attachments/assets/01a68eb7-0e68-4e2d-8624-d5f8462987b1" />
