### PR TITLE
update the email template so to make the flying notes italic and also…

### DIFF
--- a/peachjam/templates/peachjam/emails/_alert_document_list_item.html
+++ b/peachjam/templates/peachjam/emails/_alert_document_list_item.html
@@ -1,6 +1,6 @@
 {% load peachjam %}
 <li style="margin-bottom: 1rem">
   <a href="{% absolute_url site url_path %}?utm_campaign={{ utm_campaign }}&utm_source=alert&utm_medium=email">{{ title }}</a>
-  {% if blurb %}<div>{{ blurb|striptags }}</div>{% endif %}
+  {% if blurb %}<div>{{ blurb }}</div>{% endif %}
   {% if flynote %}<div style="margin-top: 0.5rem; font-style: italic">{{ flynote|linebreaksbr }}</div>{% endif %}
 </li>

--- a/peachjam/templates/peachjam/emails/_alert_document_list_item.html
+++ b/peachjam/templates/peachjam/emails/_alert_document_list_item.html
@@ -1,0 +1,6 @@
+{% load peachjam %}
+<li style="margin-bottom: 1rem">
+  <a href="{% absolute_url site url_path %}?utm_campaign={{ utm_campaign }}&utm_source=alert&utm_medium=email">{{ title }}</a>
+  {% if blurb %}<div>{{ blurb|striptags }}</div>{% endif %}
+  {% if flynote %}<div style="margin-top: 0.5rem; font-style: italic">{{ flynote|linebreaksbr }}</div>{% endif %}
+</li>

--- a/peachjam/templates/peachjam/emails/_new_relationship_alert_body.html
+++ b/peachjam/templates/peachjam/emails/_new_relationship_alert_body.html
@@ -16,9 +16,7 @@
             </a>
             {% if doc.blurb %}<div>{{ doc.blurb | safe }}</div>{% endif %}
             {% if doc.flynote %}
-              <div>
-                <em>{{ doc.flynote | linebreaksbr }}</em>
-              </div>
+              <div style="margin-top: 0.5rem; font-style: italic">{{ doc.flynote | linebreaksbr }}</div>
             {% endif %}
           </li>
         {% endfor %}

--- a/peachjam/templates/peachjam/emails/_new_relationship_alert_body.html
+++ b/peachjam/templates/peachjam/emails/_new_relationship_alert_body.html
@@ -10,15 +10,7 @@
       </p>
       <ul>
         {% for doc in rel.documents %}
-          <li style="margin-bottom: 1rem">
-            <a href="{% absolute_url site doc.get_absolute_url %}?utm_campaign=new_relationship&utm_source=alert&utm_medium=email">
-              {{ doc.title }}
-            </a>
-            {% if doc.blurb %}<div>{{ doc.blurb | safe }}</div>{% endif %}
-            {% if doc.flynote %}
-              <div style="margin-top: 0.5rem; font-style: italic">{{ doc.flynote | linebreaksbr }}</div>
-            {% endif %}
-          </li>
+          {% include "peachjam/emails/_alert_document_list_item.html" with site=site url_path=doc.get_absolute_url utm_campaign="new_relationship" title=doc.title blurb=doc.blurb flynote=doc.flynote only %}
         {% endfor %}
       </ul>
     </div>

--- a/peachjam/templates/peachjam/emails/new_citation_alert.email
+++ b/peachjam/templates/peachjam/emails/new_citation_alert.email
@@ -19,8 +19,8 @@
           <a href="{% absolute_url site citing.document.get_absolute_url %}?utm_campaign=new_citation&utm_source=alert&utm_medium=email">{{ citing.document.title }}</a>
           {% if citing.document.blurb %}<div>{{ citing.blurb | safe }}</div>{% endif %}
           {% if citing.document.flynote %}
-            <div>
-              <em>{{ citing.document.flynote | linebreaksbr }}</em>
+            <div style="margin-top: 0.5rem; font-style: italic">
+              {{ citing.document.flynote | linebreaksbr }}
             </div>
           {% endif %}
         </li>

--- a/peachjam/templates/peachjam/emails/new_citation_alert.email
+++ b/peachjam/templates/peachjam/emails/new_citation_alert.email
@@ -15,15 +15,7 @@
     </p>
     <ul>
       {% for citing in item.citing_documents %}
-        <li style="margin-bottom: 1rem">
-          <a href="{% absolute_url site citing.document.get_absolute_url %}?utm_campaign=new_citation&utm_source=alert&utm_medium=email">{{ citing.document.title }}</a>
-          {% if citing.document.blurb %}<div>{{ citing.blurb | safe }}</div>{% endif %}
-          {% if citing.document.flynote %}
-            <div style="margin-top: 0.5rem; font-style: italic">
-              {{ citing.document.flynote | linebreaksbr }}
-            </div>
-          {% endif %}
-        </li>
+        {% include "peachjam/emails/_alert_document_list_item.html" with site=site url_path=citing.document.get_absolute_url utm_campaign="new_citation" title=citing.document.title blurb=citing.document.blurb flynote=citing.document.flynote only %}
         <ul>
           {% for pc in citing.provision_citations %}
             <li>

--- a/peachjam/templates/peachjam/emails/user_following_alert.email
+++ b/peachjam/templates/peachjam/emails/user_following_alert.email
@@ -13,10 +13,14 @@
     <b>{{ item.followed_object }}</b>
     <ul>
       {% for doc in item.documents %}
-        <li>
+        <li style="margin-bottom: 1rem">
           <a href="{% absolute_url site doc.expression_frbr_uri %}?utm_campaign=following&utm_source=alert&utm_medium=email">{{ doc.title }}</a>
           {% if doc.blurb %}<div>{{ doc.blurb }}</div>{% endif %}
-          {% if doc.flynote %}<div>{{ doc.flynote|linebreaksbr }}</div>{% endif %}
+          {% if doc.flynote %}
+            <div style="margin-top: 0.5rem; font-style: italic">
+              {{ doc.flynote | linebreaksbr }}
+            </div>
+          {% endif %}
         </li>
       {% endfor %}
     </ul>

--- a/peachjam/templates/peachjam/emails/user_following_alert.email
+++ b/peachjam/templates/peachjam/emails/user_following_alert.email
@@ -13,15 +13,7 @@
     <b>{{ item.followed_object }}</b>
     <ul>
       {% for doc in item.documents %}
-        <li style="margin-bottom: 1rem">
-          <a href="{% absolute_url site doc.expression_frbr_uri %}?utm_campaign=following&utm_source=alert&utm_medium=email">{{ doc.title }}</a>
-          {% if doc.blurb %}<div>{{ doc.blurb }}</div>{% endif %}
-          {% if doc.flynote %}
-            <div style="margin-top: 0.5rem; font-style: italic">
-              {{ doc.flynote | linebreaksbr }}
-            </div>
-          {% endif %}
-        </li>
+        {% include "peachjam/emails/_alert_document_list_item.html" with site=site url_path=doc.expression_frbr_uri utm_campaign="following" title=doc.title blurb=doc.blurb flynote=doc.flynote only %}
       {% endfor %}
     </ul>
     <hr/>

--- a/peachjam/tests/test_email_templates.py
+++ b/peachjam/tests/test_email_templates.py
@@ -135,11 +135,10 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
         html = message.alternatives[0][0] if message.alternatives else message.body
 
         self.assert_alert_document_item_spacing(html)
-        self.assertIn("Short blurb", html)
-        self.assertNotIn("&lt;b&gt;blurb&lt;/b&gt;", html)
+        self.assertIn("Short &lt;b&gt;blurb&lt;/b&gt;", html)
         self.assertIn("First line<br>Second line", html)
 
-    def test_citation_alert_email_strips_blurb_markup(self):
+    def test_citation_alert_email_escapes_blurb_markup(self):
         context = self.base_context("example.org")
         context.update(
             {
@@ -175,11 +174,10 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
         html = message.alternatives[0][0] if message.alternatives else message.body
 
         self.assert_alert_document_item_spacing(html)
-        self.assertIn("Short blurb", html)
-        self.assertNotIn("<b>blurb</b>", html)
+        self.assertIn("Short &lt;b&gt;blurb&lt;/b&gt;", html)
         self.assertIn("First line<br>Second line", html)
 
-    def test_relationship_alert_email_strips_blurb_markup(self):
+    def test_relationship_alert_email_escapes_blurb_markup(self):
         context = self.base_context("example.org")
         context.update(
             {
@@ -217,8 +215,7 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
         html = message.alternatives[0][0] if message.alternatives else message.body
 
         self.assert_alert_document_item_spacing(html)
-        self.assertIn("Short blurb", html)
-        self.assertNotIn("<b>blurb</b>", html)
+        self.assertIn("Short &lt;b&gt;blurb&lt;/b&gt;", html)
         self.assertIn("First line<br>Second line", html)
 
     def test_search_alert_email_does_not_duplicate_protocol(self):

--- a/peachjam/tests/test_email_templates.py
+++ b/peachjam/tests/test_email_templates.py
@@ -98,6 +98,42 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
             html,
         )
 
+    def test_following_alert_email_adds_email_safe_flynote_spacing(self):
+        context = self.base_context("example.org")
+        context.update(
+            {
+                "manage_url_path": "/en/my/following/",
+                "followed_documents": [
+                    {
+                        "followed_object": "Civil procedure",
+                        "documents": [
+                            SimpleNamespace(
+                                title="Example document",
+                                expression_frbr_uri="/documents/example/",
+                                blurb="Short blurb",
+                                flynote="First line\nSecond line",
+                            )
+                        ],
+                    }
+                ],
+            }
+        )
+
+        message = get_templated_mail(
+            template_name="user_following_alert",
+            from_email="test@example.org",
+            to=["user@example.org"],
+            context=context,
+        )
+        html = message.alternatives[0][0] if message.alternatives else message.body
+
+        self.assertIn('<li style="margin-bottom: 1rem">', html)
+        self.assertIn(
+            '<div style="margin-top: 0.5rem; font-style: italic">',
+            html,
+        )
+        self.assertIn("First line<br>Second line", html)
+
     def test_search_alert_email_does_not_duplicate_protocol(self):
         context = self.base_context("https://example.org")
         context.update(

--- a/peachjam/tests/test_email_templates.py
+++ b/peachjam/tests/test_email_templates.py
@@ -17,6 +17,13 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
             "PRIMARY_COLOUR": "#123456",
         }
 
+    def assert_alert_document_item_spacing(self, html):
+        self.assertIn('<li style="margin-bottom: 1rem">', html)
+        self.assertIn(
+            '<div style="margin-top: 0.5rem; font-style: italic">',
+            html,
+        )
+
     def test_absolute_url_tag_adds_https_and_preserves_existing_scheme(self):
         template = Template(
             "{% load peachjam %}"
@@ -110,7 +117,7 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
                             SimpleNamespace(
                                 title="Example document",
                                 expression_frbr_uri="/documents/example/",
-                                blurb="Short blurb",
+                                blurb="Short <b>blurb</b>",
                                 flynote="First line\nSecond line",
                             )
                         ],
@@ -127,11 +134,91 @@ class EmailTemplateUrlTestCase(SimpleTestCase):
         )
         html = message.alternatives[0][0] if message.alternatives else message.body
 
-        self.assertIn('<li style="margin-bottom: 1rem">', html)
-        self.assertIn(
-            '<div style="margin-top: 0.5rem; font-style: italic">',
-            html,
+        self.assert_alert_document_item_spacing(html)
+        self.assertIn("Short blurb", html)
+        self.assertNotIn("&lt;b&gt;blurb&lt;/b&gt;", html)
+        self.assertIn("First line<br>Second line", html)
+
+    def test_citation_alert_email_strips_blurb_markup(self):
+        context = self.base_context("example.org")
+        context.update(
+            {
+                "manage_url_path": "/en/my/following/",
+                "saved_documents": [
+                    {
+                        "saved_document": SimpleNamespace(
+                            title="Saved document",
+                            get_absolute_url="/documents/saved/",
+                        ),
+                        "citing_documents": [
+                            {
+                                "document": SimpleNamespace(
+                                    title="Citing document",
+                                    get_absolute_url="/documents/citing/",
+                                    blurb="Short <b>blurb</b>",
+                                    flynote="First line\nSecond line",
+                                ),
+                                "provision_citations": [],
+                            }
+                        ],
+                    }
+                ],
+            }
         )
+
+        message = get_templated_mail(
+            template_name="new_citation_alert",
+            from_email="test@example.org",
+            to=["user@example.org"],
+            context=context,
+        )
+        html = message.alternatives[0][0] if message.alternatives else message.body
+
+        self.assert_alert_document_item_spacing(html)
+        self.assertIn("Short blurb", html)
+        self.assertNotIn("<b>blurb</b>", html)
+        self.assertIn("First line<br>Second line", html)
+
+    def test_relationship_alert_email_strips_blurb_markup(self):
+        context = self.base_context("example.org")
+        context.update(
+            {
+                "manage_url_path": "/en/my/following/",
+                "saved_documents": [
+                    {
+                        "saved_document": SimpleNamespace(
+                            get_absolute_url="/documents/saved/",
+                            work=SimpleNamespace(title="Saved document"),
+                        ),
+                        "relationships": {
+                            "new_amendment": {
+                                "label": "New amendments published for",
+                                "documents": [
+                                    SimpleNamespace(
+                                        title="Related document",
+                                        get_absolute_url="/documents/related/",
+                                        blurb="Short <b>blurb</b>",
+                                        flynote="First line\nSecond line",
+                                    )
+                                ],
+                            }
+                        },
+                    }
+                ],
+            }
+        )
+
+        message = get_templated_mail(
+            template_name="new_relationship_alert",
+            from_email="test@example.org",
+            to=["user@example.org"],
+            context=context,
+        )
+        html = message.alternatives[0][0] if message.alternatives else message.body
+
+        self.assert_alert_document_item_spacing(html)
+        self.assertIn("Short blurb", html)
+        self.assertNotIn("<b>blurb</b>", html)
         self.assertIn("First line<br>Second line", html)
 
     def test_search_alert_email_does_not_duplicate_protocol(self):


### PR DESCRIPTION
update the email template so to make the flying notes italic and also create some spacing between the list. i didnt use exact padding coz i have seen the structure of styling email templates we are using the margin, so i have just followed it and still will achieve the same goal we want.