### PR TITLE
Update the lawreport page to group the data in a less confusing way

### DIFF
--- a/peachjam/templates/peachjam/law_report/law_report_volume_cases_index.html
+++ b/peachjam/templates/peachjam/law_report/law_report_volume_cases_index.html
@@ -1,8 +1,5 @@
 {% extends 'peachjam/law_report/law_report_volume_detail.html' %}
 {% load i18n %}
-{% block alerts %}
-  <h3 class="h5 mb-3">{% trans "Index of cited cases" %}</h3>
-{% endblock %}
 {% block document-table %}
   {% trans "case" as doc_count_noun %}
   {% trans "cases" as doc_count_noun_plural %}

--- a/peachjam/templates/peachjam/law_report/law_report_volume_detail.html
+++ b/peachjam/templates/peachjam/law_report/law_report_volume_detail.html
@@ -14,7 +14,14 @@
         <li class="breadcrumb-item">
           <a href="{{ law_report.get_absolute_url }}">{{ law_report.title }}</a>
         </li>
-        <li class="breadcrumb-item active" aria-current="page">{{ law_report_volume.title }}</li>
+        {% if section == "judgments" %}
+          <li class="breadcrumb-item active" aria-current="page">{{ law_report_volume.title }}</li>
+        {% else %}
+          <li class="breadcrumb-item">
+            <a href="{{ law_report_volume.get_absolute_url }}">{{ law_report_volume.title }}</a>
+          </li>
+          <li class="breadcrumb-item active" aria-current="page">{{ section_title }}</li>
+        {% endif %}
       </ol>
     </nav>
   </div>
@@ -29,23 +36,42 @@
            hx-trigger="load">
       </div>
     {% endblock %}
-    <h2 class="h4 mb-0">{{ law_report_volume.title }}</h2>
+    <p class="h4 mb-0">{{ law_report_volume.title }}</p>
   </div>
 {% endblock %}
 {% block count-and-search %}{% endblock %}
 {% block nav-tabs %}
-  <ul class="nav nav-tabs border-bottom mb-3">
-    <li class="nav-item">
-      <a class="nav-link {% if active_tab == 'judgments' %}active{% endif %}"
-         href="{{ law_report_volume.get_absolute_url }}">{% trans 'Reported judgments' %}</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link {% if active_tab == 'cases' %}active{% endif %}"
-         href="{% url 'law_report_volume_cases_index' law_report.slug law_report_volume.slug %}">{% trans 'Cited cases' %}</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link {% if active_tab == 'legislation' %}active{% endif %}"
-         href="{% url 'law_report_volume_legislation_index' law_report.slug law_report_volume.slug %}">{% trans 'Cited legislation' %}</a>
-    </li>
-  </ul>
+  {% if section == "judgments" %}
+    <div class="mb-4">
+      <h2 class="h5 mb-3">{% trans 'Explore related indexes' %}</h2>
+      <div class="row row-cols-1 row-cols-md-2 g-3">
+        <div class="col">
+          <a class="card h-100 text-decoration-none text-reset"
+             href="{% url 'law_report_volume_cases_index' law_report.slug law_report_volume.slug %}">
+            <div class="card-body">
+              <h3 class="h5 card-title mb-2">{% trans 'Cited cases' %}</h3>
+              <p class="card-text text-muted mb-0">{% trans 'Browse judgments cited by the reported judgments in this volume.' %}</p>
+            </div>
+          </a>
+        </div>
+        <div class="col">
+          <a class="card h-100 text-decoration-none text-reset"
+             href="{% url 'law_report_volume_legislation_index' law_report.slug law_report_volume.slug %}">
+            <div class="card-body">
+              <h3 class="h5 card-title mb-2">{% trans 'Cited legislation' %}</h3>
+              <p class="card-text text-muted mb-0">
+                {% trans 'Browse legislation cited by the reported judgments in this volume.' %}
+              </p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+{% block alerts %}
+  <div class="mb-3">
+    <h2 class="h4 mb-1">{{ section_title }}</h2>
+    {% if section_description %}<p class="text-muted mb-0">{{ section_description }}</p>{% endif %}
+  </div>
 {% endblock %}

--- a/peachjam/templates/peachjam/law_report/law_report_volume_detail.html
+++ b/peachjam/templates/peachjam/law_report/law_report_volume_detail.html
@@ -36,7 +36,7 @@
            hx-trigger="load">
       </div>
     {% endblock %}
-    <p class="h4 mb-0">{{ law_report_volume.title }}</p>
+    <h2 class="h4 mb-0">{{ law_report_volume.title }}</h2>
   </div>
 {% endblock %}
 {% block count-and-search %}{% endblock %}

--- a/peachjam/templates/peachjam/law_report/law_report_volume_detail.html
+++ b/peachjam/templates/peachjam/law_report/law_report_volume_detail.html
@@ -46,24 +46,32 @@
       <h2 class="h5 mb-3">{% trans 'Explore related indexes' %}</h2>
       <div class="row row-cols-1 row-cols-md-2 g-3">
         <div class="col">
-          <a class="card h-100 text-decoration-none text-reset"
-             href="{% url 'law_report_volume_cases_index' law_report.slug law_report_volume.slug %}">
+          <div class="card h-100 position-relative">
             <div class="card-body">
-              <h3 class="h5 card-title mb-2">{% trans 'Cited cases' %}</h3>
+              <h3 class="h5 card-title mb-2">
+                <a class="stretched-link"
+                   href="{% url 'law_report_volume_cases_index' law_report.slug law_report_volume.slug %}">
+                  {% trans 'Cited cases' %}
+                </a>
+              </h3>
               <p class="card-text text-muted mb-0">{% trans 'Browse judgments cited by the reported judgments in this volume.' %}</p>
             </div>
-          </a>
+          </div>
         </div>
         <div class="col">
-          <a class="card h-100 text-decoration-none text-reset"
-             href="{% url 'law_report_volume_legislation_index' law_report.slug law_report_volume.slug %}">
+          <div class="card h-100 position-relative">
             <div class="card-body">
-              <h3 class="h5 card-title mb-2">{% trans 'Cited legislation' %}</h3>
+              <h3 class="h5 card-title mb-2">
+                <a class="stretched-link"
+                   href="{% url 'law_report_volume_legislation_index' law_report.slug law_report_volume.slug %}">
+                  {% trans 'Cited legislation' %}
+                </a>
+              </h3>
               <p class="card-text text-muted mb-0">
                 {% trans 'Browse legislation cited by the reported judgments in this volume.' %}
               </p>
             </div>
-          </a>
+          </div>
         </div>
       </div>
     </div>

--- a/peachjam/templates/peachjam/law_report/law_report_volume_legislation_index.html
+++ b/peachjam/templates/peachjam/law_report/law_report_volume_legislation_index.html
@@ -1,8 +1,5 @@
 {% extends 'peachjam/law_report/law_report_volume_detail.html' %}
 {% load i18n %}
-{% block alerts %}
-  <h3 class="h5 mb-3">{% trans "Index of cited legislation" %}</h3>
-{% endblock %}
 {% block document-table %}
   {% trans "document" as doc_count_noun %}
   {% trans "documents" as doc_count_noun_plural %}

--- a/peachjam/tests/test_law_reports.py
+++ b/peachjam/tests/test_law_reports.py
@@ -235,7 +235,7 @@ class LawReportViewsTestCase(TestCase):
             '<h1 id="main-page-heading" class="mb-0">East Africa Law Reports</h1>',
             html=False,
         )
-        self.assertContains(response, '<p class="h4 mb-0">Volume 1</p>', html=False)
+        self.assertContains(response, '<h2 class="h4 mb-0">Volume 1</h2>', html=False)
         self.assertContains(response, "Explore related indexes")
         self.assertContains(response, "Reported judgments")
         self.assertContains(
@@ -314,7 +314,7 @@ class LawReportViewsTestCase(TestCase):
             '<h1 id="main-page-heading" class="mb-0">East Africa Law Reports</h1>',
             html=False,
         )
-        self.assertContains(response, '<p class="h4 mb-0">Volume 1</p>', html=False)
+        self.assertContains(response, '<h2 class="h4 mb-0">Volume 1</h2>', html=False)
         self.assertNotContains(response, "Explore related indexes")
         self.assertNotContains(
             response, 'class="card h-100 text-decoration-none text-reset"'
@@ -409,7 +409,7 @@ class LawReportViewsTestCase(TestCase):
             '<h1 id="main-page-heading" class="mb-0">East Africa Law Reports</h1>',
             html=False,
         )
-        self.assertContains(response, '<p class="h4 mb-0">Volume 1</p>', html=False)
+        self.assertContains(response, '<h2 class="h4 mb-0">Volume 1</h2>', html=False)
         self.assertNotContains(response, "Explore related indexes")
         self.assertNotContains(
             response, 'class="card h-100 text-decoration-none text-reset"'

--- a/peachjam/tests/test_law_reports.py
+++ b/peachjam/tests/test_law_reports.py
@@ -243,7 +243,13 @@ class LawReportViewsTestCase(TestCase):
         )
         self.assertContains(
             response,
-            'class="card h-100 text-decoration-none text-reset"',
+            'class="card h-100 position-relative"',
+            count=2,
+            html=False,
+        )
+        self.assertContains(
+            response,
+            'class="stretched-link"',
             count=2,
             html=False,
         )

--- a/peachjam/tests/test_law_reports.py
+++ b/peachjam/tests/test_law_reports.py
@@ -235,9 +235,36 @@ class LawReportViewsTestCase(TestCase):
             '<h1 id="main-page-heading" class="mb-0">East Africa Law Reports</h1>',
             html=False,
         )
-        self.assertContains(response, '<h2 class="h4 mb-0">Volume 1</h2>', html=False)
-        self.assertContains(response, "nav nav-tabs border-bottom", html=False)
+        self.assertContains(response, '<p class="h4 mb-0">Volume 1</p>', html=False)
+        self.assertContains(response, "Explore related indexes")
         self.assertContains(response, "Reported judgments")
+        self.assertContains(
+            response, "Browse the judgments reported in this law report volume."
+        )
+        self.assertContains(
+            response,
+            'class="card h-100 text-decoration-none text-reset"',
+            count=2,
+            html=False,
+        )
+        self.assertNotContains(
+            response,
+            "Browse the judgments reported in this volume.",
+        )
+        self.assertContains(
+            response,
+            reverse(
+                "law_report_volume_cases_index",
+                args=[self.law_report.slug, self.volume_1.slug],
+            ),
+        )
+        self.assertContains(
+            response,
+            reverse(
+                "law_report_volume_legislation_index",
+                args=[self.law_report.slug, self.volume_1.slug],
+            ),
+        )
         self.assertFalse(response.context.get("doc_table_toggle"))
         self.assertNotContains(
             response, 'class="doc-table-children collapse"', html=False
@@ -253,7 +280,7 @@ class LawReportViewsTestCase(TestCase):
             response.context["facet_data"]["labels"]["options"],
         )
         self.assertEqual(self.volume_1, response.context["law_report_volume"])
-        self.assertEqual("judgments", response.context["active_tab"])
+        self.assertEqual("judgments", response.context["section"])
         parent_row = next(
             doc
             for doc in response.context["documents"]
@@ -275,7 +302,7 @@ class LawReportViewsTestCase(TestCase):
         self.assertTemplateUsed(
             response, "peachjam/law_report/law_report_volume_cases_index.html"
         )
-        self.assertEqual("cases", response.context["active_tab"])
+        self.assertEqual("cases", response.context["section"])
         self.assertTrue(response.context.get("doc_table_toggle"))
         self.assertEqual("Cited by", response.context.get("doc_table_toggle_title"))
         self.assertContains(
@@ -287,15 +314,28 @@ class LawReportViewsTestCase(TestCase):
             '<h1 id="main-page-heading" class="mb-0">East Africa Law Reports</h1>',
             html=False,
         )
-        self.assertContains(response, '<h2 class="h4 mb-0">Volume 1</h2>', html=False)
-        self.assertNotContains(response, "<h1>Cited cases</h1>", html=False)
+        self.assertContains(response, '<p class="h4 mb-0">Volume 1</p>', html=False)
+        self.assertNotContains(response, "Explore related indexes")
+        self.assertNotContains(
+            response, 'class="card h-100 text-decoration-none text-reset"'
+        )
         self.assertNotContains(response, "Advanced search")
+        self.assertContains(
+            response, '<h2 class="h4 mb-1">Cited cases</h2>', html=False
+        )
+        self.assertContains(
+            response, "Browse judgments cited by the reported judgments in this volume."
+        )
         self.assertContains(response, "Citation")
         self.assertContains(response, "Judgment date")
         self.assertContains(response, self.second_judgment.title)
         self.assertContains(response, self.first_judgment.title)
         self.assertNotContains(response, self.unrelated_judgment.title)
-        self.assertContains(response, "Reported judgments")
+        self.assertContains(
+            response,
+            f'<a href="{self.volume_1.get_absolute_url()}">Volume 1</a>',
+            html=False,
+        )
         self.assertNotContains(response, "1 reported judgment")
         self.assertContains(response, "Cited by 1 judgment")
         self.assertIn("labels", response.context["facet_data"])
@@ -357,7 +397,7 @@ class LawReportViewsTestCase(TestCase):
         self.assertTemplateUsed(
             response, "peachjam/law_report/law_report_volume_legislation_index.html"
         )
-        self.assertEqual("legislation", response.context["active_tab"])
+        self.assertEqual("legislation", response.context["section"])
         self.assertTrue(response.context.get("doc_table_toggle"))
         self.assertEqual("Cited by", response.context.get("doc_table_toggle_title"))
         self.assertContains(
@@ -369,13 +409,27 @@ class LawReportViewsTestCase(TestCase):
             '<h1 id="main-page-heading" class="mb-0">East Africa Law Reports</h1>',
             html=False,
         )
-        self.assertContains(response, '<h2 class="h4 mb-0">Volume 1</h2>', html=False)
-        self.assertNotContains(response, "<h1>Cited legislation</h1>", html=False)
+        self.assertContains(response, '<p class="h4 mb-0">Volume 1</p>', html=False)
+        self.assertNotContains(response, "Explore related indexes")
+        self.assertNotContains(
+            response, 'class="card h-100 text-decoration-none text-reset"'
+        )
         self.assertNotContains(response, "Advanced search")
+        self.assertContains(
+            response, '<h2 class="h4 mb-1">Cited legislation</h2>', html=False
+        )
+        self.assertContains(
+            response,
+            "Browse legislation cited by the reported judgments in this volume.",
+        )
         self.assertContains(response, self.cited_legislation.title, count=1)
         self.assertContains(response, self.first_judgment.title)
         self.assertNotContains(response, self.other_legislation.title)
-        self.assertContains(response, "Reported judgments")
+        self.assertContains(
+            response,
+            f'<a href="{self.volume_1.get_absolute_url()}">Volume 1</a>',
+            html=False,
+        )
         self.assertNotContains(response, "1 reported judgment")
         self.assertContains(response, "Cited by 1 judgment")
         self.assertIn("years", response.context["facet_data"])
@@ -413,4 +467,4 @@ class LawReportViewsTestCase(TestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual("judgments", response.context["active_tab"])
+        self.assertEqual("judgments", response.context["section"])

--- a/peachjam/views/law_reports.py
+++ b/peachjam/views/law_reports.py
@@ -51,7 +51,9 @@ class LawReportDetailView(DetailView):
 
 class LawReportVolumeViewMixin:
     navbar_link = "law_report"
-    active_tab = None
+    section = None
+    section_title = None
+    section_description = None
 
     @cached_property
     def law_report(self):
@@ -71,7 +73,9 @@ class LawReportVolumeViewMixin:
         context = super().get_context_data(**kwargs)
         context["law_report"] = self.law_report
         context["law_report_volume"] = self.law_report_volume
-        context["active_tab"] = self.active_tab
+        context["section"] = self.section
+        context["section_title"] = self.section_title
+        context["section_description"] = self.section_description
         return context
 
 
@@ -94,7 +98,9 @@ class LawReportVolumeDetailView(
     LawReportVolumeTableMixin, LawReportVolumeViewMixin, FilteredJudgmentView
 ):
     template_name = "peachjam/law_report/law_report_volume_detail.html"
-    active_tab = "judgments"
+    section = "judgments"
+    section_title = _("Reported judgments")
+    section_description = _("Browse the judgments reported in this law report volume.")
     doc_table_toggle = False
 
     def get_base_queryset(self, exclude=None):
@@ -241,7 +247,11 @@ class LawReportVolumeCasesIndexView(
     LawReportVolumeCitationIndexMixin, LawReportVolumeViewMixin, FilteredJudgmentView
 ):
     template_name = "peachjam/law_report/law_report_volume_cases_index.html"
-    active_tab = "cases"
+    section = "cases"
+    section_title = _("Cited cases")
+    section_description = _(
+        "Browse judgments cited by the reported judgments in this volume."
+    )
 
     def get_form(self):
         return FilteredDocumentListView.get_form(self)
@@ -251,7 +261,11 @@ class LawReportVolumeLegislationIndexView(
     LawReportVolumeCitationIndexMixin, LawReportVolumeViewMixin, LegislationListView
 ):
     template_name = "peachjam/law_report/law_report_volume_legislation_index.html"
-    active_tab = "legislation"
+    section = "legislation"
+    section_title = _("Cited legislation")
+    section_description = _(
+        "Browse legislation cited by the reported judgments in this volume."
+    )
     latest_expression_only = True
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
I have updated the lawreport page for listing judgement to a new look. And a less confusing one, please have a look and tell me how it looks:

Before:
<img width="1440" height="857" alt="Screenshot 2026-05-11 at 12 55 52 PM" src="https://github.com/user-attachments/assets/0cd086ee-f0b9-4ca4-b41a-528645d9d259" />


After:


<img width="1229" height="625" alt="Screenshot 2026-05-12 at 10 38 25 AM" src="https://github.com/user-attachments/assets/96192946-ff4f-4b22-8677-53b3b225785b" />


<img width="1440" height="854" alt="Screenshot 2026-05-11 at 12 56 45 PM" src="https://github.com/user-attachments/assets/0e76e6e4-498c-4ad6-a591-ac82f7a9fdda" />
