### PR TITLE
Clear the node_order_by on Flynote

### DIFF
--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -366,7 +366,7 @@ class Flynote(LifecycleModelMixin, MP_Node):
         if not flynote_lines:
             return None
 
-        return "\n".join(flynote_lines)
+        return "\n".join(sorted(flynote_lines))
 
 
 class JudgmentFlynote(models.Model):

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -55,7 +55,6 @@ class Flynote(LifecycleModelMixin, MP_Node):
 
     name = models.CharField(_("name"), max_length=255)
     deprecated = models.BooleanField(_("deprecated"), default=False, db_index=True)
-    node_order_by = ["name"]
 
     class Meta:
         verbose_name = _("flynote")
@@ -266,7 +265,7 @@ class Flynote(LifecycleModelMixin, MP_Node):
                 # moving nodes updates path attributes, so always work with latest info from db
                 child.refresh_from_db()
                 self.refresh_from_db()
-                child.move(self, pos="sorted-child")
+                child.move(self, pos="last-child")
 
         source.delete()
         FlynoteDocumentCount.quick_refresh_for_single_flynote(self)

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -732,9 +732,7 @@ class Judgment(CoreDocument):
         """Serialise the flynote tree to a string for storage in flynote and flynote_raw."""
         from peachjam.models import Flynote
 
-        judgment_flynotes = list(
-            self.flynotes.select_related("flynote").order_by("flynote__path")
-        )
+        judgment_flynotes = list(self.flynotes.select_related("flynote"))
 
         # we update flynote_raw as well (without triggering attribute change events) so that a human can edit
         # the flynote and we won't lose the changes made through the Flynote tree

--- a/peachjam/tests/test_flynote_manager.py
+++ b/peachjam/tests/test_flynote_manager.py
@@ -95,6 +95,10 @@ class FlynoteManagerViewTest(TestCase):
 
         names = {node["name"] for node in payload["results"]}
         self.assertEqual(names, {"Criminal law", "Contract law"})
+        self.assertEqual(
+            [node["name"] for node in payload["results"]],
+            ["Contract law", "Criminal law"],
+        )
         criminal = next(
             node for node in payload["results"] if node["name"] == "Criminal law"
         )
@@ -116,6 +120,10 @@ class FlynoteManagerViewTest(TestCase):
 
         names = {node["name"] for node in payload["results"]}
         self.assertEqual(names, {"Bail", "Sentencing"})
+        self.assertEqual(
+            [node["name"] for node in payload["results"]],
+            ["Bail", "Sentencing"],
+        )
         self.assertNotIn("Appeals", names)
 
     def test_path_endpoint_returns_path_to_node(self):

--- a/peachjam/views/flynotes.py
+++ b/peachjam/views/flynotes.py
@@ -172,7 +172,11 @@ class FlynoteManagerMixin(FlynoteViewMixin):
 @method_decorator(staff_member_required, name="dispatch")
 class FlynoteManagerTreeView(FlynoteManagerMixin, View):
     def get(self, request, *args, **kwargs):
-        flynotes = Flynote.get_root_nodes().select_related("document_count_cache")
+        flynotes = (
+            Flynote.get_root_nodes()
+            .select_related("document_count_cache")
+            .order_by("name")
+        )
         return JsonResponse({"results": [self.serialize_node(f) for f in flynotes]})
 
 
@@ -180,7 +184,11 @@ class FlynoteManagerTreeView(FlynoteManagerMixin, View):
 class FlynoteManagerTreeChildrenView(FlynoteManagerMixin, View):
     def get(self, request, *args, **kwargs):
         parent = get_object_or_404(Flynote, pk=kwargs["pk"])
-        flynotes = parent.get_children().select_related("document_count_cache")
+        flynotes = (
+            parent.get_children()
+            .select_related("document_count_cache")
+            .order_by("name")
+        )
         return JsonResponse({"results": [self.serialize_node(f) for f in flynotes]})
 
 


### PR DESCRIPTION
we don't need the Flynote tree to be ordered; we order when necessary. With node_order_by set, when we change flynote names we need to recompute paths, which we aren't doing.

Simplest is to just clear ordering. This also simplifies move operations.