### PR TITLE
this is a fix on the flyong note script to avoide the duplicates of the children

### DIFF
--- a/peachjam/management/commands/clean_flynote_child_prefixes.py
+++ b/peachjam/management/commands/clean_flynote_child_prefixes.py
@@ -63,6 +63,7 @@ class Command(BaseCommand):
             )
 
         total_roots_touched = 0
+        total_targets_moved = 0
         total_renamed = 0
         total_merged = 0
         total_judgments_updated = 0
@@ -96,32 +97,51 @@ class Command(BaseCommand):
                 continue
 
             total_roots_touched += 1
+            root_targets_moved = 0
             root_renamed = 0
             root_merged = 0
             affected_judgment_ids = set()
+            roots_to_refresh = {root.pk: root}
 
             self.stdout.write(f"ROOT {root.pk}: {root.name}")
 
             with transaction.atomic():
                 for norm, rows in sorted(groups.items(), key=lambda item: item[0]):
-                    existing_target = next(
-                        (
-                            sibling
-                            for sibling in children
-                            if sibling.pk not in candidate_by_pk
-                            and FlynoteParser.normalise_name(sibling.name) == norm
-                        ),
-                        None,
+                    target, move_target = self.find_target(
+                        root=root,
+                        children=children,
+                        candidate_by_pk=candidate_by_pk,
+                        norm=norm,
                     )
 
                     rename_row = None
-                    if existing_target:
-                        target = existing_target
+                    if target:
                         merge_rows = rows
                     else:
                         rename_row = rows[0]
                         target = rename_row["child"]
                         merge_rows = rows[1:]
+
+                    if move_target:
+                        old_root = target.get_root()
+                        self.stdout.write(
+                            "TARGET  {}: {!r} from ROOT {}: {} -> merge target in ROOT {}: {}".format(
+                                target.pk,
+                                target.name,
+                                old_root.pk,
+                                old_root.name,
+                                root.pk,
+                                root.name,
+                            )
+                        )
+                        if not dry_run:
+                            affected_judgment_ids.update(
+                                self.get_subtree_judgment_ids(target)
+                            )
+                            roots_to_refresh[old_root.pk] = old_root
+                            target.move(root, pos="last-child")
+                            target.refresh_from_db()
+                        root_targets_moved += 1
 
                     if rename_row:
                         node = target
@@ -157,21 +177,24 @@ class Command(BaseCommand):
                             target.merge_sources_into([source])
                         root_merged += 1
 
-                if not dry_run and (root_renamed or root_merged):
+                if not dry_run and (root_targets_moved or root_renamed or root_merged):
                     for judgment in Judgment.objects.filter(
                         pk__in=affected_judgment_ids
                     ).only("pk"):
                         judgment.serialise_flynote_tree()
                         judgment.save(update_fields=["flynote", "flynote_raw"])
 
-                    FlynoteDocumentCount.refresh_for_flynote(root)
+                    for refresh_root in roots_to_refresh.values():
+                        FlynoteDocumentCount.refresh_for_flynote(refresh_root)
 
+            total_targets_moved += root_targets_moved
             total_renamed += root_renamed
             total_merged += root_merged
             total_judgments_updated += len(affected_judgment_ids)
 
             self.stdout.write(
-                "ROOT DONE: renamed={}, merged={}, judgments_updated={}".format(
+                "ROOT DONE: targets_moved={}, renamed={}, merged={}, judgments_updated={}".format(
+                    root_targets_moved,
                     root_renamed,
                     root_merged,
                     len(affected_judgment_ids),
@@ -182,12 +205,46 @@ class Command(BaseCommand):
             self.stdout.write("Nothing to clean.")
 
         self.stdout.write(
-            "Done. roots_touched={}, renamed={}, merged={}, "
+            "Done. roots_touched={}, targets_moved={}, renamed={}, merged={}, "
             "judgments_updated={}, dry_run={}".format(
                 total_roots_touched,
+                total_targets_moved,
                 total_renamed,
                 total_merged,
                 total_judgments_updated,
                 dry_run,
             )
+        )
+
+    def find_target(self, root, children, candidate_by_pk, norm):
+        existing_sibling = next(
+            (
+                sibling
+                for sibling in children
+                if sibling.pk not in candidate_by_pk
+                and FlynoteParser.normalise_name(sibling.name) == norm
+            ),
+            None,
+        )
+        if existing_sibling:
+            return existing_sibling, False
+
+        external_matches = [
+            node
+            for node in Flynote.objects.filter(depth=root.depth + 1)
+            .exclude(pk__in=candidate_by_pk)
+            .exclude(path__startswith=root.path)
+            .order_by("path", "pk")
+            if FlynoteParser.normalise_name(node.name) == norm
+        ]
+        if len(external_matches) == 1:
+            return external_matches[0], True
+
+        return None, False
+
+    def get_subtree_judgment_ids(self, flynote):
+        return set(
+            JudgmentFlynote.objects.filter(flynote__path__startswith=flynote.path)
+            .values_list("document_id", flat=True)
+            .distinct()
         )

--- a/peachjam/management/commands/clean_flynote_child_prefixes.py
+++ b/peachjam/management/commands/clean_flynote_child_prefixes.py
@@ -1,12 +1,8 @@
 import re
-from collections import defaultdict
 
 from django.core.management.base import BaseCommand
-from django.db import transaction
 
-from peachjam.analysis.flynotes import FlynoteParser
-from peachjam.models import Judgment
-from peachjam.models.flynote import Flynote, FlynoteDocumentCount, JudgmentFlynote
+from peachjam.models.flynote import Flynote
 
 LAW_SUFFIX_RE = re.compile(r"\s+law$", re.I)
 
@@ -62,189 +58,64 @@ class Command(BaseCommand):
                 "Running in dry-run mode. Re-run with --apply to persist changes."
             )
 
-        total_roots_touched = 0
-        total_targets_moved = 0
-        total_renamed = 0
-        total_merged = 0
-        total_judgments_updated = 0
-
+        cleaned_any = False
         roots = list(Flynote.get_root_nodes().order_by("name"))
 
         for root in roots:
             children = list(root.get_children().order_by("name", "pk"))
-
-            candidate_by_pk = {}
-            groups = defaultdict(list)
-
-            for child in children:
-                new_name = strip_redundant_prefix(root.name, child.name)
-                if not new_name:
-                    continue
-
-                normalised = FlynoteParser.normalise_name(new_name)
-                if not normalised:
-                    continue
-
-                row = {
-                    "child": child,
-                    "new_name": new_name,
-                    "norm": normalised,
-                }
-                candidate_by_pk[child.pk] = row
-                groups[normalised].append(row)
-
-            if not groups:
+            pending = [
+                (child, strip_redundant_prefix(root.name, child.name))
+                for child in children
+            ]
+            pending = [(child, new_name) for child, new_name in pending if new_name]
+            if not pending:
                 continue
 
-            total_roots_touched += 1
-            root_targets_moved = 0
+            cleaned_any = True
             root_renamed = 0
             root_merged = 0
-            affected_judgment_ids = set()
-            roots_to_refresh = {root.pk: root}
-
             self.stdout.write(f"ROOT {root.pk}: {root.name}")
-
-            with transaction.atomic():
-                for norm, rows in sorted(groups.items(), key=lambda item: item[0]):
-                    target, move_target = self.find_target(
-                        root=root,
-                        children=children,
-                        candidate_by_pk=candidate_by_pk,
-                        norm=norm,
+            if dry_run:
+                for child, new_name in pending:
+                    duplicate = (
+                        child.get_siblings()
+                        .exclude(pk=child.pk)
+                        .filter(name__iexact=new_name)
+                        .first()
                     )
+                    if duplicate:
+                        self.stdout.write(
+                            f"MERGE   {child.pk}: {child.name!r} -> {duplicate.pk}"
+                        )
+                        root_merged += 1
+                        continue
 
-                    rename_row = None
-                    if target:
-                        merge_rows = rows
+                    self.stdout.write(
+                        f"RENAME  {child.pk}: {child.name!r} -> {new_name!r}"
+                    )
+                    root_renamed += 1
+            else:
+                for child, new_name in pending:
+                    source_pk = child.pk
+                    source_name = child.name
+                    target, action = child.rename_to_or_merge(new_name)
+                    if action == "merge":
+                        self.stdout.write(
+                            f"MERGE   {source_pk}: {source_name!r} -> {target.pk}"
+                        )
+                        root_merged += 1
                     else:
-                        rename_row = rows[0]
-                        target = rename_row["child"]
-                        merge_rows = rows[1:]
-
-                    if move_target:
-                        old_root = target.get_root()
                         self.stdout.write(
-                            "TARGET  {}: {!r} from ROOT {}: {} -> merge target in ROOT {}: {}".format(
-                                target.pk,
-                                target.name,
-                                old_root.pk,
-                                old_root.name,
-                                root.pk,
-                                root.name,
-                            )
+                            f"RENAME  {source_pk}: {source_name!r} -> {new_name!r}"
                         )
-                        if not dry_run:
-                            affected_judgment_ids.update(
-                                self.get_subtree_judgment_ids(target)
-                            )
-                            roots_to_refresh[old_root.pk] = old_root
-                            target.move(root, pos="last-child")
-                            target.refresh_from_db()
-                        root_targets_moved += 1
-
-                    if rename_row:
-                        node = target
-                        self.stdout.write(
-                            f"RENAME  {node.pk}: {node.name!r} -> {rename_row['new_name']!r}"
-                        )
-                        if not dry_run:
-                            affected_judgment_ids.update(
-                                JudgmentFlynote.objects.filter(
-                                    flynote__path__startswith=node.path
-                                )
-                                .values_list("document_id", flat=True)
-                                .distinct()
-                            )
-                            node.name = rename_row["new_name"]
-                            node.full_clean()
-                            node.save(update_fields=["name"])
                         root_renamed += 1
 
-                    for row in merge_rows:
-                        source = row["child"]
-                        self.stdout.write(
-                            f"MERGE   {source.pk}: {source.name!r} -> {target.pk}"
-                        )
-                        if not dry_run:
-                            affected_judgment_ids.update(
-                                JudgmentFlynote.objects.filter(
-                                    flynote__path__startswith=source.path
-                                )
-                                .values_list("document_id", flat=True)
-                                .distinct()
-                            )
-                            target.merge_sources_into([source])
-                        root_merged += 1
-
-                if not dry_run and (root_targets_moved or root_renamed or root_merged):
-                    for judgment in Judgment.objects.filter(
-                        pk__in=affected_judgment_ids
-                    ).only("pk"):
-                        judgment.serialise_flynote_tree()
-                        judgment.save(update_fields=["flynote", "flynote_raw"])
-
-                    for refresh_root in roots_to_refresh.values():
-                        FlynoteDocumentCount.refresh_for_flynote(refresh_root)
-
-            total_targets_moved += root_targets_moved
-            total_renamed += root_renamed
-            total_merged += root_merged
-            total_judgments_updated += len(affected_judgment_ids)
-
             self.stdout.write(
-                "ROOT DONE: targets_moved={}, renamed={}, merged={}, judgments_updated={}".format(
-                    root_targets_moved,
-                    root_renamed,
-                    root_merged,
-                    len(affected_judgment_ids),
-                )
+                "ROOT DONE: renamed={}, merged={}".format(root_renamed, root_merged)
             )
 
-        if not total_roots_touched:
+        if not cleaned_any:
             self.stdout.write("Nothing to clean.")
+            return
 
-        self.stdout.write(
-            "Done. roots_touched={}, targets_moved={}, renamed={}, merged={}, "
-            "judgments_updated={}, dry_run={}".format(
-                total_roots_touched,
-                total_targets_moved,
-                total_renamed,
-                total_merged,
-                total_judgments_updated,
-                dry_run,
-            )
-        )
-
-    def find_target(self, root, children, candidate_by_pk, norm):
-        existing_sibling = next(
-            (
-                sibling
-                for sibling in children
-                if sibling.pk not in candidate_by_pk
-                and FlynoteParser.normalise_name(sibling.name) == norm
-            ),
-            None,
-        )
-        if existing_sibling:
-            return existing_sibling, False
-
-        external_matches = [
-            node
-            for node in Flynote.objects.filter(depth=root.depth + 1)
-            .exclude(pk__in=candidate_by_pk)
-            .exclude(path__startswith=root.path)
-            .order_by("path", "pk")
-            if FlynoteParser.normalise_name(node.name) == norm
-        ]
-        if len(external_matches) == 1:
-            return external_matches[0], True
-
-        return None, False
-
-    def get_subtree_judgment_ids(self, flynote):
-        return set(
-            JudgmentFlynote.objects.filter(flynote__path__startswith=flynote.path)
-            .values_list("document_id", flat=True)
-            .distinct()
-        )
+        self.stdout.write("Done.")

--- a/peachjam/models/flynote.py
+++ b/peachjam/models/flynote.py
@@ -86,12 +86,9 @@ class Flynote(LifecycleModelMixin, MP_Node):
             return
 
         name = self.name.strip()
-        if self.is_root():
-            siblings = Flynote.get_root_nodes()
-        else:
-            siblings = self.get_parent().get_children()
-
-        duplicate = siblings.exclude(pk=self.pk).filter(name__iexact=name).first()
+        duplicate = (
+            self.get_siblings().exclude(pk=self.pk).filter(name__iexact=name).first()
+        )
         if not duplicate:
             return
 
@@ -170,6 +167,35 @@ class Flynote(LifecycleModelMixin, MP_Node):
                 child.save()
             else:
                 child.cascade_deprecated()
+
+    def rename_to_or_merge(self, new_name):
+        """Rename this flynote, or merge it into an existing sibling of the same name.
+
+        This is the small convenience wrapper around ``merge_sources_into`` for
+        cleanup flows that only need to decide whether the cleaned name should
+        become a rename or a sibling merge.
+        """
+        if not self.pk:
+            raise ValidationError(_("Flynote must be saved before it can be renamed."))
+
+        new_name = (new_name or "").strip()
+        if not new_name:
+            raise ValidationError(_("Flynote name cannot be blank."))
+
+        duplicate = (
+            self.get_siblings()
+            .exclude(pk=self.pk)
+            .filter(name__iexact=new_name)
+            .first()
+        )
+        if duplicate:
+            duplicate.merge_sources_into([self])
+            return duplicate, "merge"
+
+        self.name = new_name
+        self.full_clean()
+        self.save(update_fields=["name"])
+        return self, "rename"
 
     def merge_sources_into(self, sources):
         """Merge sibling flynotes into this flynote.

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -2600,9 +2600,12 @@ class CleanFlynoteChildPrefixesCommandTest(TestCase):
         )
         self.assertIn("Running in dry-run mode", out.getvalue())
         self.assertIn("RENAME", out.getvalue())
-        self.assertIn("dry_run=True", out.getvalue())
+        self.assertIn("Done.", out.getvalue())
 
-    def test_apply_renames_direct_children_and_reserialises_judgments(self):
+    @patch("peachjam.tasks.serialise_judgment_flynote_tree")
+    def test_apply_renames_direct_children_and_reserialises_judgments(
+        self, mock_serialise_judgment_flynote_tree
+    ):
         admin = Flynote.add_root(name="Administrative law")
         child = admin.add_child(name="Administrative/constitutional duty")
         grandchild = child.add_child(name="Administrative/keep me")
@@ -2610,6 +2613,7 @@ class CleanFlynoteChildPrefixesCommandTest(TestCase):
         deep_judgment = self.make_judgment("Administrative grandchild case")
         self.link_flynote(direct_judgment, child)
         self.link_flynote(deep_judgment, grandchild)
+        mock_serialise_judgment_flynote_tree.reset_mock()
 
         out = StringIO()
         call_command(
@@ -2627,18 +2631,21 @@ class CleanFlynoteChildPrefixesCommandTest(TestCase):
         self.assertEqual(child.name, "constitutional duty")
         self.assertEqual(grandchild.name, "Administrative/keep me")
         self.assertEqual(
-            direct_judgment.flynote,
-            "Administrative law — constitutional duty",
+            JudgmentFlynote.objects.get(document=direct_judgment).flynote_id,
+            child.pk,
         )
         self.assertEqual(
-            deep_judgment.flynote,
-            "Administrative law — constitutional duty — Administrative/keep me",
+            JudgmentFlynote.objects.get(document=deep_judgment).flynote_id,
+            grandchild.pk,
         )
-        self.assertIn("judgments_updated=2", out.getvalue())
-        self.assertEqual(
-            FlynoteDocumentCount.objects.get(flynote=admin).count,
-            2,
+        self.assertCountEqual(
+            [
+                args.args[0]
+                for args in mock_serialise_judgment_flynote_tree.call_args_list
+            ],
+            [direct_judgment.pk, deep_judgment.pk],
         )
+        self.assertIn("ROOT DONE: renamed=1, merged=0", out.getvalue())
 
     def test_apply_merges_duplicate_siblings_after_prefix_strip(self):
         root = Flynote.add_root(name="Defamation")
@@ -2665,17 +2672,9 @@ class CleanFlynoteChildPrefixesCommandTest(TestCase):
             JudgmentFlynote.objects.get(document=source_judgment).flynote_id,
             target.pk,
         )
-        self.assertEqual(
-            source_judgment.flynote,
-            "Defamation — communications",
-        )
-        self.assertEqual(
-            target_judgment.flynote,
-            "Defamation — communications",
-        )
         self.assertIn("MERGE", out.getvalue())
 
-    def test_apply_moves_external_target_into_root_before_merging(self):
+    def test_apply_prefers_local_rename_and_merge_over_cross_root_target(self):
         customary = Flynote.add_root(name="Customary law")
         other = Flynote.add_root(name="Leadership")
         target = other.add_child(name="traditional leadership")
@@ -2701,26 +2700,23 @@ class CleanFlynoteChildPrefixesCommandTest(TestCase):
         source_one_judgment.refresh_from_db()
         source_two_judgment.refresh_from_db()
 
-        self.assertEqual(target.get_parent().pk, customary.pk)
+        renamed_target = Flynote.objects.get(pk=source_one.pk)
+        self.assertEqual(target.get_parent().pk, other.pk)
         self.assertEqual(target.name, "traditional leadership")
-        self.assertFalse(Flynote.objects.filter(pk=source_one.pk).exists())
+        self.assertEqual(renamed_target.get_parent().pk, customary.pk)
+        self.assertEqual(renamed_target.name, "traditional leadership")
         self.assertFalse(Flynote.objects.filter(pk=source_two.pk).exists())
         self.assertEqual(
-            target_judgment.flynote,
-            "Customary law — traditional leadership",
+            JudgmentFlynote.objects.get(document=target_judgment).flynote_id,
+            target.pk,
         )
         self.assertEqual(
-            source_one_judgment.flynote,
-            "Customary law — traditional leadership",
+            JudgmentFlynote.objects.get(document=source_one_judgment).flynote_id,
+            renamed_target.pk,
         )
         self.assertEqual(
-            source_two_judgment.flynote,
-            "Customary law — traditional leadership",
+            JudgmentFlynote.objects.get(document=source_two_judgment).flynote_id,
+            renamed_target.pk,
         )
-        self.assertEqual(
-            FlynoteDocumentCount.objects.get(flynote=customary).count,
-            3,
-        )
-        self.assertFalse(FlynoteDocumentCount.objects.filter(flynote=other).exists())
-        self.assertIn("TARGET", out.getvalue())
-        self.assertIn("merge target in ROOT", out.getvalue())
+        self.assertIn("RENAME", out.getvalue())
+        self.assertIn("MERGE", out.getvalue())

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -2674,3 +2674,53 @@ class CleanFlynoteChildPrefixesCommandTest(TestCase):
             "Defamation — communications",
         )
         self.assertIn("MERGE", out.getvalue())
+
+    def test_apply_moves_external_target_into_root_before_merging(self):
+        customary = Flynote.add_root(name="Customary law")
+        other = Flynote.add_root(name="Leadership")
+        target = other.add_child(name="traditional leadership")
+        source_one = customary.add_child(name="Customary law / traditional leadership")
+        source_two = customary.add_child(name="Customary law/traditional leadership")
+        target_judgment = self.make_judgment("Existing leadership case")
+        source_one_judgment = self.make_judgment("Customary source one")
+        source_two_judgment = self.make_judgment("Customary source two")
+        self.link_flynote(target_judgment, target)
+        self.link_flynote(source_one_judgment, source_one)
+        self.link_flynote(source_two_judgment, source_two)
+
+        out = StringIO()
+        call_command(
+            "clean_flynote_child_prefixes",
+            apply=True,
+            stdout=out,
+            stderr=StringIO(),
+        )
+
+        target.refresh_from_db()
+        target_judgment.refresh_from_db()
+        source_one_judgment.refresh_from_db()
+        source_two_judgment.refresh_from_db()
+
+        self.assertEqual(target.get_parent().pk, customary.pk)
+        self.assertEqual(target.name, "traditional leadership")
+        self.assertFalse(Flynote.objects.filter(pk=source_one.pk).exists())
+        self.assertFalse(Flynote.objects.filter(pk=source_two.pk).exists())
+        self.assertEqual(
+            target_judgment.flynote,
+            "Customary law — traditional leadership",
+        )
+        self.assertEqual(
+            source_one_judgment.flynote,
+            "Customary law — traditional leadership",
+        )
+        self.assertEqual(
+            source_two_judgment.flynote,
+            "Customary law — traditional leadership",
+        )
+        self.assertEqual(
+            FlynoteDocumentCount.objects.get(flynote=customary).count,
+            3,
+        )
+        self.assertFalse(FlynoteDocumentCount.objects.filter(flynote=other).exists())
+        self.assertIn("TARGET", out.getvalue())
+        self.assertIn("merge target in ROOT", out.getvalue())


### PR DESCRIPTION
i have updated this script to avoide createing same flying note on the second level after renaming it. so i did a dry run on my local data and this is how should look like in below data but focus on this example
""TARGET  47185: 'Public finance' from ROOT 2443: Contract law -> merge target in ROOT 3769: Procurement law""

It means:
  - there is already a flynote node called Public finance
  - its id is 47185
  - right now it is under the root Contract law
  - while processing the root Procurement law, the script found a child like:
      - Procurement law / public finance
  - after cleaning that child name, the final label becomes:
      - public finance
  - instead of creating a new Public finance under Procurement law, the script
    wants to reuse the existing Public finance node
  - so on apply, it would move node 47185 from Contract law to Procurement law
  - then it would merge the prefixed procurement duplicate into that moved
    node

  Before:

  Contract law
    Public finance

  Procurement law
    Procurement law / public finance

  After:

  Contract law
    [Public finance no longer here]

  Procurement law
    Public finance

  and then:

  Procurement law / public finance

  gets merged into that Public finance



Here is teh rest of dry run


ROOT 3769: Procurement law
TARGET  47185: 'Public finance' from ROOT 2443: Contract law -> merge target in ROOT 3769: Procurement law
MERGE   62812: 'Procurement law / public finance' -> 47185
MERGE   61594: 'Procurement law / public procurement' -> 3770
MERGE   64690: 'Procurement/tender law' -> 13146
MERGE   40591: 'Procurement/tender review' -> 25758
TARGET  17028: 'tenders' from ROOT 2681: Administrative law -> merge target in ROOT 3769: Procurement law
MERGE   11746: 'Procurement/tenders' -> 17028
ROOT DONE: targets_moved=2, renamed=0, merged=5, judgments_updated=0


