### PR TITLE
fix the display isssue of flynotes to display in a multiline and in chain

### DIFF
--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -91,12 +91,19 @@ class FlynoteDisplayGrouper:
                 node_key = key_func(component)
                 node = index.get(node_key)
                 if node is None:
-                    node = {"value": component, "children": [], "_index": {}}
+                    node = {
+                        "value": component,
+                        "children": [],
+                        "_index": {},
+                        "is_terminal": False,
+                    }
                     items.append(node)
                     index[node_key] = node
 
                 items = node["children"]
                 index = node["_index"]
+            if path:
+                node["is_terminal"] = True
 
         return roots
 
@@ -108,7 +115,7 @@ class FlynoteDisplayGrouper:
             chain = [node["value"]]
             last = node
 
-            while len(last["children"]) == 1:
+            while len(last["children"]) == 1 and not last["is_terminal"]:
                 last = last["children"][0]
                 chain.append(last["value"])
 

--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -68,68 +68,60 @@ class FlynoteDisplayGrouper:
             if component.strip()
         )
 
-    @staticmethod
-    def common_path_prefix(paths):
-        if not paths:
-            return ()
-
-        prefix = []
-        for components in zip(*paths):
-            if len(set(components)) != 1:
-                break
-            prefix.append(components[0])
-
-        return tuple(prefix)
-
-    @staticmethod
-    def group_paths_by_head(paths):
-        groups = []
-        for path in paths:
-            head = path[0]
-            if not groups or groups[-1][0] != head:
-                groups.append((head, [path]))
-            else:
-                groups[-1][1].append(path)
-        return [group for _, group in groups]
-
     @classmethod
-    def build_groups(cls, paths, inherited_prefix=()):
+    def build_groups(cls, paths):
         if not paths:
             return []
 
-        if len(paths) == 1:
-            return [{"text": " — ".join(inherited_prefix + paths[0]), "children": []}]
+        return cls.compress_tree(cls.build_tree(paths), "text")
 
-        prefix = cls.common_path_prefix(paths)
-        if not prefix:
-            grouped_paths = []
-            for group in cls.group_paths_by_head(paths):
-                grouped_paths.extend(cls.build_groups(group, inherited_prefix))
-            return grouped_paths
+    @staticmethod
+    def build_tree(paths, key_func=None):
+        roots = []
+        root_index = {}
+        if key_func is None:
 
-        combined_prefix = inherited_prefix + prefix
-        remainders = [path[len(prefix) :] for path in paths]
-        descendant_paths = [remainder for remainder in remainders if remainder]
+            def key_func(value):
+                return value
 
-        if not descendant_paths:
-            return [{"text": " — ".join(combined_prefix), "children": []}]
+        for path in paths:
+            items = roots
+            index = root_index
+            for component in path:
+                node_key = key_func(component)
+                node = index.get(node_key)
+                if node is None:
+                    node = {"value": component, "children": [], "_index": {}}
+                    items.append(node)
+                    index[node_key] = node
 
-        child_groups = cls.group_paths_by_head(descendant_paths)
-        if len(descendant_paths) != len(paths) or all(
-            len(group) == 1 for group in child_groups
-        ):
-            return [
-                {
-                    "text": " — ".join(combined_prefix),
-                    "children": cls.build_groups(descendant_paths),
-                }
-            ]
+                items = node["children"]
+                index = node["_index"]
 
-        grouped_paths = []
-        for group in child_groups:
-            grouped_paths.extend(cls.build_groups(group, combined_prefix))
+        return roots
 
-        return grouped_paths
+    @classmethod
+    def compress_tree(cls, nodes, value_key):
+        groups = []
+
+        for node in nodes:
+            chain = [node["value"]]
+            last = node
+
+            while len(last["children"]) == 1:
+                last = last["children"][0]
+                chain.append(last["value"])
+
+            children = cls.compress_tree(last["children"], value_key)
+            group = {
+                value_key: " — ".join(chain) if value_key == "text" else chain,
+                "children": children,
+            }
+            if value_key == "text" and children and len(chain) > 1:
+                group["parts"] = chain
+            groups.append(group)
+
+        return groups
 
     @classmethod
     def group_linked_flynotes(cls, linked_flynotes):
@@ -141,8 +133,7 @@ class FlynoteDisplayGrouper:
         grouped plain-flynote display.
         """
 
-        roots = []
-        root_index = {}
+        paths = []
         seen_paths = set()
 
         for item in linked_flynotes or []:
@@ -157,27 +148,17 @@ class FlynoteDisplayGrouper:
             if path_key in seen_paths:
                 continue
             seen_paths.add(path_key)
+            paths.append(nodes)
 
-            items = roots
-            index = root_index
-            for node in nodes:
-                node_key = getattr(node, "pk", None) or getattr(node, "name", None)
-                group = index.get(node_key)
-                if group is None:
-                    group = {"node": node, "children": [], "_index": {}}
-                    items.append(group)
-                    index[node_key] = group
-
-                items = group["children"]
-                index = group["_index"]
-
-        def cleanup(groups):
-            return [
-                {"node": group["node"], "children": cleanup(group["children"])}
-                for group in groups
-            ]
-
-        return cleanup(roots)
+        return cls.compress_tree(
+            cls.build_tree(
+                paths,
+                lambda node: getattr(node, "pk", None)
+                or getattr(node, "name", None)
+                or id(node),
+            ),
+            "nodes",
+        )
 
 
 class FlynoteParser:

--- a/peachjam/analysis/flynotes.py
+++ b/peachjam/analysis/flynotes.py
@@ -126,9 +126,18 @@ class FlynoteDisplayGrouper:
             }
             if value_key == "text" and children and len(chain) > 1:
                 group["parts"] = chain
+                group["child_indent"] = cls.chain_prefix_length(chain)
+            if value_key == "nodes" and children and len(chain) > 1:
+                group["child_indent"] = cls.chain_prefix_length(chain)
             groups.append(group)
 
         return groups
+
+    @staticmethod
+    def chain_prefix_length(chain):
+        return sum(len(getattr(item, "name", item)) for item in chain[:-1]) + (
+            max(len(chain) - 1, 0) * 3
+        )
 
     @classmethod
     def group_linked_flynotes(cls, linked_flynotes):

--- a/peachjam/static/stylesheets/components/_text.scss
+++ b/peachjam/static/stylesheets/components/_text.scss
@@ -13,10 +13,20 @@ ul.flynotes > li {
   padding: 0 0.25rem;
 }
 
-.flynote-chain-tail {
-  display: inline-block;
+.flynote-chain {
+  display: inline-grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  max-width: 100%;
   text-indent: 0;
   vertical-align: top;
+}
+
+.flynote-chain-tail {
+  text-indent: 0;
+}
+
+.flynote-chain-tail > ul.flynotes > li {
+  overflow-wrap: anywhere;
 }
 
 .fs-sm {

--- a/peachjam/static/stylesheets/components/_text.scss
+++ b/peachjam/static/stylesheets/components/_text.scss
@@ -9,6 +9,21 @@ ul.flynotes > li {
   margin-bottom: 0;
 }
 
+.flynote-chain {
+  display: inline-grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  text-indent: 0;
+  vertical-align: top;
+}
+
+.flynote-chain-separator {
+  padding: 0 0.25rem;
+}
+
+.flynote-chain-children {
+  grid-column: 2;
+}
+
 .fs-sm {
   font-size: small;
 }

--- a/peachjam/static/stylesheets/components/_text.scss
+++ b/peachjam/static/stylesheets/components/_text.scss
@@ -10,22 +10,29 @@ ul.flynotes > li {
 }
 
 .flynote-chain-separator {
-  padding: 0 0.25rem;
+  white-space: nowrap;
 }
 
 .flynote-chain {
-  display: inline-grid;
-  grid-template-columns: max-content minmax(0, 1fr);
   max-width: 100%;
+  overflow-wrap: normal;
   text-indent: 0;
-  vertical-align: top;
 }
 
+.flynote-chain-prefix,
 .flynote-chain-tail {
   text-indent: 0;
 }
 
-.flynote-chain-tail > ul.flynotes > li {
+.flynote-chain-tail {
+  overflow-wrap: anywhere;
+}
+
+.flynote-chain-children {
+  margin-left: min(var(--flynote-child-indent), 40ch);
+}
+
+.flynote-chain-children ul.flynotes > li {
   overflow-wrap: anywhere;
 }
 

--- a/peachjam/static/stylesheets/components/_text.scss
+++ b/peachjam/static/stylesheets/components/_text.scss
@@ -9,19 +9,14 @@ ul.flynotes > li {
   margin-bottom: 0;
 }
 
-.flynote-chain {
-  display: inline-grid;
-  grid-template-columns: max-content minmax(0, 1fr);
-  text-indent: 0;
-  vertical-align: top;
-}
-
 .flynote-chain-separator {
   padding: 0 0.25rem;
 }
 
-.flynote-chain-children {
-  grid-column: 2;
+.flynote-chain-tail {
+  display: inline-block;
+  text-indent: 0;
+  vertical-align: top;
 }
 
 .fs-sm {

--- a/peachjam/templates/peachjam/document/_linked_flynotes.html
+++ b/peachjam/templates/peachjam/document/_linked_flynotes.html
@@ -3,10 +3,11 @@
   <ul class="{% if nested %}list-unstyled flynotes{% else %}list-unstyled flynotes my-2{% endif %}">
     {% for item in linked_flynote_groups %}
       <li>
-        {% if nested %}—{% endif %}
         {% if item.children and item.nodes|length > 1 %}
-          <div class="flynote-chain">
-            <div class="flynote-chain-prefix">
+          <div class="flynote-chain"
+               style="--flynote-child-indent: {{ item.child_indent }}ch">
+            <span class="flynote-chain-prefix">
+              {% if nested %}—{% endif %}
               {% for node in item.nodes %}
                 {% if not forloop.last %}
                   {% if link_flynote_topics %}
@@ -14,11 +15,11 @@
                   {% else %}
                     {{ node.name }}
                   {% endif %}
-                  <span class="flynote-chain-separator">—</span>
+                  <span class="flynote-chain-separator">&nbsp;—&nbsp;</span>
                 {% endif %}
               {% endfor %}
-            </div>
-            <div class="flynote-chain-tail">
+            </span>
+            <span class="flynote-chain-tail">
               {% for node in item.nodes %}
                 {% if forloop.last %}
                   {% if link_flynote_topics %}
@@ -28,10 +29,13 @@
                   {% endif %}
                 {% endif %}
               {% endfor %}
+            </span>
+            <div class="flynote-chain-children">
               {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
             </div>
           </div>
         {% else %}
+          {% if nested %}—{% endif %}
           {% for node in item.nodes %}
             {% if not forloop.first %}—{% endif %}
             {% if link_flynote_topics %}

--- a/peachjam/templates/peachjam/document/_linked_flynotes.html
+++ b/peachjam/templates/peachjam/document/_linked_flynotes.html
@@ -4,13 +4,47 @@
     {% for item in linked_flynote_groups %}
       <li>
         {% if nested %}—{% endif %}
-        {% if link_flynote_topics %}
-          <a href="{{ item.node.get_absolute_url }}">{{ item.node.name }}</a>
+        {% if item.children and item.nodes|length > 1 %}
+          <div class="flynote-chain">
+            <div class="flynote-chain-prefix">
+              {% for node in item.nodes %}
+                {% if not forloop.last %}
+                  {% if link_flynote_topics %}
+                    <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+                  {% else %}
+                    {{ node.name }}
+                  {% endif %}
+                  <span class="flynote-chain-separator">—</span>
+                {% endif %}
+              {% endfor %}
+            </div>
+            <div class="flynote-chain-tail">
+              {% for node in item.nodes %}
+                {% if forloop.last %}
+                  {% if link_flynote_topics %}
+                    <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+                  {% else %}
+                    {{ node.name }}
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            </div>
+            <div class="flynote-chain-children">
+              {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
+            </div>
+          </div>
         {% else %}
-          {{ item.node.name }}
-        {% endif %}
-        {% if item.children %}
-          {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
+          {% for node in item.nodes %}
+            {% if not forloop.first %}—{% endif %}
+            {% if link_flynote_topics %}
+              <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+            {% else %}
+              {{ node.name }}
+            {% endif %}
+          {% endfor %}
+          {% if item.children %}
+            {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
+          {% endif %}
         {% endif %}
       </li>
     {% endfor %}

--- a/peachjam/templates/peachjam/document/_linked_flynotes.html
+++ b/peachjam/templates/peachjam/document/_linked_flynotes.html
@@ -5,33 +5,29 @@
       <li>
         {% if nested %}—{% endif %}
         {% if item.children and item.nodes|length > 1 %}
-          <div class="flynote-chain">
-            <div class="flynote-chain-prefix">
-              {% for node in item.nodes %}
-                {% if not forloop.last %}
-                  {% if link_flynote_topics %}
-                    <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
-                  {% else %}
-                    {{ node.name }}
-                  {% endif %}
-                  <span class="flynote-chain-separator">—</span>
+          <span class="flynote-chain-prefix">
+            {% for node in item.nodes %}
+              {% if not forloop.last %}
+                {% if link_flynote_topics %}
+                  <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+                {% else %}
+                  {{ node.name }}
                 {% endif %}
-              {% endfor %}
-            </div>
-            <div class="flynote-chain-tail">
-              {% for node in item.nodes %}
-                {% if forloop.last %}
-                  {% if link_flynote_topics %}
-                    <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
-                  {% else %}
-                    {{ node.name }}
-                  {% endif %}
+                <span class="flynote-chain-separator">—</span>
+              {% endif %}
+            {% endfor %}
+          </span>
+          <div class="flynote-chain-tail">
+            {% for node in item.nodes %}
+              {% if forloop.last %}
+                {% if link_flynote_topics %}
+                  <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+                {% else %}
+                  {{ node.name }}
                 {% endif %}
-              {% endfor %}
-            </div>
-            <div class="flynote-chain-children">
-              {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
-            </div>
+              {% endif %}
+            {% endfor %}
+            {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
           </div>
         {% else %}
           {% for node in item.nodes %}

--- a/peachjam/templates/peachjam/document/_linked_flynotes.html
+++ b/peachjam/templates/peachjam/document/_linked_flynotes.html
@@ -5,29 +5,31 @@
       <li>
         {% if nested %}—{% endif %}
         {% if item.children and item.nodes|length > 1 %}
-          <span class="flynote-chain-prefix">
-            {% for node in item.nodes %}
-              {% if not forloop.last %}
-                {% if link_flynote_topics %}
-                  <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
-                {% else %}
-                  {{ node.name }}
+          <div class="flynote-chain">
+            <div class="flynote-chain-prefix">
+              {% for node in item.nodes %}
+                {% if not forloop.last %}
+                  {% if link_flynote_topics %}
+                    <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+                  {% else %}
+                    {{ node.name }}
+                  {% endif %}
+                  <span class="flynote-chain-separator">—</span>
                 {% endif %}
-                <span class="flynote-chain-separator">—</span>
-              {% endif %}
-            {% endfor %}
-          </span>
-          <div class="flynote-chain-tail">
-            {% for node in item.nodes %}
-              {% if forloop.last %}
-                {% if link_flynote_topics %}
-                  <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
-                {% else %}
-                  {{ node.name }}
+              {% endfor %}
+            </div>
+            <div class="flynote-chain-tail">
+              {% for node in item.nodes %}
+                {% if forloop.last %}
+                  {% if link_flynote_topics %}
+                    <a href="{{ node.get_absolute_url }}">{{ node.name }}</a>
+                  {% else %}
+                    {{ node.name }}
+                  {% endif %}
                 {% endif %}
-              {% endif %}
-            {% endfor %}
-            {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
+              {% endfor %}
+              {% include "peachjam/document/_linked_flynotes.html" with linked_flynote_groups=item.children nested=True link_flynote_topics=link_flynote_topics %}
+            </div>
           </div>
         {% else %}
           {% for node in item.nodes %}

--- a/peachjam/templates/peachjam/judgment/_flynote_groups.html
+++ b/peachjam/templates/peachjam/judgment/_flynote_groups.html
@@ -3,16 +3,18 @@
     <li>
       {% if nested %}—{% endif %}
       {% if item.children and item.parts|length > 1 %}
-        <span class="flynote-chain-prefix">
-          {% for part in item.parts %}
-            {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">—</span>{% endif %}
-          {% endfor %}
-        </span>
-        <div class="flynote-chain-tail">
-          {% for part in item.parts %}
-            {% if forloop.last %}{{ part }}{% endif %}
-          {% endfor %}
-          {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
+        <div class="flynote-chain">
+          <div class="flynote-chain-prefix">
+            {% for part in item.parts %}
+              {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">—</span>{% endif %}
+            {% endfor %}
+          </div>
+          <div class="flynote-chain-tail">
+            {% for part in item.parts %}
+              {% if forloop.last %}{{ part }}{% endif %}
+            {% endfor %}
+            {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
+          </div>
         </div>
       {% else %}
         {{ item.text }}

--- a/peachjam/templates/peachjam/judgment/_flynote_groups.html
+++ b/peachjam/templates/peachjam/judgment/_flynote_groups.html
@@ -3,20 +3,16 @@
     <li>
       {% if nested %}—{% endif %}
       {% if item.children and item.parts|length > 1 %}
-        <div class="flynote-chain">
-          <div class="flynote-chain-prefix">
-            {% for part in item.parts %}
-              {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">—</span>{% endif %}
-            {% endfor %}
-          </div>
-          <div class="flynote-chain-tail">
-            {% for part in item.parts %}
-              {% if forloop.last %}{{ part }}{% endif %}
-            {% endfor %}
-          </div>
-          <div class="flynote-chain-children">
-            {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
-          </div>
+        <span class="flynote-chain-prefix">
+          {% for part in item.parts %}
+            {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">—</span>{% endif %}
+          {% endfor %}
+        </span>
+        <div class="flynote-chain-tail">
+          {% for part in item.parts %}
+            {% if forloop.last %}{{ part }}{% endif %}
+          {% endfor %}
+          {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
         </div>
       {% else %}
         {{ item.text }}

--- a/peachjam/templates/peachjam/judgment/_flynote_groups.html
+++ b/peachjam/templates/peachjam/judgment/_flynote_groups.html
@@ -1,22 +1,26 @@
 <ul class="{% if nested %}list-unstyled flynotes{% else %}list-unstyled flynotes my-2{% endif %}">
   {% for item in flynote_groups %}
     <li>
-      {% if nested %}—{% endif %}
       {% if item.children and item.parts|length > 1 %}
-        <div class="flynote-chain">
-          <div class="flynote-chain-prefix">
+        <div class="flynote-chain"
+             style="--flynote-child-indent: {{ item.child_indent }}ch">
+          <span class="flynote-chain-prefix">
+            {% if nested %}—{% endif %}
             {% for part in item.parts %}
-              {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">—</span>{% endif %}
+              {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">&nbsp;—&nbsp;</span>{% endif %}
             {% endfor %}
-          </div>
-          <div class="flynote-chain-tail">
+          </span>
+          <span class="flynote-chain-tail">
             {% for part in item.parts %}
               {% if forloop.last %}{{ part }}{% endif %}
             {% endfor %}
+          </span>
+          <div class="flynote-chain-children">
             {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
           </div>
         </div>
       {% else %}
+        {% if nested %}—{% endif %}
         {{ item.text }}
         {% if item.children %}
           {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}

--- a/peachjam/templates/peachjam/judgment/_flynote_groups.html
+++ b/peachjam/templates/peachjam/judgment/_flynote_groups.html
@@ -1,13 +1,28 @@
 <ul class="{% if nested %}list-unstyled flynotes{% else %}list-unstyled flynotes my-2{% endif %}">
   {% for item in flynote_groups %}
     <li>
-      {% if nested %}
-        — {{ item.text }}
+      {% if nested %}—{% endif %}
+      {% if item.children and item.parts|length > 1 %}
+        <div class="flynote-chain">
+          <div class="flynote-chain-prefix">
+            {% for part in item.parts %}
+              {% if not forloop.last %}{{ part }}<span class="flynote-chain-separator">—</span>{% endif %}
+            {% endfor %}
+          </div>
+          <div class="flynote-chain-tail">
+            {% for part in item.parts %}
+              {% if forloop.last %}{{ part }}{% endif %}
+            {% endfor %}
+          </div>
+          <div class="flynote-chain-children">
+            {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
+          </div>
+        </div>
       {% else %}
         {{ item.text }}
-      {% endif %}
-      {% if item.children %}
-        {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
+        {% if item.children %}
+          {% include "peachjam/judgment/_flynote_groups.html" with flynote_groups=item.children nested=True %}
+        {% endif %}
       {% endif %}
     </li>
   {% endfor %}

--- a/peachjam/tests/test_flynotes.py
+++ b/peachjam/tests/test_flynotes.py
@@ -2573,8 +2573,10 @@ class JudgmentDetailFlynoteNavigationTest(TestCase):
         )
 
         self.assertIn('<ul class="list-unstyled flynotes my-2">', html)
-        self.assertIn('<ul class="list-unstyled flynotes">', html)
-        self.assertEqual(html.count("<li>"), 2)
+        self.assertNotIn('<ul class="list-unstyled flynotes">', html)
+        self.assertEqual(html.count("<li>"), 1)
+        self.assertIn("Administrative law", html)
+        self.assertIn("judicial review", html)
 
     def test_linked_flynotes_use_judgment_flynotes_in_path_order(self):
         judgment = Judgment.objects.create(

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -636,6 +636,7 @@ class JudgmentTestCase(TestCase):
                 {
                     "text": "Customs law — internal appeal jurisdiction",
                     "parts": ["Customs law", "internal appeal jurisdiction"],
+                    "child_indent": 14,
                     "children": [
                         {
                             "text": "administrative-law duty to consider discretionary relief",

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -81,34 +81,46 @@ class JudgmentTestCase(TestCase):
         self.assertGroupedFlynotesEqual(
             [
                 {
-                    "text": (
-                        "Customs law — Customs and excise act — Diesel refund scheme — "
-                        "Interpretation of Note 6(f)(ii)(cc)"
-                    ),
+                    "text": "Customs law",
                     "children": [
                         {
-                            "text": "joint venture as substantive authorised user",
-                            "children": [],
+                            "text": (
+                                "Customs and excise act — Diesel refund scheme — "
+                                "Interpretation of Note 6(f)(ii)(cc)"
+                            ),
+                            "parts": [
+                                "Customs and excise act",
+                                "Diesel refund scheme",
+                                "Interpretation of Note 6(f)(ii)(cc)",
+                            ],
+                            "children": [
+                                {
+                                    "text": "joint venture as substantive authorised user",
+                                    "children": [],
+                                },
+                                {
+                                    "text": (
+                                        "Note 5 discretion to pay refunds to third parties on good cause shown"
+                                    ),
+                                    "children": [],
+                                },
+                            ],
                         },
                         {
-                            "text": "Note 5 discretion to pay refunds to third parties on good cause shown",
-                            "children": [],
+                            "text": "internal appeal jurisdiction",
+                            "children": [
+                                {
+                                    "text": "administrative-law duty to consider discretionary relief",
+                                    "children": [],
+                                },
+                                {
+                                    "text": "NAC cannot introduce new grounds or increase original quantum",
+                                    "children": [],
+                                },
+                            ],
                         },
                     ],
-                },
-                {
-                    "text": "Customs law — internal appeal jurisdiction",
-                    "children": [
-                        {
-                            "text": "administrative-law duty to consider discretionary relief",
-                            "children": [],
-                        },
-                        {
-                            "text": "NAC cannot introduce new grounds or increase original quantum",
-                            "children": [],
-                        },
-                    ],
-                },
+                }
             ],
             judgment,
         )
@@ -194,6 +206,12 @@ class JudgmentTestCase(TestCase):
                         "Administrative Law — Judicial Review — Legality Review — "
                         "Unlawful Appointment"
                     ),
+                    "parts": [
+                        "Administrative Law",
+                        "Judicial Review",
+                        "Legality Review",
+                        "Unlawful Appointment",
+                    ],
                     "children": [
                         {
                             "text": "Jurisdiction, Delay, Legality of Municipal Appointments",
@@ -205,6 +223,49 @@ class JudgmentTestCase(TestCase):
                         },
                     ],
                 }
+            ],
+            judgment,
+        )
+
+    def test_grouped_flynote_lines_compresses_single_child_paths_recursively(self):
+        judgment = Judgment(
+            flynote=(
+                "Criminal law — concurrency of sentences — condonation of late appeal\n"
+                "Criminal law — concurrency of sentences — link between offences\n"
+                "Criminal law — sentencing — Prescribed minimum sentences — "
+                "substantial and compelling circumstances — appellate interference only where sentencing "
+                "discretion misdirected, disproportionate or vitiated"
+            )
+        )
+
+        self.assertGroupedFlynotesEqual(
+            [
+                {
+                    "text": "Criminal law",
+                    "children": [
+                        {
+                            "text": "concurrency of sentences",
+                            "children": [
+                                {
+                                    "text": "condonation of late appeal",
+                                    "children": [],
+                                },
+                                {
+                                    "text": "link between offences",
+                                    "children": [],
+                                },
+                            ],
+                        },
+                        {
+                            "text": (
+                                "sentencing — Prescribed minimum sentences — "
+                                "substantial and compelling circumstances — appellate interference only where "
+                                "sentencing discretion misdirected, disproportionate or vitiated"
+                            ),
+                            "children": [],
+                        },
+                    ],
+                },
             ],
             judgment,
         )
@@ -261,7 +322,7 @@ class JudgmentTestCase(TestCase):
         def simplify(groups):
             return [
                 {
-                    "node": item["node"].name,
+                    "nodes": [node.name for node in item["nodes"]],
                     "children": simplify(item["children"]),
                 }
                 for item in groups
@@ -270,46 +331,40 @@ class JudgmentTestCase(TestCase):
         self.assertEqual(
             [
                 {
-                    "node": "Family law",
+                    "nodes": ["Family law"],
                     "children": [
                         {
-                            "node": "Matrimonial property act",
+                            "nodes": ["Matrimonial property act"],
                             "children": [
                                 {
-                                    "node": "Doctrine of notice inapplicable to contingent accrual claims",
+                                    "nodes": [
+                                        "Doctrine of notice inapplicable to contingent accrual claims"
+                                    ],
                                     "children": [],
                                 },
                                 {
-                                    "node": (
+                                    "nodes": [
                                         "accrual claim contingent until dissolution, not a proprietary "
                                         "right of occupation"
-                                    ),
+                                    ],
                                     "children": [],
                                 },
                             ],
                         },
                         {
-                            "node": "PIE Act",
-                            "children": [
-                                {
-                                    "node": (
-                                        "eviction may be just and equitable where spouse has no vested right"
-                                    ),
-                                    "children": [],
-                                }
+                            "nodes": [
+                                "PIE Act",
+                                "eviction may be just and equitable where spouse has no vested right",
                             ],
+                            "children": [],
                         },
                         {
-                            "node": "Procedure",
-                            "children": [
-                                {
-                                    "node": (
-                                        "proper form of order when jurisdictional threshold not met "
-                                        "(confirmation vs striking off roll)."
-                                    ),
-                                    "children": [],
-                                }
+                            "nodes": [
+                                "Procedure",
+                                "proper form of order when jurisdictional threshold not met "
+                                "(confirmation vs striking off roll).",
                             ],
+                            "children": [],
                         },
                     ],
                 },
@@ -369,7 +424,8 @@ class JudgmentTestCase(TestCase):
             normalized_html,
         )
         self.assertIn(
-            '— <a href="/judgments/topics/matrimonial-property-act/">Matrimonial property act</a>',
+            '<div class="flynote-chain-tail"> '
+            '<a href="/judgments/topics/matrimonial-property-act/">Matrimonial property act</a>',
             normalized_html,
         )
         self.assertIn(
@@ -384,7 +440,7 @@ class JudgmentTestCase(TestCase):
             "accrual claim contingent until dissolution, not a proprietary right of occupation</a>",
             normalized_html,
         )
-        self.assertGreaterEqual(html.count("<ul"), 3)
+        self.assertEqual(2, html.count("<ul"))
 
     def test_document_table_row_renders_grouped_flynotes_without_topic_links(self):
         class EmptyRelatedManager:
@@ -455,7 +511,50 @@ class JudgmentTestCase(TestCase):
         self.assertNotIn("/judgments/topics/", html)
         self.assertIn("— Matrimonial property act", normalized_html)
         self.assertIn("— PIE Act", normalized_html)
-        self.assertGreaterEqual(html.count("<ul"), 3)
+        self.assertEqual(2, html.count("<ul"))
+
+    def test_grouped_linked_flynotes_indents_children_under_compressed_topic(self):
+        def node(name):
+            slug = name.lower().replace(" ", "-")
+            node_obj = SimpleNamespace(name=name)
+            node_obj.get_absolute_url = lambda: f"/judgments/topics/{slug}/"
+            return node_obj
+
+        document = SimpleNamespace(
+            blurb="Respondents liable.",
+            flynote="",
+            flynote_lines=[],
+            linked_flynotes=[
+                {
+                    "nodes": [
+                        node("Tort"),
+                        node("Delict"),
+                        node("assessment of credibility and probabilities"),
+                    ]
+                },
+                {
+                    "nodes": [
+                        node("Tort"),
+                        node("Delict"),
+                        node("causation (but-for and legal causation)"),
+                    ]
+                },
+            ],
+        )
+
+        html = render_to_string(
+            "peachjam/judgment/_blurb_and_flynotes.html",
+            {"document": document},
+        )
+        normalized_html = " ".join(html.split())
+
+        self.assertIn(
+            '<div class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">—</span>',
+            normalized_html,
+        )
+        self.assertIn('<div class="flynote-chain-tail"> Delict </div>', normalized_html)
+        self.assertIn("— assessment of credibility and probabilities", normalized_html)
+        self.assertIn("— causation (but-for and legal causation)", normalized_html)
 
     def test_grouped_flynote_lines_groups_ancestor_with_descendants(self):
         judgment = Judgment(
@@ -472,6 +571,7 @@ class JudgmentTestCase(TestCase):
             [
                 {
                     "text": "Customs law — internal appeal jurisdiction",
+                    "parts": ["Customs law", "internal appeal jurisdiction"],
                     "children": [
                         {
                             "text": "administrative-law duty to consider discretionary relief",

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -270,6 +270,26 @@ class JudgmentTestCase(TestCase):
             judgment,
         )
 
+    def test_grouped_flynote_lines_keeps_explicit_ancestor_topic(self):
+        judgment = Judgment(
+            flynote=("Administrative law\n" "Administrative law — PAJA")
+        )
+
+        self.assertGroupedFlynotesEqual(
+            [
+                {
+                    "text": "Administrative law",
+                    "children": [
+                        {
+                            "text": "PAJA",
+                            "children": [],
+                        },
+                    ],
+                },
+            ],
+            judgment,
+        )
+
     def test_group_linked_flynotes_groups_single_line_semicolon_branches(self):
         def node(name):
             node_obj = SimpleNamespace(name=name)
@@ -366,6 +386,44 @@ class JudgmentTestCase(TestCase):
                             ],
                             "children": [],
                         },
+                    ],
+                },
+            ],
+            simplify(grouped),
+        )
+
+    def test_group_linked_flynotes_keeps_explicit_ancestor_topic(self):
+        def node(name):
+            node_obj = SimpleNamespace(name=name)
+            slug = name.lower().replace(" ", "-")
+            node_obj.get_absolute_url = lambda: f"/judgments/topics/{slug}/"
+            return node_obj
+
+        grouped = group_linked_flynotes(
+            [
+                {"nodes": [node("Administrative law")]},
+                {"nodes": [node("Administrative law"), node("PAJA")]},
+            ]
+        )
+
+        def simplify(groups):
+            return [
+                {
+                    "nodes": [node.name for node in item["nodes"]],
+                    "children": simplify(item["children"]),
+                }
+                for item in groups
+            ]
+
+        self.assertEqual(
+            [
+                {
+                    "nodes": ["Administrative law"],
+                    "children": [
+                        {
+                            "nodes": ["PAJA"],
+                            "children": [],
+                        }
                     ],
                 },
             ],
@@ -549,7 +607,7 @@ class JudgmentTestCase(TestCase):
         normalized_html = " ".join(html.split())
 
         self.assertIn(
-            '<span class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">—</span>',
+            '<div class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">—</span>',
             normalized_html,
         )
         self.assertIn(

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -93,6 +93,7 @@ class JudgmentTestCase(TestCase):
                                 "Diesel refund scheme",
                                 "Interpretation of Note 6(f)(ii)(cc)",
                             ],
+                            "child_indent": 48,
                             "children": [
                                 {
                                     "text": "joint venture as substantive authorised user",
@@ -212,6 +213,7 @@ class JudgmentTestCase(TestCase):
                         "Legality Review",
                         "Unlawful Appointment",
                     ],
+                    "child_indent": 57,
                     "children": [
                         {
                             "text": "Jurisdiction, Delay, Legality of Municipal Appointments",
@@ -482,7 +484,7 @@ class JudgmentTestCase(TestCase):
             normalized_html,
         )
         self.assertIn(
-            '<div class="flynote-chain-tail"> '
+            '<span class="flynote-chain-tail"> '
             '<a href="/judgments/topics/matrimonial-property-act/">Matrimonial property act</a>',
             normalized_html,
         )
@@ -607,11 +609,12 @@ class JudgmentTestCase(TestCase):
         normalized_html = " ".join(html.split())
 
         self.assertIn(
-            '<div class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">—</span>',
+            '<span class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">&nbsp;—&nbsp;</span>',
             normalized_html,
         )
         self.assertIn(
-            '<div class="flynote-chain-tail"> Delict <ul class="list-unstyled flynotes">',
+            '<span class="flynote-chain-tail"> Delict </span> '
+            '<div class="flynote-chain-children"> <ul class="list-unstyled flynotes">',
             normalized_html,
         )
         self.assertIn("— assessment of credibility and probabilities", normalized_html)

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -549,10 +549,13 @@ class JudgmentTestCase(TestCase):
         normalized_html = " ".join(html.split())
 
         self.assertIn(
-            '<div class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">—</span>',
+            '<span class="flynote-chain-prefix"> Tort <span class="flynote-chain-separator">—</span>',
             normalized_html,
         )
-        self.assertIn('<div class="flynote-chain-tail"> Delict </div>', normalized_html)
+        self.assertIn(
+            '<div class="flynote-chain-tail"> Delict <ul class="list-unstyled flynotes">',
+            normalized_html,
+        )
         self.assertIn("— assessment of credibility and probabilities", normalized_html)
         self.assertIn("— causation (but-for and legal causation)", normalized_html)
 


### PR DESCRIPTION
fix the display isssue of flynotes to display in a multiline and in chain if only have a 1 child. Looks good now
Before:
<img width="1316" height="676" alt="Screenshot 2026-06-04 at 11 56 16 AM" src="https://github.com/user-attachments/assets/b4fc8f73-4203-4051-85eb-0e526fe4844f" />
<img width="1306" height="679" alt="Screenshot 2026-06-04 at 11 57 22 AM" src="https://github.com/user-attachments/assets/8030952b-4b8c-42d9-b5c4-96ecb032a276" />

After:

<img width="1426" height="640" alt="Screenshot 2026-06-04 at 11 57 07 AM" src="https://github.com/user-attachments/assets/bf78bad7-ddca-42f7-83dc-5a78e7553512" />
<img width="1492" height="569" alt="Screenshot 2026-06-04 at 11 57 49 AM" src="https://github.com/user-attachments/assets/a0d12a49-228a-4ca8-ac18-dd5b71deeb16" />
