### PR TITLE
Avoid potential db lookup when serialiser CourtRegistry

### DIFF
--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -258,7 +258,7 @@ class CourtRegistry(models.Model):
         unique_together = ("court", "name")
 
     def __str__(self):
-        return f"{self.name} - {self.court}"
+        return self.name
 
     def get_absolute_url(self):
         return reverse("court_registry", args=[self.court.code, self.code])


### PR DESCRIPTION
Sentry shows that we sometimes spend time here when Sentry is serialising context.

I don't think this will change the world but it's worth doing