### PR TITLE
ensure libreoffice is installed in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,14 @@ jobs:
           packages: libreoffice poppler-utils pandoc
           version: test-apt-v1
           execute_install_scripts: true
+      - name: Inspect cached system packages
+        run: |
+          which pandoc || true
+          pandoc --version || true
+          which pdftotext || true
+          pdftotext -v || true
+          which soffice || true
+          soffice --version || true
       - name: Ensure system packages are installed
         run: |
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           packages: libreoffice poppler-utils pandoc
           version: test-apt-v1
           execute_install_scripts: true
-      - name: Install system packages
+      - name: Install libreoffice
         run: |
           sudo apt-get update
           sudo apt-get install -y libreoffice

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,16 +62,12 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libreoffice poppler-utils pandoc
-          version: test-apt-v1
+          version: test-apt-v3
           execute_install_scripts: true
-      - name: Inspect cached system packages
+      - name: Install system packages
         run: |
-          which pandoc || true
-          pandoc --version || true
-          which pdftotext || true
-          pdftotext -v || true
-          which soffice || true
-          soffice --version || true
+          sudo apt-get update
+          sudo apt-get install -y libreoffice poppler-utils pandoc
       - name: Install deps
         run: |
           python -m pip install --upgrade "setuptools<82" wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,12 +72,6 @@ jobs:
           pdftotext -v || true
           which soffice || true
           soffice --version || true
-      - name: Ensure system packages are installed
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libreoffice poppler-utils pandoc
-          which soffice
-          soffice --version
       - name: Install deps
         run: |
           python -m pip install --upgrade "setuptools<82" wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y libreoffice poppler-utils pandoc
+          sudo apt-get install -y libreoffice
       - name: Install deps
         run: |
           python -m pip install --upgrade "setuptools<82" wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libreoffice poppler-utils pandoc
-          version: test-apt-v3
+          version: test-apt-v1
           execute_install_scripts: true
       - name: Install system packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,12 @@ jobs:
           packages: libreoffice poppler-utils pandoc
           version: test-apt-v1
           execute_install_scripts: true
+      - name: Ensure system packages are installed
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libreoffice poppler-utils pandoc
+          which soffice
+          soffice --version
       - name: Install deps
         run: |
           python -m pip install --upgrade "setuptools<82" wheel


### PR DESCRIPTION
lets install the soffice with apt and stop relying on caching, it will still be fast but not as relying on caching but now we need to solve the issue of soffice not get installed well