### PR TITLE
fix the issue of add child none in the flynote path

### DIFF
--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -2832,7 +2832,6 @@ class FlynoteUpdater:
         can proceed safely.
         """
         locked_parent = Flynote.objects.select_for_update().get(pk=parent.pk)
-        locked_parent.refresh_from_db(fields=["path", "depth", "numchild"])
 
         if locked_parent.numchild and locked_parent.get_last_child() is None:
             log.warning(

--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -2822,6 +2822,29 @@ class FlynoteUpdater:
         self.node_cache = {}
         self.update_counts = update_counts
 
+    def get_parent_for_child_insert(self, parent):
+        """Lock and refresh the parent row before inserting a child.
+
+        Treebeard decides whether a node is a leaf from ``numchild`` on the
+        in-memory parent. In production we have seen parent rows where
+        ``numchild`` says children exist but the last-child lookup returns
+        nothing. Repair that drift before calling ``add_child()`` so the insert
+        can proceed safely.
+        """
+        locked_parent = Flynote.objects.select_for_update().get(pk=parent.pk)
+        locked_parent.refresh_from_db(fields=["path", "depth", "numchild"])
+
+        if locked_parent.numchild and locked_parent.get_last_child() is None:
+            log.warning(
+                "Repairing flynote %s before add_child(): numchild=%s but no last child exists.",
+                locked_parent.pk,
+                locked_parent.numchild,
+            )
+            Flynote.objects.filter(pk=locked_parent.pk).update(numchild=0)
+            locked_parent.numchild = 0
+
+        return locked_parent
+
     def get_or_create_node(self, parent, name):
         """Find an existing Flynote whose normalised sibling name matches, or create a new one.
 
@@ -2862,10 +2885,7 @@ class FlynoteUpdater:
 
         try:
             if parent:
-                # Treebeard uses parent state such as numchild when adding a child.
-                # Cached parent instances can go stale across multiple judgments,
-                # so refresh before inserting under an existing node.
-                parent.refresh_from_db(fields=["path", "depth", "numchild"])
+                parent = self.get_parent_for_child_insert(parent)
                 node = parent.add_child(name=name)
             else:
                 node = Flynote.add_root(name=name)

--- a/peachjam/tests/test_admin.py
+++ b/peachjam/tests/test_admin.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django_webtest import WebTest
+from docpipe.soffice import SOfficeError
 from webtest import Upload
 
 from peachjam.models import (
@@ -24,6 +25,12 @@ class TestJudgmentAdmin(WebTest):
 
     def setUp(self):
         self.app.set_user(User.objects.get(username="admin@example.com"))
+
+    def submit_or_skip_soffice(self, form):
+        try:
+            return form.submit()
+        except (FileNotFoundError, SOfficeError):
+            self.skipTest("LibreOffice conversion unavailable in this environment")
 
     def make_judgment(self, anonymised=False):
         return Judgment.objects.create(
@@ -81,7 +88,7 @@ class TestJudgmentAdmin(WebTest):
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
 
-        response = form.submit()
+        response = self.submit_or_skip_soffice(form)
         self.assertRedirects(response, judgment_list_url)
 
         judgment = Judgment.objects.filter(
@@ -112,7 +119,7 @@ class TestJudgmentAdmin(WebTest):
         form2["source_file-0-file"] = Upload(
             "upload_pdf.pdf", pdf_file_content, "application/pdf"
         )
-        response2 = form2.submit()
+        response2 = self.submit_or_skip_soffice(form2)
         self.assertRedirects(response2, judgment_list_url)
 
         judgment.refresh_from_db()
@@ -177,7 +184,7 @@ class TestJudgmentAdmin(WebTest):
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
 
-        response2 = form2.submit()
+        response2 = self.submit_or_skip_soffice(form2)
         self.assertRedirects(response2, judgment_list_url)
 
         judgment.refresh_from_db()

--- a/peachjam/tests/test_admin.py
+++ b/peachjam/tests/test_admin.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django_webtest import WebTest
-from docpipe.soffice import SOfficeError
 from webtest import Upload
 
 from peachjam.models import (
@@ -25,12 +24,6 @@ class TestJudgmentAdmin(WebTest):
 
     def setUp(self):
         self.app.set_user(User.objects.get(username="admin@example.com"))
-
-    def submit_or_skip_soffice(self, form):
-        try:
-            return form.submit()
-        except (FileNotFoundError, SOfficeError):
-            self.skipTest("LibreOffice conversion unavailable in this environment")
 
     def make_judgment(self, anonymised=False):
         return Judgment.objects.create(
@@ -88,7 +81,7 @@ class TestJudgmentAdmin(WebTest):
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
 
-        response = self.submit_or_skip_soffice(form)
+        response = form.submit()
         self.assertRedirects(response, judgment_list_url)
 
         judgment = Judgment.objects.filter(
@@ -119,7 +112,7 @@ class TestJudgmentAdmin(WebTest):
         form2["source_file-0-file"] = Upload(
             "upload_pdf.pdf", pdf_file_content, "application/pdf"
         )
-        response2 = self.submit_or_skip_soffice(form2)
+        response2 = form2.submit()
         self.assertRedirects(response2, judgment_list_url)
 
         judgment.refresh_from_db()
@@ -184,7 +177,7 @@ class TestJudgmentAdmin(WebTest):
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
 
-        response2 = self.submit_or_skip_soffice(form2)
+        response2 = form2.submit()
         self.assertRedirects(response2, judgment_list_url)
 
         judgment.refresh_from_db()

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -1298,6 +1298,18 @@ class GetOrCreateFlynoteNodeTest(TestCase):
         self.assertFalse(child.is_root())
         self.assertEqual(child.get_parent().pk, parent.pk)
 
+    def test_repairs_parent_numchild_when_last_child_is_missing(self):
+        parent = Flynote.add_root(name="Criminal law")
+        Flynote.objects.filter(pk=parent.pk).update(numchild=1)
+        parent.refresh_from_db(fields=["path", "depth", "numchild"])
+
+        child = self.updater.get_or_create_node(parent, "admissibility")
+
+        self.assertIsNotNone(child)
+        self.assertEqual(child.get_parent().pk, parent.pk)
+        parent.refresh_from_db(fields=["numchild"])
+        self.assertEqual(parent.numchild, 1)
+
 
 class UpdateFlynoteForJudgmentTest(TestCase):
     fixtures = ["tests/countries", "tests/courts", "tests/languages"]


### PR DESCRIPTION
This pr addresses this issue #3221  whereby the issue was under the flying note updater when creating the child node under the existing parent whereby parent is saying it has a child but in actual the metadata is lying there is no child existing so it returns none. 