### PR TITLE
Separated the filter box to be stabel instead of reloading everytime

### DIFF
--- a/peachjam/templates/peachjam/flynote/manager/_merge_picker.html
+++ b/peachjam/templates/peachjam/flynote/manager/_merge_picker.html
@@ -1,67 +1,11 @@
-{% load humanize %}
 <div id="merge-picker">
-  <!-- keep the form out of the card so that the remove buttons don't trigger hx-confirm -->
-  <form id="merge-picker-form"
-        method="post"
-        action="{{ merge_url }}"
-        hx-post="{{ merge_url }}"
-        hx-target="closest section"
-        hx-swap="outerHTML"
-        hx-confirm="Are you sure? This cannot be undone.">
-    {% csrf_token %}
-  </form>
-  <input type="hidden" name="q" value="{{ query }}" form="merge-picker-form"/>
-  <div class="card mb-4">
-    <h3 class="card-header h5">Selected flynotes to merge into this one</h3>
-    {% if selected_flynotes %}
-      <ul class="list-group list-group-flush mb-0">
-        {% for flynote in selected_flynotes %}
-          <li class="list-group-item d-flex align-items-center">
-            <button type="button"
-                    class="btn btn-danger btn-sm me-3"
-                    hx-get="{{ picker_url }}"
-                    hx-target="#merge-picker"
-                    hx-swap="outerHTML"
-                    hx-include="#merge-search-form"
-                    hx-confirm
-                    hx-vals='{"remove":"{{ flynote.pk }}"}'>
-              Remove
-            </button>
-            <div class="flex-grow-1">
-              <input type="hidden"
-                     name="selected"
-                     value="{{ flynote.pk }}"
-                     form="merge-picker-form"/>
-              <a href="{{ manager_url }}?flynote={{ flynote.pk }}"
-                 target="_blank"
-                 rel="noopener">{{ flynote.name }}</a>
-              {% for flynote_id, names in child_names.items %}
-                {% if flynote_id == flynote.pk %}<small class="text-muted d-block">{{ names|join:", " }}</small>{% endif %}
-              {% endfor %}
-            </div>
-            <span class="badge bg-secondary">{{ flynote.document_total|intcomma }}</span>
-          </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <div class="card-body">No flynotes selected yet.</div>
-    {% endif %}
-    <div class="card-footer">
-      <button type="submit"
-              class="btn btn-primary"
-              form="merge-picker-form"
-              {% if not selected_flynotes %}disabled{% endif %}>
-        Merge these flynotes
-      </button>
-    </div>
-  </div>
   <form id="merge-search-form"
         method="get"
         hx-get="{{ picker_url }}"
-        hx-target="#merge-picker"
-        hx-swap="outerHTML"
+        hx-target="#merge-picker-content"
+        hx-swap="innerHTML"
+        hx-include="#merge-picker-state"
         hx-trigger="input changed delay:300ms from:#id_q, search from:#id_q">
-    {% for flynote in selected_flynotes %}<input type="hidden" name="selected" value="{{ flynote.pk }}"/>{% endfor %}
     <div class="mb-3">
       <label for="id_q" class="form-label">Find sibling flynotes to merge</label>
       <input id="id_q"
@@ -71,32 +15,5 @@
              class="form-control"/>
     </div>
   </form>
-  {% if search_results %}
-    <ul class="list-group list-group-flush">
-      {% for flynote in search_results %}
-        <li class="list-group-item d-flex align-items-center">
-          <button type="button"
-                  class="btn btn-primary btn-sm me-3"
-                  hx-get="{{ picker_url }}"
-                  hx-target="#merge-picker"
-                  hx-swap="outerHTML"
-                  hx-include="#merge-search-form"
-                  hx-vals='{"add":"{{ flynote.pk }}"}'>
-            Add
-          </button>
-          <div class="flex-grow-1">
-            <a href="{{ manager_url }}?flynote={{ flynote.pk }}"
-               target="_blank"
-               rel="noopener">{{ flynote.name }}</a>
-            {% for flynote_id, names in child_names.items %}
-              {% if flynote_id == flynote.pk %}<small class="text-muted d-block">{{ names|join:"; " }}</small>{% endif %}
-            {% endfor %}
-          </div>
-          <span class="badge bg-secondary">{{ flynote.document_total|intcomma }}</span>
-        </li>
-      {% endfor %}
-    </ul>
-  {% else %}
-    <p>No matching sibling flynotes found.</p>
-  {% endif %}
+  <div id="merge-picker-content">{% include "peachjam/flynote/manager/_merge_picker_content.html" %}</div>
 </div>

--- a/peachjam/templates/peachjam/flynote/manager/_merge_picker_content.html
+++ b/peachjam/templates/peachjam/flynote/manager/_merge_picker_content.html
@@ -1,0 +1,88 @@
+{% load humanize %}
+<!-- keep the form out of the card so that the remove buttons don't trigger hx-confirm -->
+<form id="merge-picker-form"
+      method="post"
+      action="{{ merge_url }}"
+      hx-post="{{ merge_url }}"
+      hx-target="closest section"
+      hx-swap="outerHTML"
+      hx-confirm="Are you sure? This cannot be undone.">
+  {% csrf_token %}
+</form>
+<input type="hidden" name="q" value="{{ query }}" form="merge-picker-form"/>
+<div id="merge-picker-state">
+  {% for flynote in selected_flynotes %}
+    <input type="hidden"
+           name="selected"
+           value="{{ flynote.pk }}"
+           form="merge-picker-form"/>
+  {% endfor %}
+</div>
+<div class="card mb-4">
+  <h3 class="card-header h5">Selected flynotes to merge into this one</h3>
+  {% if selected_flynotes %}
+    <ul class="list-group list-group-flush mb-0">
+      {% for flynote in selected_flynotes %}
+        <li class="list-group-item d-flex align-items-center">
+          <button type="button"
+                  class="btn btn-danger btn-sm me-3"
+                  hx-get="{{ picker_url }}"
+                  hx-target="#merge-picker-content"
+                  hx-swap="innerHTML focus-scroll:false"
+                  hx-include="#merge-search-form, #merge-picker-state"
+                  hx-confirm
+                  hx-vals='{"remove":"{{ flynote.pk }}"}'>
+            Remove
+          </button>
+          <div class="flex-grow-1">
+            <a href="{{ manager_url }}?flynote={{ flynote.pk }}"
+               target="_blank"
+               rel="noopener">{{ flynote.name }}</a>
+            {% for flynote_id, names in child_names.items %}
+              {% if flynote_id == flynote.pk %}<small class="text-muted d-block">{{ names|join:", " }}</small>{% endif %}
+            {% endfor %}
+          </div>
+          <span class="badge bg-secondary">{{ flynote.document_total|intcomma }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <div class="card-body">No flynotes selected yet.</div>
+  {% endif %}
+  <div class="card-footer">
+    <button type="submit"
+            class="btn btn-primary"
+            form="merge-picker-form"
+            {% if not selected_flynotes %}disabled{% endif %}>
+      Merge these flynotes
+    </button>
+  </div>
+</div>
+{% if search_results %}
+  <ul class="list-group list-group-flush">
+    {% for flynote in search_results %}
+      <li class="list-group-item d-flex align-items-center">
+        <button type="button"
+                class="btn btn-primary btn-sm me-3"
+                hx-get="{{ picker_url }}"
+                hx-target="#merge-picker-content"
+                hx-swap="innerHTML focus-scroll:false"
+                hx-include="#merge-search-form, #merge-picker-state"
+                hx-vals='{"add":"{{ flynote.pk }}"}'>
+          Add
+        </button>
+        <div class="flex-grow-1">
+          <a href="{{ manager_url }}?flynote={{ flynote.pk }}"
+             target="_blank"
+             rel="noopener">{{ flynote.name }}</a>
+          {% for flynote_id, names in child_names.items %}
+            {% if flynote_id == flynote.pk %}<small class="text-muted d-block">{{ names|join:"; " }}</small>{% endif %}
+          {% endfor %}
+        </div>
+        <span class="badge bg-secondary">{{ flynote.document_total|intcomma }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p>No matching sibling flynotes found.</p>
+{% endif %}

--- a/peachjam/tests/test_flynote_manager.py
+++ b/peachjam/tests/test_flynote_manager.py
@@ -538,9 +538,12 @@ class FlynoteManagerViewTest(TestCase):
         )
         self.assertContains(
             response,
-            f'<input type="hidden" name="selected" value="{self.sentencing.pk}"/>',
-            html=True,
+            'id="merge-picker-state"',
         )
+        self.assertContains(response, 'name="selected"')
+        self.assertContains(response, f'value="{self.sentencing.pk}"')
+        self.assertContains(response, 'hx-target="#merge-picker-content"')
+        self.assertContains(response, 'hx-include="#merge-picker-state"')
 
     def test_workspace_merge_picker_adds_and_removes_selected_flynotes(self):
         self.client.force_login(self.staff_user)
@@ -551,9 +554,13 @@ class FlynoteManagerViewTest(TestCase):
         self.assertEqual(add_response.status_code, 200)
         self.assertContains(
             add_response,
-            f'<input type="hidden" name="selected" value="{self.bail.pk}"/>',
-            html=True,
+            'hx-swap="innerHTML focus-scroll:false"',
         )
+        self.assertNotContains(add_response, 'id="merge-search-form"')
+        self.assertNotContains(add_response, 'id="id_q"')
+        self.assertContains(add_response, 'id="merge-picker-state"')
+        self.assertContains(add_response, 'name="selected"')
+        self.assertContains(add_response, f'value="{self.bail.pk}"')
         self.assertContains(add_response, "Remove")
 
         remove_response = self.client.get(

--- a/peachjam/views/flynotes.py
+++ b/peachjam/views/flynotes.py
@@ -496,7 +496,7 @@ class FlynoteManagerMergeView(FlynoteManagerDetailView):
 
 @method_decorator(staff_member_required, name="dispatch")
 class FlynoteManagerMergePickerView(FlynoteManagerMixin, TemplateView):
-    template_name = "peachjam/flynote/manager/_merge_picker.html"
+    template_name = "peachjam/flynote/manager/_merge_picker_content.html"
 
     def dispatch(self, request, *args, **kwargs):
         if not request.user.has_perm("peachjam.change_flynote"):


### PR DESCRIPTION
This code addresses an issue in the flynote merger whereby on filter it reloads the whole page even the filter all the time, so this separates it so that it reloads only the results/state

https://www.loom.com/share/84e4f596cd0a484daf3728be5c3f18a1


@longhotsummer  here is the vedio