### PR TITLE
fix the small bug to show the  division specific labels that editors …

### DIFF
--- a/peachjam/admin.py
+++ b/peachjam/admin.py
@@ -2246,7 +2246,8 @@ class ExternalDocumentAdmin(DocumentAdmin):
 class CourtRegistryAdmin(BaseAdmin):
     help_topic = "site-admin/add-court-registries"
     readonly_fields = ("code",)
-    list_display = ("name", "code")
+    list_display = ("court", "name", "code")
+    list_select_related = ("court",)
 
 
 @admin.register(Outcome)

--- a/peachjam/models/judgment.py
+++ b/peachjam/models/judgment.py
@@ -258,7 +258,7 @@ class CourtRegistry(models.Model):
         unique_together = ("court", "name")
 
     def __str__(self):
-        return self.name
+        return f"{self.court.code} - {self.name}"
 
     def get_absolute_url(self):
         return reverse("court_registry", args=[self.court.code, self.code])

--- a/peachjam/tests/test_judgment.py
+++ b/peachjam/tests/test_judgment.py
@@ -925,6 +925,16 @@ class JudgmentTestCase(TestCase):
 
         self.assertEqual(court, judgment.court)
 
+    def test_court_registry_str_includes_court_code(self):
+        court = Court.objects.first()
+        registry = CourtRegistry.objects.create(
+            court=court,
+            name="Main registry",
+            code="main-registry",
+        )
+
+        self.assertEqual(f"{court.code} - Main registry", str(registry))
+
     @patch("peachjam.models.judgment.JudgmentSummariser")
     def test_generate_summary_updates_judgment_fields(self, summariser_cls):
         expected_flynote = (


### PR DESCRIPTION
fix the small bug to show court codes for court registry choices

Before:
<img width="869" height="343" alt="Screenshot 2026-06-09 at 4 44 31 PM" src="https://github.com/user-attachments/assets/4bc014a5-cb08-4e6c-9468-b92c4d532b3b" />


Now:
<img width="797" height="328" alt="Screenshot 2026-06-09 at 4 47 41 PM" src="https://github.com/user-attachments/assets/802c0013-39a5-4fea-89e8-634dd5b103f1" />

