### PR TITLE
Removed all RSS/Atom support except for articles

### DIFF
--- a/peachjam/feeds.py
+++ b/peachjam/feeds.py
@@ -5,98 +5,13 @@ from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed, Rss201rev2Feed
 
-from peachjam.models import (
-    Article,
-    CoreDocument,
-    GenericDocument,
-    Judgment,
-    Legislation,
-)
+from peachjam.models import Article
 
 
-class BaseFeed(Feed):
-    model = None
-
-    def clean_xml_text(self, text):
-        """Remove control characters that are not allowed in XML."""
-        return re.sub(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", "", text)
-
-    def items(self):
-        if self.model in [Article]:
-            return self.model.objects.filter(published=True).order_by("-date")[:100]
-
-        return self.model.objects.order_by("-created_at")[:100]
-
-    def item_pubdate(self, item):
-        return datetime.datetime.combine(item.date, datetime.time())
-
-    def item_title(self, item):
-        return self.clean_xml_text(item.title)
-
-    def item_description(self, item):
-        return self.clean_xml_text(item.title)
-
-
-class BaseAtomFeed(BaseFeed):
-    feed_type = Atom1Feed
-
-
-class JudgmentFeed(BaseFeed):
-    model = Judgment
-    link = "/judgments/"
-    description = "Updates on changes and additions to Judgments"
-
-
-class JudgmentAtomSiteNewsFeed(JudgmentFeed, BaseAtomFeed):
-    subtitle = JudgmentFeed.description
-
-
-class GenericDocumentFeed(BaseFeed):
-    model = GenericDocument
-    title = "Generic Documents"
-    link = "/doc/"
-    description = "Updates on changes and additions to Generic Documents"
-
-
-class GenericDocumentAtomSiteNewsFeed(GenericDocumentFeed, BaseAtomFeed):
-    subtitle = GenericDocumentFeed.description
-
-
-class LegislationFeed(BaseFeed):
-    model = Legislation
-    title = "Legal Instruments"
-    link = "/legal_instruments/"
-    description = "Updates on changes and additions to Legal Instruments"
-
-
-class LegislationAtomSiteNewsFeed(LegislationFeed, BaseAtomFeed):
-    subtitle = LegislationFeed.description
-
-
-class CoreDocumentFeed(BaseFeed):
-    model = CoreDocument
-    title = "Core Documents"
-    link = "/core_documents"
-    description = "Updates on changes and additions to Core Documents"
-
-
-class CoreDocumentAtomSiteNewsFeed(CoreDocumentFeed, BaseAtomFeed):
-    subtitle = CoreDocumentFeed.description
-
-
-class CustomArticleFeedGenerator(Rss201rev2Feed):
-    def add_item_elements(self, handler, item):
-        super().add_item_elements(handler, item)
-        handler.addQuickElement("image", item.get("image", ""))
-        handler.addQuickElement("body", item.get("body", ""))
-
-
-class ArticleFeed(BaseFeed):
-    model = Article
+class ArticleFeed(Feed):
     title = f"{settings.PEACHJAM['APP_NAME']} Articles"
     link = "/articles/"
     description = "Updates on changes and additions to articles"
-    feed_type = CustomArticleFeedGenerator
 
     def __call__(self, request, *args, **kwargs):
         self.request = request
@@ -113,6 +28,34 @@ class ArticleFeed(BaseFeed):
             "body": item.body,
         }
 
+    def clean_xml_text(self, text):
+        """Remove control characters that are not allowed in XML."""
+        return re.sub(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", "", text)
 
-class ArticleAtomSiteNewsFeed(ArticleFeed, BaseAtomFeed):
+    def items(self):
+        return Article.objects.filter(published=True).order_by("-date")[:100]
+
+    def item_pubdate(self, item):
+        return datetime.datetime.combine(item.date, datetime.time())
+
+    def item_title(self, item):
+        return self.clean_xml_text(item.title)
+
+    def item_description(self, item):
+        return self.clean_xml_text(item.title)
+
+
+class CustomArticleFeedGenerator(Rss201rev2Feed):
+    def add_item_elements(self, handler, item):
+        super().add_item_elements(handler, item)
+        handler.addQuickElement("image", item.get("image", ""))
+        handler.addQuickElement("body", item.get("body", ""))
+
+
+class ArticleRSSFeed(ArticleFeed):
+    feed_type = CustomArticleFeedGenerator
+
+
+class ArticleAtomSiteNewsFeed(ArticleFeed):
+    feed_type = Atom1Feed
     subtitle = ArticleFeed.description

--- a/peachjam/templates/peachjam/layouts/base.html
+++ b/peachjam/templates/peachjam/layouts/base.html
@@ -13,32 +13,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     {% block head-meta %}
-      <link rel="alternate"
-            type="application/atom+xml"
-            title="Atom RSS Feed"
-            href="{% url 'atom_feed' %}"/>
-      {% if request.path == '/judgments/' %}
-        <link rel="alternate"
-              type="application/atom+xml"
-              title="Judgments Atom RSS Feed"
-              href="{% url 'judgment_feed' %}"/>
-      {% endif %}
-      {% if request.path == '/doc/' %}
-        <link rel="alternate"
-              type="application/atom+xml"
-              title="AU Documents Atom RSS Feed"
-              href="{% url 'generic_document_feed' %}"/>
-      {% endif %}
-      {% if request.path == '/legislation/' %}
-        <link rel="alternate"
-              type="application/atom+xml"
-              title="Treaties & Protocols Atom RSS Feed"
-              href="{% url 'legislation_feed' %}"/>
-      {% endif %}
       {% if request.path == '/articles/' %}
         <link rel="alternate"
               type="application/atom+xml"
-              title="{{ APP_NAME }} Articles RSS Feed"
+              title="{{ APP_NAME }} Articles Atom Feed"
               href="{% url 'article_feed' %}"/>
       {% endif %}
       {% block favicon %}

--- a/peachjam/urls/feeds.py
+++ b/peachjam/urls/feeds.py
@@ -1,22 +1,8 @@
 from django.urls import path
 
-from peachjam.feeds import (
-    ArticleAtomSiteNewsFeed,
-    CoreDocumentAtomSiteNewsFeed,
-    GenericDocumentAtomSiteNewsFeed,
-    JudgmentAtomSiteNewsFeed,
-    LegislationAtomSiteNewsFeed,
-)
+from peachjam.feeds import ArticleAtomSiteNewsFeed
 
 urlpatterns = [
     # feeds
-    path("judgments.xml", JudgmentAtomSiteNewsFeed(), name="judgment_feed"),
-    path(
-        "generic_documents.xml",
-        GenericDocumentAtomSiteNewsFeed(),
-        name="generic_document_feed",
-    ),
-    path("legislation.xml", LegislationAtomSiteNewsFeed(), name="legislation_feed"),
-    path("all.xml", CoreDocumentAtomSiteNewsFeed(), name="atom_feed"),
     path("articles.xml", ArticleAtomSiteNewsFeed(), name="article_feed"),
 ]


### PR DESCRIPTION
Closes #3197 

- Removed all outdated support except for articles
- I'm unsure if we should remove RSS support for articles. We implemented it, but it seems we don't use it.