### PR TITLE
Automated translation strings extraction

### DIFF
--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -1,0 +1,73 @@
+name: Extract translations PR
+
+on:
+  push:
+    branches:
+      - sandrava-3217
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  extract-translations:
+    runs-on: ubuntu-latest
+    name: Extract translations and open PR
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: gettext
+          version: extract-translations-apt-v1
+          execute_install_scripts: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade "setuptools<82" wheel
+          pip install .[dev]
+          npm ci --no-audit --prefer-offline --ignore-scripts
+
+      - name: Extract translatable strings
+        run: bash scripts/extract-translations.sh
+
+      - name: Check for updated PO files
+        id: po_changes
+        run: |
+          if git diff --name-only | grep -qE '.+/locale/.+/LC_MESSAGES/.+\.po$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.po_changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.LA_ACTIONS_TOKEN || github.token }}
+          commit-message: Extract new translation strings
+          branch: automated-extract-translations
+          branch-suffix: timestamp
+          base: main
+          title: Extract new translation strings
+          body: |
+            Automated extraction of translation strings from `main`.
+
+            This PR includes updated Django translation catalogs:
+            - `**/locale/*/LC_MESSAGES/*.po`
+          add-paths: |
+            **/locale/*/LC_MESSAGES/*.po

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -3,7 +3,7 @@ name: Extract translations PR
 on:
   push:
     branches:
-      - sandrava-3217
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -45,17 +45,17 @@ jobs:
       - name: Extract translatable strings
         run: bash scripts/extract-translations.sh
 
-      - name: Check for updated PO files
-        id: po_changes
+      - name: Check for updated translation files
+        id: translation_changes
         run: |
-          if git diff --name-only | grep -qE '.+/locale/.+/LC_MESSAGES/.+\.po$'; then
+          if git diff --name-only | grep -qE '.+/locale/.+/LC_MESSAGES/.+\.po$|.*/js/locale/.+/translation\.json$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create pull request
-        if: steps.po_changes.outputs.changed == 'true'
+        if: steps.translation_changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.LA_ACTIONS_TOKEN || github.token }}
@@ -67,7 +67,9 @@ jobs:
           body: |
             Automated extraction of translation strings from `main`.
 
-            This PR includes updated Django translation catalogs:
+            This PR includes updated translation catalogs:
             - `**/locale/*/LC_MESSAGES/*.po`
+            - `**/js/locale/*/translation.json`
           add-paths: |
             **/locale/*/LC_MESSAGES/*.po
+            **/js/locale/*/translation.json

--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -48,7 +48,8 @@ const vueTemplateExtractionPlugin = (): Plugin => ({
 
           keys.set(pluralKey, {
             key: `${key}${suffix}`,
-             ns: 'translation'
+            ns: 'translation',
+            defaultValue: key
           });
         }
       }

--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -26,11 +26,32 @@ const vueTemplateExtractionPlugin = (): Plugin => ({
   async onEnd (keys: ExtractedKeysMap) {
     const vueFiles = await findVueFiles('peachjam/js');
     const keyPattern = /(?:this\.)?(?:\bi18next\.t|\$t|\bt)\(\s*(['"`])(.*?)\1/g;
+    const countPattern = /(?:this\.)?(?:\bi18next\.t|\$t|\bt)\(\s*(['"`])(.*?)\1\s*,\s*\{[^}]*\bcount\s*:/g;
+    const countPluralSuffixes = ['_one', '_many', '_other'];
     const pluralSuffixes = ['_zero', '_one', '_two', '_few', '_many', '_other'];
 
     for (const file of vueFiles) {
       const content = await readFile(file, 'utf8');
       let match;
+
+      while ((match = countPattern.exec(content)) !== null) {
+        const key = match[2] || '';
+        if (!key.trim()) {
+          continue;
+        }
+
+        for (const suffix of countPluralSuffixes) {
+          const pluralKey = `translation:${key}${suffix}`;
+          if (keys.has(pluralKey)) {
+            continue;
+          }
+
+          keys.set(pluralKey, {
+            key: `${key}${suffix}`,
+             ns: 'translation'
+          });
+        }
+      }
 
       while ((match = keyPattern.exec(content)) !== null) {
         const key = match[2] || '';

--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -210,7 +210,7 @@
                 <div class="my-3 d-flex">
                   <div class="me-2">
                     <span v-if="searchInfo.count > 9999">{{ $t('More than 10,000 documents found.') }}</span>
-                    <span v-else>{{ $t('{count} documents found', { count: searchInfo.count }) }}</span>
+                    <span v-else>{{ $t('{count} document found', { count: searchInfo.count }) }}</span>
                       &nbsp;
                     <a
                       href="#"

--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -210,7 +210,7 @@
                 <div class="my-3 d-flex">
                   <div class="me-2">
                     <span v-if="searchInfo.count > 9999">{{ $t('More than 10,000 documents found.') }}</span>
-                    <span v-else>{{ $t('{document_count} documents found', { document_count: searchInfo.count }) }}</span>
+                    <span v-else>{{ $t('{count} documents found', { count: searchInfo.count }) }}</span>
                       &nbsp;
                     <a
                       href="#"

--- a/peachjam/js/components/ProvisionCitations/ProvisionCitationCount.vue
+++ b/peachjam/js/components/ProvisionCitations/ProvisionCitationCount.vue
@@ -5,7 +5,7 @@
       <span class="badge rounded-pill bg-secondary">{{ citations }}</span>
       <span class="gutter-item-link ms-2 border p-2 rounded bg-white d-inline-flex justify-content-around">
         <a :href="`${expressionFrbrUri}/provision/${provision_eid}`">
-          {{ $t('Cited {count} times', {count: citations}) }}
+          {{ $t('Cited {count} time', {count: citations}) }}
         </a>
        <button
           type="button"


### PR DESCRIPTION
Closes #3217 
- Since our custom extracts our translatable strings as keys by default, I set the countable strings to be singular. The i18next will handle the plurals (see video).
- Stuck with _one i18next syntax for plurals.
- Added and tested the GitHub workflow for our extraction script.

https://www.loom.com/share/4d861dc51c034b52a0beca9444d98119