### PR TITLE
Add a warning to mark the file as safe to download if its anonymised

### DIFF
--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -506,6 +506,16 @@ class Judgment(CoreDocument):
             return []
         return [line.strip() for line in self.flynote.splitlines() if line.strip()]
 
+    @property
+    def needs_source_file_anonymisation(self):
+        if not self.anonymised:
+            return False
+
+        try:
+            return not self.source_file.file_is_anonymised
+        except SourceFile.DoesNotExist:
+            return False
+
     def assign_mnc(self):
         """Assign an MNC to this judgment, if one hasn't already been assigned or if details have changed."""
         if self.date and self.court_id:

--- a/peachjam/templates/admin/peachjam/judgment/change_form.html
+++ b/peachjam/templates/admin/peachjam/judgment/change_form.html
@@ -5,6 +5,9 @@
   {% if original.must_be_anonymised and not original.anonymised %}
     <div class="alert alert-warning">{% trans "This judgment must be anonymised before it can be published." %}</div>
   {% endif %}
+  {% if original.needs_source_file_anonymisation %}
+    <div class="alert alert-warning">{% trans "Mark the source file as anonymised if it is safe to download." %}</div>
+  {% endif %}
 {% endblock %}
 {% block extra_actions %}
   {% if original %}

--- a/peachjam/templates/admin/peachjam/judgment/change_form.html
+++ b/peachjam/templates/admin/peachjam/judgment/change_form.html
@@ -6,7 +6,9 @@
     <div class="alert alert-warning">{% trans "This judgment must be anonymised before it can be published." %}</div>
   {% endif %}
   {% if original.needs_source_file_anonymisation %}
-    <div class="alert alert-warning">{% trans "Mark the source file as anonymised if it is safe to download." %}</div>
+    <div class="alert alert-warning">
+      {% trans "This judgment is marked as anonymised, but the attached source file is not marked as anonymised. Mark the source file as anonymised if it is safe to download." %}
+    </div>
   {% endif %}
 {% endblock %}
 {% block extra_actions %}

--- a/peachjam/tests/test_admin.py
+++ b/peachjam/tests/test_admin.py
@@ -2,6 +2,7 @@ import os
 from datetime import date
 
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django_webtest import WebTest
 from webtest import Upload
@@ -13,6 +14,7 @@ from peachjam.models import (
     JournalArticle,
     Judgment,
     Language,
+    SourceFile,
     VolumeIssue,
 )
 
@@ -22,6 +24,32 @@ class TestJudgmentAdmin(WebTest):
 
     def setUp(self):
         self.app.set_user(User.objects.get(username="admin@example.com"))
+
+    def make_judgment(self, anonymised=False):
+        return Judgment.objects.create(
+            case_name="Warning test case",
+            court_id=1,
+            date=date(2026, 1, 8),
+            language=Language.objects.get(pk="en"),
+            jurisdiction=Country.objects.get(pk="ZA"),
+            anonymised=anonymised,
+        )
+
+    def attach_source_file(self, judgment, file_is_anonymised):
+        with open(
+            os.path.abspath("peachjam/fixtures/source_files/gauteng_judgment.pdf"), "rb"
+        ) as pdf_file:
+            return SourceFile.objects.create(
+                document=judgment,
+                file=SimpleUploadedFile(
+                    "warning-source.pdf",
+                    pdf_file.read(),
+                    content_type="application/pdf",
+                ),
+                filename="warning-source.pdf",
+                mimetype="application/pdf",
+                file_is_anonymised=file_is_anonymised,
+            )
 
     def test_add_judgment_docx_swap_pdf(self):
         # add judgment
@@ -158,6 +186,36 @@ class TestJudgmentAdmin(WebTest):
             judgment.document_content.content_html,
         )
         self.assertEqual("file.docx", judgment.source_file.filename)
+
+    def test_change_form_warns_if_anonymised_judgment_source_file_is_not_marked_anonymised(
+        self,
+    ):
+        judgment = self.make_judgment(anonymised=True)
+        self.attach_source_file(judgment, file_is_anonymised=False)
+
+        response = self.app.get(
+            reverse("admin:peachjam_judgment_change", kwargs={"object_id": judgment.pk})
+        )
+
+        self.assertIn(
+            "This judgment is marked as anonymised, but the attached source file is not marked as anonymised.",
+            response.text,
+        )
+
+    def test_change_form_does_not_warn_when_attached_source_file_is_marked_anonymised(
+        self,
+    ):
+        judgment = self.make_judgment(anonymised=True)
+        self.attach_source_file(judgment, file_is_anonymised=True)
+
+        response = self.app.get(
+            reverse("admin:peachjam_judgment_change", kwargs={"object_id": judgment.pk})
+        )
+
+        self.assertNotIn(
+            "This judgment is marked as anonymised, but the attached source file is not marked as anonymised.",
+            response.text,
+        )
 
 
 class TestDocumentAdminHtmlEdit(WebTest):


### PR DESCRIPTION
This task is solving this issue #3199  whereby when the editors are editing they can seee a warning to tell them that they should indicate the PDF is anonymised and safe to download. Its not a blocker but just a reminder

<img width="1343" height="737" alt="Screenshot 2026-05-08 at 12 20 09 PM" src="https://github.com/user-attachments/assets/d3f8302b-7c91-459c-86a5-6a90b3465b46" />
