### PR TITLE
block all websockets and immidietly close with code 1000

### DIFF
--- a/peachjam/asgi.py
+++ b/peachjam/asgi.py
@@ -19,4 +19,17 @@ class DjangoUvicornWorker(UvicornWorker):
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "africanlii.settings")
 
-application = get_asgi_application()
+django_application = get_asgi_application()
+
+
+async def reject_unsupported_websocket_scope(app, scope, receive, send):
+    """Close unsolicited websocket upgrades before they reach Django's HTTP-only ASGI app."""
+    if scope["type"] == "websocket":
+        await send({"type": "websocket.close", "code": 1000})
+        return
+
+    await app(scope, receive, send)
+
+
+async def application(scope, receive, send):
+    await reject_unsupported_websocket_scope(django_application, scope, receive, send)

--- a/peachjam/tests/test_asgi.py
+++ b/peachjam/tests/test_asgi.py
@@ -1,0 +1,52 @@
+from asgiref.sync import async_to_sync
+from django.test import SimpleTestCase
+
+from peachjam.asgi import reject_unsupported_websocket_scope
+
+
+class RejectUnsupportedWebsocketScopeTests(SimpleTestCase):
+    def test_closes_websocket_scope_without_calling_wrapped_app(self):
+        called = False
+        messages = []
+
+        async def fake_app(scope, receive, send):
+            nonlocal called
+            called = True
+
+        async def receive():
+            return {"type": "websocket.connect"}
+
+        async def send(message):
+            messages.append(message)
+
+        async_to_sync(reject_unsupported_websocket_scope)(
+            fake_app,
+            {"type": "websocket"},
+            receive,
+            send,
+        )
+
+        self.assertFalse(called)
+        self.assertEqual([{"type": "websocket.close", "code": 1000}], messages)
+
+    def test_passes_http_scope_through_to_wrapped_app(self):
+        called = False
+
+        async def fake_app(scope, receive, send):
+            nonlocal called
+            called = True
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            return None
+
+        async_to_sync(reject_unsupported_websocket_scope)(
+            fake_app,
+            {"type": "http"},
+            receive,
+            send,
+        )
+
+        self.assertTrue(called)


### PR DESCRIPTION
this addresse this issue #3179   whereby we dont support websockets. This wount affect the other normal flows like http,Elasticsearch, login, pages, HTMX, etc., it will only block the websockets only. but team you can test on your end before approving and see if its woking ok