### PR TITLE
Remove node_order_by from Taxonomy

### DIFF
--- a/africanlii/views/home.py
+++ b/africanlii/views/home.py
@@ -53,7 +53,7 @@ class HomePageView(BaseHomePageView):
         )
         context["recs"] = RegionalEconomicCommunity.objects.prefetch_related("locality")
         context["member_states"] = MemberState.objects.prefetch_related("country")
-        context["taxonomies"] = Taxonomy.dump_bulk()
+        context["taxonomies"] = Taxonomy.sort_bulk_tree(Taxonomy.dump_bulk())
         context["taxonomy_url"] = "taxonomy_detail"
         context["court_classes"] = CourtClass.objects.prefetch_related("courts")
         context["documents_count"] = CoreDocument.objects.exclude(

--- a/africanlii/views/taxonomy.py
+++ b/africanlii/views/taxonomy.py
@@ -38,7 +38,9 @@ class DocIndexesListView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         taxonomy = get_object_or_404(Taxonomy, slug="case-index")
-        context["taxonomies"] = Taxonomy.dump_bulk(parent=taxonomy)
+        context["taxonomies"] = Taxonomy.sort_bulk_tree(
+            Taxonomy.dump_bulk(parent=taxonomy)
+        )
         context["taxonomy_url"] = "doc_index_detail"
         context["taxonomy_link_prefix"] = "indexes"
         return context

--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -409,7 +409,7 @@ class TopicTreeWidget(forms.CheckboxSelectMultiple):
             for kid in item.get("children", []):
                 fixup(kid)
 
-        tree = Taxonomy.dump_bulk()
+        tree = Taxonomy.sort_bulk_tree(Taxonomy.dump_bulk())
         for x in tree:
             fixup(x)
         return tree
@@ -1229,7 +1229,7 @@ class TaxonomyAdmin(AccessGroupMixin, TreeAdmin):
                 fixup(kid)
 
         # grab the tree and turn it into something la-table-of-contents-controller understands
-        tree = self.model.dump_bulk()
+        tree = self.model.sort_bulk_tree(self.model.dump_bulk())
         for x in tree:
             fixup(x)
         resp.context_data["tree_json"] = json.dumps(tree)

--- a/peachjam/management/commands/taxonomies.py
+++ b/peachjam/management/commands/taxonomies.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             root_node = Taxonomy.objects.filter(slug=root).first()
             if not root_node:
                 raise ValueError("Root node not found: " + root)
-        data = Taxonomy.dump_bulk(root_node, keep_ids=False)
+        data = Taxonomy.sort_bulk_tree(Taxonomy.dump_bulk(root_node, keep_ids=False))
 
         # keep only the name and slug of the data
         def fixup(node):

--- a/peachjam/models/taxonomies.py
+++ b/peachjam/models/taxonomies.py
@@ -19,7 +19,6 @@ class Taxonomy(MP_Node):
     name = models.CharField(_("name"), max_length=255)
     path_name = models.CharField(_("path name"), max_length=4096, blank=True)
     slug = models.SlugField(_("slug"), max_length=10 * 1024, unique=True)
-    node_order_by = ["name"]
     entity_profile = GenericRelation(
         "peachjam.EntityProfile", verbose_name=_("profile")
     )
@@ -159,7 +158,7 @@ class Taxonomy(MP_Node):
             if is_restricted and not is_allowed:
                 exclude.append(child["id"])
 
-        children = self.get_children().exclude(id__in=exclude)
+        children = self.get_children().exclude(id__in=exclude).order_by("name")
         return children
 
     def get_offline_ancestor(self):
@@ -167,6 +166,31 @@ class Taxonomy(MP_Node):
         if self.allow_offline:
             return self
         return self.get_ancestors().filter(allow_offline=True).first()
+
+    @classmethod
+    def sort_bulk_tree(cls, tree):
+        """Sort a treebeard dump_bulk tree by taxonomy name at every level."""
+        tree.sort(
+            key=lambda node: (
+                str(node.get("data", {}).get("name") or "").casefold(),
+                str(node.get("data", {}).get("slug") or "").casefold(),
+            )
+        )
+        for node in tree:
+            if "children" in node:
+                cls.sort_bulk_tree(node["children"])
+        return tree
+
+    @classmethod
+    def sort_item_tree(cls, tree):
+        """Sort a nested taxonomy-object tree by taxonomy name at every level."""
+        return {
+            topic: cls.sort_item_tree(children)
+            for topic, children in sorted(
+                tree.items(),
+                key=lambda item: (item[0].name.casefold(), item[0].slug.casefold()),
+            )
+        }
 
     @classmethod
     def get_tree_for_items(cls, items):
@@ -187,7 +211,7 @@ class Taxonomy(MP_Node):
                     current_level[node] = {}
                 current_level = current_level[node]
 
-        return tree
+        return cls.sort_item_tree(tree)
 
     @classmethod
     def get_allowed_taxonomies(cls, user=None, root=None):
@@ -237,7 +261,7 @@ class Taxonomy(MP_Node):
             if filtered_node is not None
         ]
         return {
-            "tree": filtered_taxonomies,
+            "tree": cls.sort_bulk_tree(filtered_taxonomies),
             "pk_list": node_ids,
         }
 

--- a/peachjam/tests/test_taxonomies.py
+++ b/peachjam/tests/test_taxonomies.py
@@ -35,6 +35,50 @@ class TaxonomyTestCase(WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("public", response.headers.get("Cache-Control", ""))
 
+    def test_taxonomy_tree_is_not_ordered_by_treebeard(self):
+        self.assertEqual(Taxonomy.node_order_by, [])
+
+    def test_allowed_children_are_ordered_by_name(self):
+        self.root.add_child(name="Zoning")
+        self.root.add_child(name="Administrative law")
+
+        children = list(
+            self.root.get_allowed_children(
+                User.objects.get(username="user@example.com")
+            )
+        )
+
+        self.assertEqual(
+            [child.name for child in children],
+            ["Administrative law", "Land Rights", "Zoning"],
+        )
+
+    def test_allowed_taxonomies_are_ordered_by_name(self):
+        self.root.add_child(name="Zoning")
+        self.root.add_child(name="Administrative law")
+
+        tree = Taxonomy.get_allowed_taxonomies()["tree"]
+        collections = next(
+            node for node in tree if node["data"]["name"] == "Collections"
+        )
+
+        self.assertEqual(
+            [child["data"]["name"] for child in collections["children"]],
+            ["Administrative law", "Land Rights", "Zoning"],
+        )
+
+    def test_taxonomy_tree_for_items_is_ordered_by_name(self):
+        zoning = self.root.add_child(name="Zoning")
+        admin = self.root.add_child(name="Administrative law")
+
+        tree = Taxonomy.get_tree_for_items([zoning, admin])
+        root_children = tree[self.root]
+
+        self.assertEqual(
+            [topic.name for topic in root_children],
+            ["Administrative law", "Zoning"],
+        )
+
     def test_restricted_taxonomy_unauthorized(self):
         unauthorized_user = User.objects.get(username="user@example.com")
         land = Taxonomy.objects.get(name="Land Rights")


### PR DESCRIPTION
We don't need the taxonomy to maintain its order, we order nodes during display. This simplifies tree management and prevents treebeard's MP_Node's path from getting broken when we change the name of a node, but don't re-fix the tree.

See also https://github.com/laws-africa/peachjam/pull/3203