### PR TITLE
Updated case history view to show clear timeline within a single tree

### DIFF
--- a/peachjam/templates/peachjam/_case_histories.html
+++ b/peachjam/templates/peachjam/_case_histories.html
@@ -30,7 +30,7 @@
         {% if subscription_required %}
           {% include "peachjam_subs/_subscription_required.html" %}
         {% else %}
-          <p class="text-muted">Showing case history timeline – from most recent to oldest</p>
+          <p class="text-muted">{% trans 'Showing case history timeline, from most recent to oldest' %}</p>
           <div class="vertical-timeline ms-5 mt-4">
             {% for entry in case_histories %}
               <div class="vertical-timeline__item">

--- a/peachjam/templates/peachjam/_case_histories.html
+++ b/peachjam/templates/peachjam/_case_histories.html
@@ -1,13 +1,11 @@
 {% load i18n %}
-{% if case_histories %}
-  {% if show_review_notice %}
-    <div hx-swap-oob="beforeend:#extra-notices">
-      <div class="alert alert-warning">
-        <i class="bi bi-exclamation-triangle-fill"></i>
-        {% trans 'This judgment was reviewed by another court. See the Case history tab for details.' %}
-      </div>
+{% if show_review_notice %}
+  <div hx-swap-oob="beforeend:#extra-notices">
+    <div class="alert alert-warning">
+      <i class="bi bi-exclamation-triangle-fill"></i>
+      {% trans 'This judgment was reviewed by another court. See the Case history tab for details.' %}
     </div>
-  {% endif %}
+  </div>
   <ul hx-swap-oob="beforeend:#document-tab-list">
     <li class="nav-item" role="presentation">
       <button class="nav-link"
@@ -32,75 +30,50 @@
         {% if subscription_required %}
           {% include "peachjam_subs/_subscription_required.html" %}
         {% else %}
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>{% trans 'Date' %}</th>
-                <th>{% trans 'Case' %}</th>
-                <th>{% trans 'Court' %}</th>
-                <th>{% trans 'Judges' %}</th>
-                <th>{% trans 'Outcome' %}</th>
-                <th>{% trans 'Appeal outcome' %}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for entry in case_histories %}
-                <tr>
-                  <td>{{ entry.document.date }}</td>
-                  <td>
-                    <a href="{{ entry.document.get_absolute_url }}">{{ entry.document.title }}</a>
-                    {% if entry.document == document %}
-                      <span class="badge text-bg-primary">{% trans "This judgment" %}</span>
-                    {% endif %}
-                  </td>
-                  <td>{{ entry.document.court }}</td>
-                  <td>
-                    {% for judge in entry.document.judges.all %}
-                      {# djlint:off #}
-          <span class="text-nowrap"><a href="{{ judge.get_absolute_url }}">{{ judge }}</a>{% if not forloop.last %},{% endif %}</span>
-                      {# djlint:on #}
-                    {% endfor %}
-                  </td>
-                  <td>{{ entry.document.outcome }}</td>
-                  <td>&nbsp;</td>
-                </tr>
-                {% for child in entry.children %}
-                  <tr>
-                    <td>{{ child.info.date }}</td>
-                    <td>
-                      ↳
-                      {% if child.document %}
-                        <a href="{{ child.document.get_absolute_url }}">{{ child.document.title }}</a>
-                        {% if child.document == document %}
-                          <span class="badge text-bg-primary">{% trans "This judgment" %}</span>
-                        {% endif %}
-                      {% else %}
-                        {{ child.case_history.case_number }}
+          <p class="text-muted">Showing case history timeline – from most recent to oldest</p>
+          <div class="vertical-timeline ms-5 mt-4">
+            {% for entry in case_histories %}
+              <div class="vertical-timeline__item">
+                <div class="card mb-3">
+                  <div class="card-body">
+                    <div class="mb-1">
+                      <span class="text-muted">{{ entry.document.date }}</span>
+                      {% if entry.is_current %}
+                        <span class="badge rounded-pill bg-primary ms-1">{% trans 'You are here' %}</span>
                       {% endif %}
-                    </td>
-                    <td>{{ child.info.court }}</td>
-                    <td>
-                      {% for judge in child.info.judges.all %}
-                        {# djlint:off #}
-            <span class="text-nowrap"><a href="{{ judge.get_absolute_url }}">{{ judge }}</a>{% if not forloop.last %},{% endif %}</span>
-                        {# djlint:on #}
-                      {% endfor %}
-                    </td>
-                    <td>
-                      {% if child.document %}
-                        {% for outcome in child.document.outcomes.all %}
-                          {# djlint:off #}
-                <span class="text-nowrap">{{ outcome }}{% if not forloop.last %},{% endif %}</span>
-                          {# djlint:on #}
-                        {% endfor %}
+                    </div>
+                    <h5 class="mb-0 card-title">
+                      <a href="{{ entry.document.get_absolute_url }}">{{ entry.document.title }}</a>
+                    </h5>
+                    <div class="d-flex mt-2">
+                      <section>
+                        <span class="text-muted text-uppercase">{% trans 'Court' %}</span>
+                        <span class="card-text d-block fw-semibold">{{ entry.document.court }}</span>
+                      </section>
+                      <section class="ms-4">
+                        <span class="text-muted text-uppercase fs-6">{% trans 'Judges' %}</span>
+                        <span class="card-text d-block fw-semibold">
+                          {% for judge in entry.document.judges.all %}
+                            {{ judge }}
+                            {% if not forloop.last %},{% endif %}
+                          {% endfor %}
+                        </span>
+                      </section>
+                    </div>
+                    {% with entry.document.outcomes.all as outcomes %}
+                      {% if outcomes %}
+                        <div class="mt-1">
+                          {% for outcome in outcomes %}
+                            <span class="badge rounded-pill bg-primary-subtle text-primary">{{ outcome }}</span>
+                          {% endfor %}
+                        </div>
                       {% endif %}
-                    </td>
-                    <td>{{ child.case_history.outcome|default_if_none:"" }}</td>
-                  </tr>
-                {% endfor %}
-              {% endfor %}
-            </tbody>
-          </table>
+                    {% endwith %}
+                  </div>
+                </div>
+              </div>
+            {% endfor %}
+          </div>
         {% endif %}
       </div>
     </div>

--- a/peachjam/tests/test_views.py
+++ b/peachjam/tests/test_views.py
@@ -27,6 +27,7 @@ from peachjam.models import (
     SavedDocument,
     SourceFile,
     UserFollowing,
+    Work,
 )
 from peachjam.views.robots import (
     _language_prefixes,
@@ -477,7 +478,7 @@ class PeachjamViewsTest(TestCase):
         )
         self.assertContains(response, "Case history")
         self.assertContains(response, main_case.title)
-        self.assertContains(response, appeal_allowed.name)
+        self.assertNotContains(response, appeal_allowed.name)
 
         response = self.client.get(
             reverse("document_case_histories", args=[main_case.expression_frbr_uri[1:]])
@@ -485,7 +486,149 @@ class PeachjamViewsTest(TestCase):
         self.assertContains(response, "reviewed by another court")
         self.assertContains(response, "Case history")
         self.assertContains(response, appeal_case.title)
-        self.assertContains(response, appeal_allowed.name)
+        self.assertNotContains(response, appeal_allowed.name)
+
+    def test_case_history_hidden_without_linked_histories(self):
+        self.user = User.objects.first()
+        self.client._login(self.user, "django.contrib.auth.backends.ModelBackend")
+        self.user.user_permissions.add(
+            Permission.objects.get(codename="can_view_case_history")
+        )
+
+        standalone_case = Judgment.objects.create(
+            case_name="Standalone case",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 6, 1),
+            language=Language.objects.first(),
+        )
+
+        response = self.client.get(
+            reverse(
+                "document_case_histories",
+                args=[standalone_case.expression_frbr_uri[1:]],
+            )
+        )
+        self.assertNotContains(response, "Case history")
+        self.assertNotContains(response, "reviewed by another court")
+
+    def test_case_history_recurses_and_hides_unlinked_rows(self):
+        self.user = User.objects.first()
+        self.client._login(self.user, "django.contrib.auth.backends.ModelBackend")
+        self.user.user_permissions.add(
+            Permission.objects.get(codename="can_view_case_history")
+        )
+
+        outcome_ancestor = Outcome.objects.create(name="Outcome Ancestor")
+        outcome_current = Outcome.objects.create(name="Outcome Current")
+        outcome_child = Outcome.objects.create(name="Outcome Child")
+        outcome_grandchild = Outcome.objects.create(name="Outcome Grandchild")
+
+        ancestor_case = Judgment.objects.create(
+            case_name="Ancestor case",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 1, 1),
+            language=Language.objects.first(),
+        )
+        current_case = Judgment.objects.create(
+            case_name="Current case",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 3, 1),
+            language=Language.objects.first(),
+        )
+        child_case = Judgment.objects.create(
+            case_name="Child case",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 4, 1),
+            language=Language.objects.first(),
+        )
+        grandchild_case = Judgment.objects.create(
+            case_name="Grandchild case",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2025, 5, 1),
+            language=Language.objects.first(),
+        )
+        great_ancestor_case = Judgment.objects.create(
+            case_name="Great ancestor case",
+            jurisdiction=Country.objects.first(),
+            court=Court.objects.first(),
+            date=datetime.date(2024, 12, 1),
+            language=Language.objects.first(),
+        )
+
+        CaseHistory.objects.create(
+            judgment_work=ancestor_case.work,
+            historical_judgment_work=great_ancestor_case.work,
+            outcome=outcome_ancestor,
+        )
+        CaseHistory.objects.create(
+            judgment_work=current_case.work,
+            historical_judgment_work=ancestor_case.work,
+            outcome=outcome_current,
+        )
+        CaseHistory.objects.create(
+            judgment_work=child_case.work,
+            historical_judgment_work=current_case.work,
+            outcome=outcome_child,
+        )
+        CaseHistory.objects.create(
+            judgment_work=grandchild_case.work,
+            historical_judgment_work=child_case.work,
+            outcome=outcome_grandchild,
+        )
+
+        unlinked_work = Work.objects.create(
+            frbr_uri="/akn/aa/judgment/test/1900/999",
+            frbr_uri_country="aa",
+            frbr_uri_place="aa",
+            frbr_uri_doctype="judgment",
+            frbr_uri_actor="test",
+            frbr_uri_date="1900",
+            frbr_uri_number="999",
+            title="Unlinked work",
+            languages=["eng"],
+        )
+        CaseHistory.objects.create(
+            judgment_work=current_case.work,
+            historical_judgment_work=unlinked_work,
+            outcome=outcome_current,
+            case_number="Missing linked document case",
+        )
+
+        response = self.client.get(
+            reverse(
+                "document_case_histories", args=[current_case.expression_frbr_uri[1:]]
+            )
+        )
+
+        self.assertContains(response, "Case history")
+        self.assertContains(response, great_ancestor_case.title)
+        self.assertContains(response, ancestor_case.title)
+        self.assertContains(response, current_case.title)
+        self.assertContains(response, child_case.title)
+        self.assertContains(response, grandchild_case.title)
+        self.assertNotContains(response, outcome_ancestor.name)
+        self.assertNotContains(response, outcome_child.name)
+        self.assertNotContains(response, outcome_grandchild.name)
+        self.assertNotContains(response, "Missing linked document case")
+
+        response_text = response.content.decode()
+        self.assertLess(
+            response_text.index(grandchild_case.title),
+            response_text.index(child_case.title),
+        )
+        self.assertLess(
+            response_text.index(child_case.title),
+            response_text.index(current_case.title),
+        )
+        self.assertLess(
+            response_text.index(current_case.title),
+            response_text.index(ancestor_case.title),
+        )
 
     def test_document_source_file(self):
         frbr_uri = "/akn/aa-au/judgment/ecowascj/2016/52/eng@2016-11-09"

--- a/peachjam/views/judgment.py
+++ b/peachjam/views/judgment.py
@@ -12,12 +12,11 @@ from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.text import gettext_lazy as _
-from django.utils.timezone import now
 from django.views.decorators.cache import never_cache
 from django.views.generic import DetailView, ListView, TemplateView
 
 from peachjam.helpers import add_slash_to_frbr_uri
-from peachjam.models import CourtClass, Judgment
+from peachjam.models import CaseHistory, CourtClass, Judgment
 from peachjam.models.flynote import Flynote
 from peachjam.registry import registry
 from peachjam.views.generic_views import (
@@ -319,69 +318,69 @@ class CaseHistoryView(SubscriptionRequiredMixin, DetailView):
 
     def add_case_histories(self, context):
         document = self.get_object()
+        case_histories = self.get_connected_case_histories(document.work_id)
+        histories = self.get_case_history_entries(document, case_histories)
 
-        # judgments that impact this one
-        histories = [
-            {
-                "document": ch.judgment_work.documents.first(),
-                "children": [
-                    {
-                        "case_history": ch,
-                        "document": document,
-                    }
-                ],
-            }
-            for ch in document.work.incoming_case_histories.select_related(
-                "court", "historical_judgment_work", "outcome"
-            )
-            # ignore incoming history entries for dangling works that don't have a document
-            if ch.judgment_work.documents.first()
-        ]
-
-        if histories:
-            context["show_review_notice"] = True
-
-        # judgments that this one impacts
-        outgoing_histories = [
-            {
-                "case_history": ch,
-                "document": (
-                    ch.historical_judgment_work.documents.first()
-                    if ch.historical_judgment_work
-                    else None
-                ),
-            }
-            for ch in document.work.case_histories.select_related(
-                "historical_judgment_work", "outcome"
-            ).prefetch_related(
-                "historical_judgment_work__documents",
-                "historical_judgment_work__documents__outcomes",
-                "historical_judgment_work__documents__court",
-                "historical_judgment_work__documents__judges",
-            )
-        ]
-        if outgoing_histories:
-            histories.append(
-                {
-                    "document": document,
-                    "children": outgoing_histories,
-                }
-            )
-
-        today = now().date()
-        for history in histories:
-            for child in history["children"]:
-                child["info"] = child["document"] or child["case_history"]
-
-            # sort by date descending
-            history["children"].sort(
-                key=lambda x: x["info"].date or today, reverse=True
-            )
-
-        # sort by date descending
-        histories.sort(key=lambda x: x["document"].date, reverse=True)
+        context["show_review_notice"] = bool(case_histories)
 
         context["case_histories"] = histories
+        return histories
+
+    def get_connected_case_histories(self, root_work_id):
+        case_histories = {}
+        pending_work_ids = {root_work_id}
+        visited_work_ids = set()
+
+        while pending_work_ids:
+            work_ids_to_process = pending_work_ids
+            pending_work_ids = set()
+            visited_work_ids.update(work_ids_to_process)
+
+            histories = CaseHistory.objects.filter(
+                Q(judgment_work_id__in=work_ids_to_process)
+                | Q(historical_judgment_work_id__in=work_ids_to_process)
+            )
+
+            for case_history in histories:
+                if case_history.pk in case_histories:
+                    continue
+
+                case_histories[case_history.pk] = case_history
+                for work_id in (
+                    case_history.judgment_work_id,
+                    case_history.historical_judgment_work_id,
+                ):
+                    if work_id and work_id not in visited_work_ids:
+                        pending_work_ids.add(work_id)
+
+        return list(case_histories.values())
+
+    def get_case_history_entries(self, document, case_histories):
+        work_ids = {document.work_id}
+        for case_history in case_histories:
+            work_ids.add(case_history.judgment_work_id)
+            if case_history.historical_judgment_work_id:
+                work_ids.add(case_history.historical_judgment_work_id)
+
+        documents_by_work_id = {document.work_id: document}
+        related_documents = (
+            Judgment.objects.filter(work_id__in=work_ids - {document.work_id})
+            .latest_expression()
+            .select_related("court")
+            .prefetch_related("judges", "outcomes")
+        )
+        for related_document in related_documents:
+            documents_by_work_id[related_document.work_id] = related_document
+
+        histories = []
+        for case_document in documents_by_work_id.values():
+            history = {
+                "document": case_document,
+                "is_current": case_document.work_id == document.work_id,
+            }
+            histories.append(history)
+
+        histories.sort(key=lambda history: history["document"].date, reverse=True)
 
         return histories
 


### PR DESCRIPTION
Closes #3126 

- Retrieved ancestor and descendant case histories without duplicates
- Displayed only judgment outcome
- Sorted by date descending
- Removed the case_histories check in the template (used only show_review_notice) since show_review_notice is true only if there are histories
- Similar display to legislation history view

https://www.loom.com/share/09d43d80bd9d4bb2b8295116563cf10b