### PR TITLE
"All users" permission group that supports anonymous permissions

### DIFF
--- a/peachjam/apps.py
+++ b/peachjam/apps.py
@@ -15,11 +15,13 @@ class PeachJamConfig(AppConfig):
         import peachjam.adapters  # noqa
         import peachjam.checks  # noqa
         import peachjam.signals  # noqa
+        from peachjam.auth import get_or_create_all_users_permission_group
         from peachjam.helpers import get_country_absolute_url
 
         jazzmin.settings.THEMES["peachjam"] = "stylesheets/peachjam-jazzmin.css"
 
         Country.get_absolute_url = get_country_absolute_url
+        get_or_create_all_users_permission_group()
         # bump up the context for citation extraction
         CitationMatcher.text_prefix_length = CitationMatcher.text_suffix_length = 100
 

--- a/peachjam/auth.py
+++ b/peachjam/auth.py
@@ -9,8 +9,10 @@ from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.models import User
+from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth.models import Group, User
 from django.contrib.auth.views import redirect_to_login
+from django.db import IntegrityError, OperationalError, ProgrammingError
 from django.utils import translation
 from templated_email import send_templated_mail
 
@@ -53,6 +55,56 @@ def _patched_finish(self, redirect_url):
 
 LoginCodeVerificationProcess.send_by_email = _patched_send_by_email
 LoginCodeVerificationProcess.finish = _patched_finish
+
+
+def get_all_users_permission_group_name():
+    return settings.PEACHJAM.get("ALL_USERS_PERMISSION_GROUP", "All users")
+
+
+def get_or_create_all_users_permission_group():
+    group_name = get_all_users_permission_group_name()
+    if not group_name:
+        return None
+
+    try:
+        return Group.objects.get_or_create(name=group_name)[0]
+    except IntegrityError:
+        return Group.objects.get(name=group_name)
+    except (OperationalError, ProgrammingError):
+        logger.debug("Could not create all-users permission group", exc_info=True)
+        return None
+
+
+class AllUsersPermissionBackend(BaseBackend):
+    """Grant a configured baseline group of permissions to every user."""
+
+    def get_group_permissions(self, user_obj, obj=None):
+        if obj is not None:
+            return set()
+
+        if not hasattr(user_obj, "_all_users_perm_cache"):
+            group = get_or_create_all_users_permission_group()
+            if group:
+                perms = group.permissions.select_related("content_type")
+                user_obj._all_users_perm_cache = {
+                    f"{perm.content_type.app_label}.{perm.codename}" for perm in perms
+                }
+            else:
+                user_obj._all_users_perm_cache = set()
+
+        return user_obj._all_users_perm_cache
+
+    def get_all_permissions(self, user_obj, obj=None):
+        return self.get_group_permissions(user_obj, obj=obj)
+
+    def has_perm(self, user_obj, perm, obj=None):
+        return perm in self.get_all_permissions(user_obj, obj=obj)
+
+    def has_module_perms(self, user_obj, app_label):
+        return any(
+            permission.startswith(f"{app_label}.")
+            for permission in self.get_all_permissions(user_obj)
+        )
 
 
 def user_display(user):

--- a/peachjam/settings.py
+++ b/peachjam/settings.py
@@ -220,6 +220,7 @@ PEACHJAM = {
     # Email alerts
     "EMAIL_ALERTS_ENABLED": os.environ.get("EMAIL_ALERTS_ENABLED", "false") == "true",
     "AUTH_OTP": os.environ.get("AUTH_OTP", "false") == "true",
+    "ALL_USERS_PERMISSION_GROUP": "All users",
 }
 
 PEACHJAM["ES_INDEX"] = os.environ.get("ES_INDEX", slugify(PEACHJAM["APP_NAME"]))
@@ -237,6 +238,7 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL = (
 # Django all-auth
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
+    "peachjam.auth.AllUsersPermissionBackend",
     "allauth.account.auth_backends.AuthenticationBackend",
     "guardian.backends.ObjectPermissionBackend",
 ]

--- a/peachjam/tests/test_auth.py
+++ b/peachjam/tests/test_auth.py
@@ -4,11 +4,17 @@ from allauth.account.internal.flows.login_by_code import LoginCodeVerificationPr
 from allauth.account.models import Login
 from allauth.account.stages import LoginByCodeStage
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.auth.models import AnonymousUser, Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
-from peachjam.auth import _patched_finish, _patched_send_by_email
+from peachjam.auth import (
+    _patched_finish,
+    _patched_send_by_email,
+    get_or_create_all_users_permission_group,
+)
 
 
 class PatchedFinishTests(TestCase):
@@ -81,6 +87,71 @@ class PatchedFinishTests(TestCase):
 
         self.assertEqual(User.objects.filter(email="withuser@example.com").count(), 1)
         mock_finish.assert_called_once_with(proc, "/done")
+
+
+@override_settings(
+    AUTHENTICATION_BACKENDS=["peachjam.auth.AllUsersPermissionBackend"],
+    PEACHJAM={**settings.PEACHJAM, "ALL_USERS_PERMISSION_GROUP": "All users"},
+)
+class AllUsersPermissionBackendTests(TestCase):
+    fixtures = ["tests/languages"]
+
+    def setUp(self):
+        content_type = ContentType.objects.get_for_model(User)
+        self.permission = Permission.objects.create(
+            content_type=content_type,
+            codename="can_use_baseline_feature",
+            name="Can use baseline feature",
+        )
+        self.group = get_or_create_all_users_permission_group()
+        self.group.permissions.add(self.permission)
+
+    def test_group_is_created_if_missing(self):
+        Group.objects.filter(name="All users").delete()
+
+        group = get_or_create_all_users_permission_group()
+
+        self.assertIsNotNone(group)
+        self.assertEqual("All users", group.name)
+
+    def test_anonymous_user_gets_all_users_permissions(self):
+        user = AnonymousUser()
+
+        self.assertTrue(user.has_perm("auth.can_use_baseline_feature"))
+
+    def test_authenticated_user_gets_all_users_permissions(self):
+        user = User.objects.create_user(username="test-user")
+
+        self.assertTrue(user.has_perm("auth.can_use_baseline_feature"))
+
+    def test_inactive_user_gets_all_users_permissions(self):
+        user = User.objects.create_user(username="inactive-user", is_active=False)
+
+        self.assertTrue(user.has_perm("auth.can_use_baseline_feature"))
+
+    def test_permission_required_mixin_allows_anonymous_user(self):
+        class TestPermissionRequiredMixin(PermissionRequiredMixin):
+            permission_required = "auth.can_use_baseline_feature"
+
+        view = TestPermissionRequiredMixin()
+        view.request = RequestFactory().get("/")
+        view.request.user = AnonymousUser()
+
+        self.assertTrue(view.has_permission())
+
+    def test_all_users_permissions_are_not_object_permissions(self):
+        user = AnonymousUser()
+        obj = User(username="target")
+
+        self.assertFalse(user.has_perm("auth.can_use_baseline_feature", obj))
+
+    @override_settings(
+        PEACHJAM={**settings.PEACHJAM, "ALL_USERS_PERMISSION_GROUP": None}
+    )
+    def test_setting_can_disable_all_users_permissions(self):
+        user = AnonymousUser()
+
+        self.assertFalse(user.has_perm("auth.can_use_baseline_feature"))
 
 
 class PatchedSendByEmailTests(TestCase):


### PR DESCRIPTION
This allows us to assign permissions (especially feature permissions) to anonymous users, not just authenticated users.

This means we can enable features for anonymous users on some websites, but restrict them on others.