### PR TITLE
btn-badge style

### DIFF
--- a/peachjam/static/stylesheets/components/_buttons.scss
+++ b/peachjam/static/stylesheets/components/_buttons.scss
@@ -20,3 +20,8 @@
     box-shadow: none;
   }
 }
+
+.btn.btn-badge {
+  --bs-btn-padding-y: 0.25rem;
+  --bs-btn-padding-x: 0.5rem;
+}

--- a/peachjam/tests/test_compare.py
+++ b/peachjam/tests/test_compare.py
@@ -375,7 +375,7 @@ class ComparePortionsViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Suggestions")
         self.assertContains(response, "Second Act")
-        self.assertContains(response, "Suggested provision")
+        self.assertContains(response, "Suggestion")
         self.assertContains(response, f'href="{suggested_url}"')
 
     def test_chooser_for_selected_side_includes_cancel(self):


### PR DESCRIPTION
for smaller buttons in lists of tag-like buttons

<img width="816" height="434" alt="image" src="https://github.com/user-attachments/assets/89812ddd-2bbb-4012-a5eb-1a3730c1abdf" />
