### PR TITLE
cloudflare turnstile support

### DIFF
--- a/peachjam/forms.py
+++ b/peachjam/forms.py
@@ -9,7 +9,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files import File
 from django.core.mail import send_mail
 from django.core.mail.message import EmailMultiAlternatives
@@ -22,6 +22,7 @@ from django.utils.translation.trans_real import get_languages
 from django_recaptcha.fields import ReCaptchaField
 from django_recaptcha.widgets import ReCaptchaV2Invisible
 from languages_plus.models import Language
+from turnstile.fields import TurnstileField
 
 from peachjam.analysis.summariser import JudgmentSummariser
 from peachjam.models import (
@@ -45,7 +46,7 @@ User = get_user_model()
 
 
 def get_recaptcha_field():
-    """Return a captcha field that is disabled when running in DEBUG mode."""
+    """Return a human-verification field that is disabled when running in DEBUG mode."""
 
     if settings.DEBUG:
         return forms.BooleanField(
@@ -54,7 +55,15 @@ def get_recaptcha_field():
             initial=True,
         )
 
-    return ReCaptchaField(widget=ReCaptchaV2Invisible)
+    if settings.RECAPTCHA_PUBLIC_KEY and settings.RECAPTCHA_PRIVATE_KEY:
+        return ReCaptchaField(widget=ReCaptchaV2Invisible)
+
+    if settings.TURNSTILE_SECRET and settings.TURNSTILE_SITEKEY:
+        return TurnstileField()
+
+    raise ImproperlyConfigured(
+        "In production, either RECAPTCHA or TURNSTILE settings must be configured."
+    )
 
 
 def work_choices():

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -126,6 +126,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "django_htmx",
     "django_recaptcha",
+    "turnstile",
     "django_comments",
     "guardian",
 ]
@@ -286,11 +287,17 @@ SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 SOCIALACCOUNT_ADAPTER = "peachjam.auth.SocialAccountAdapter"
 ACCOUNT_ADAPTER = "peachjam.auth.AccountAdapter"
 
-# Recaptcha
+# Only one of Recaptcha or Turnstile should be configured
+# Google Recaptcha
 RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY", "")
 RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY", "")
 if DEBUG:
     SILENCED_SYSTEM_CHECKS = ["django_recaptcha.recaptcha_test_key_error"]
+
+# Cloudflare Turnstile
+if not DEBUG:
+    TURNSTILE_SITEKEY = os.environ.get("TURNSTILE_SITEKEY", "")
+    TURNSTILE_SECRET = os.environ.get("TURNSTILE_SECRET", "")
 
 
 if DEBUG:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "django-storages>=1.12.3",
     "django-templated-email>=3.0.1",
     "django-treebeard>=4.5.1",
+    "django-turnstile>=0.1.3",
     "djangorestframework>=3.13.1",
     "drf-spectacular>=0.26.0",
     "docpipe @ git+https://github.com/laws-africa/docpipe.git@a32eb0f478a945e1189ec998e1d312eddf9ac08d",


### PR DESCRIPTION
This is optional and replaces Google Recaptcha with the same functionality. The benefit is that we can use it in our Cloudflare security rules to accurately identify when CF has decided a user is human.