### PR TITLE
change flying note results from div ut ul for better accesibility

### DIFF
--- a/peachjam/templates/peachjam/flynote/_filter_form.html
+++ b/peachjam/templates/peachjam/flynote/_filter_form.html
@@ -14,4 +14,6 @@
     <div class="progress-bar progress-bar-striped progress-bar-animated w-100"></div>
   </div>
 </form>
-<div id="flynote-list-container" class="mt-1">{% include 'peachjam/flynote/_list.html' %}</div>
+{% if not omit_results %}
+  <div id="flynote-list-container" class="mt-1">{% include 'peachjam/flynote/_list.html' %}</div>
+{% endif %}

--- a/peachjam/templates/peachjam/flynote/_list.html
+++ b/peachjam/templates/peachjam/flynote/_list.html
@@ -1,19 +1,19 @@
 {% load humanize i18n peachjam %}
 {% if flynotes %}
-  <div id="flynote-list-group"
-       class="list-group list-group-flush"
-       {% if more %} hx-swap-oob="beforeend:#flynote-list-group"{% endif %}>
+  <ul id="flynote-list-group"
+      class="list-group list-group-flush"
+      {% if more %} hx-swap-oob="beforeend:#flynote-list-group"{% endif %}>
     {% for item in flynotes %}
-      <a href="{% url 'flynote_detail' item.flynote.pk %}"
-         class="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-primary">
+      <li class="list-group-item d-flex justify-content-between align-items-center position-relative">
         <div>
-          {{ item.flynote.name }}
+          <a href="{% url 'flynote_detail' item.flynote.pk %}"
+             class="stretched-link">{{ item.flynote.name }}</a>
           {% if item.child_names %}<small class="text-muted d-block">{{ item.child_names|join:", " }}</small>{% endif %}
         </div>
         <span class="badge bg-secondary">{{ item.count|intcomma }}</span>
-      </a>
+      </li>
     {% endfor %}
-  </div>
+  </ul>
   {% if page_obj.has_next %}
     <a href="#"
        hx-get="{% url 'flynote_list' %}?more&{% query_string request.GET page=page_obj.next_page_number %}"

--- a/peachjam/templates/peachjam/flynote/_list.html
+++ b/peachjam/templates/peachjam/flynote/_list.html
@@ -4,7 +4,7 @@
       class="list-group list-group-flush"
       {% if more %} hx-swap-oob="beforeend:#flynote-list-group"{% endif %}>
     {% for item in flynotes %}
-      <li class="list-group-item d-flex justify-content-between align-items-center position-relative">
+      <li class="list-group-item list-group-item-action d-flex justify-content-between align-items-center position-relative">
         <div>
           <a href="{% url 'flynote_detail' item.flynote.pk %}"
              class="stretched-link">{{ item.flynote.name }}</a>

--- a/peachjam/templates/peachjam/flynote/_list.html
+++ b/peachjam/templates/peachjam/flynote/_list.html
@@ -18,7 +18,7 @@
     <a href="#"
        hx-get="{% url 'flynote_list' %}?more&{% query_string request.GET page=page_obj.next_page_number %}"
        id="flynote-more"
-       class="btn btn-outline-primary mt-2"
+       class="btn btn-outline-primary m-3"
        {% if more %} hx-swap-oob="true"{% endif %}>{% trans "Load more ..." %}</a>
   {% endif %}
 {% elif not more %}

--- a/peachjam/templates/peachjam/flynote/_popular.html
+++ b/peachjam/templates/peachjam/flynote/_popular.html
@@ -32,7 +32,7 @@
 {% if has_more_topics %}
   <div class="collapse my-4" id="allSubtopicsCollapse">
     <div class="card shadow-sm">
-      <div class="card-body">
+      <div class="card-body sticky-top bg-white">
         <h3 class="h5 mb-3">
           {{ flynote.name }}
           <span class="badge rounded-pill text-bg-secondary ms-2 align-middle">{{ total_subtopic_count|intcomma }}</span>

--- a/peachjam/templates/peachjam/flynote/_popular.html
+++ b/peachjam/templates/peachjam/flynote/_popular.html
@@ -31,12 +31,15 @@
 </div>
 {% if has_more_topics %}
   <div class="collapse my-4" id="allSubtopicsCollapse">
-    <div class="card card-body shadow-sm">
-      <h3 class="h5 mb-3">
-        {{ flynote.name }}
-        <span class="badge rounded-pill text-bg-secondary ms-2 align-middle">{{ total_subtopic_count|intcomma }}</span>
-      </h3>
-      {% include 'peachjam/flynote/_filter_form.html' with onload=True %}
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h3 class="h5 mb-3">
+          {{ flynote.name }}
+          <span class="badge rounded-pill text-bg-secondary ms-2 align-middle">{{ total_subtopic_count|intcomma }}</span>
+        </h3>
+        {% include 'peachjam/flynote/_filter_form.html' with onload=True omit_results=True %}
+      </div>
+      <div id="flynote-list-container">{% include 'peachjam/flynote/_list.html' %}</div>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
put heading and filter inside the padding and card body and list items outside the card body, flush to the card edges 

Before:
<img width="1109" height="487" alt="Screenshot 2026-05-07 at 2 55 01 PM" src="https://github.com/user-attachments/assets/13e49f99-bd19-40c0-8465-e7c4dbbce646" />
<img width="1310" height="233" alt="Screenshot 2026-05-07 at 2 55 14 PM" src="https://github.com/user-attachments/assets/8f329697-28f8-4c70-9c10-09a1627c7786" />


<img width="1316" height="455" alt="Screenshot 2026-05-07 at 1 38 39 PM" src="https://github.com/user-attachments/assets/f6ec5548-ebbe-4cb9-aa55-7a1be16f4edb" />

After:

<img width="1192" height="363" alt="Screenshot 2026-05-07 at 2 56 08 PM" src="https://github.com/user-attachments/assets/ab681b47-bd09-4d66-b229-d09e915ae8bc" />




<img width="1277" height="462" alt="Screenshot 2026-05-07 at 1 39 08 PM" src="https://github.com/user-attachments/assets/08a31e1e-f1b9-4551-bd44-ac8b1a287c3c" />
