### PR TITLE
I have Implemented entity search results for courts and judges.

### DIFF
--- a/peachjam/js/components/FindDocuments/index.vue
+++ b/peachjam/js/components/FindDocuments/index.vue
@@ -196,7 +196,6 @@
           <div class="col-md-12 col-lg-9 position-relative">
             <div>
               <FacetBadges v-model="facets" :permissive="searchInfo.count === 0" />
-              <div id="saved-search-button" />
               <div
                 id="saved-search-modal"
                 class="modal fade"
@@ -206,6 +205,11 @@
               >
                 <div id="saved-search-modal-dialog" class="modal-dialog" />
               </div>
+              <div
+                v-if="searchInfo.entity_results_html"
+                v-html="searchInfo.entity_results_html"
+              />
+              <div id="saved-search-button" />
               <div v-if="searchInfo.count">
                 <div class="my-3 d-flex">
                   <div class="me-2">

--- a/peachjam_search/entity_matcher.py
+++ b/peachjam_search/entity_matcher.py
@@ -2,10 +2,11 @@ import re
 import string
 from dataclasses import dataclass
 from typing import Iterable
+from urllib.parse import urlencode
 
 from django.core.cache import cache
 from django.db.models import Model, QuerySet
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.translation import gettext_lazy as _
 
 from peachjam.models import Court, Judge, Locality
@@ -145,10 +146,14 @@ class LocalityEntityProvider(EntityProvider):
         return super().get_queryset().select_related("jurisdiction")
 
     def get_url(self, entity) -> str:
-        return reverse(
-            "locality_legislation_list",
-            kwargs={"code": entity.place_code()},
-        )
+        try:
+            return reverse(
+                "locality_legislation_list",
+                kwargs={"code": entity.place_code()},
+            )
+        except NoReverseMatch:
+            # Some site URL configs don't have a locality legislation route.
+            return f"{reverse('legislation_list')}?{urlencode({'localities': entity.name})}"
 
     def match(self, query: str, normalized_query: str) -> list[CandidateMatch]:
         matches = []

--- a/peachjam_search/entity_matcher.py
+++ b/peachjam_search/entity_matcher.py
@@ -5,9 +5,10 @@ from typing import Iterable
 
 from django.core.cache import cache
 from django.db.models import Model, QuerySet
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from peachjam.models import Court, Judge
+from peachjam.models import Court, Judge, Locality
 
 
 @dataclass(frozen=True)
@@ -134,8 +135,47 @@ class JudgeEntityProvider(EntityProvider):
         return set(query_tokens).issubset(set(name_tokens))
 
 
+class LocalityEntityProvider(EntityProvider):
+    entity_type = "locality"
+    type_label = _("Locality")
+    model = Locality
+    fields = ("id", "name", "code", "jurisdiction")
+
+    def get_queryset(self) -> QuerySet:
+        return super().get_queryset().select_related("jurisdiction")
+
+    def get_url(self, entity) -> str:
+        return reverse(
+            "locality_legislation_list",
+            kwargs={"code": entity.place_code()},
+        )
+
+    def match(self, query: str, normalized_query: str) -> list[CandidateMatch]:
+        matches = []
+
+        for locality in self.get_entities():
+            normalized_names = [
+                normalize(locality.name),
+                normalize(re.sub(r"\s*\([^)]*\)", "", locality.name)),
+            ]
+            normalized_place_code = normalize(locality.place_code())
+
+            if query == locality.name:
+                matches.append(CandidateMatch(locality, "exact", 1.0))
+            elif normalized_query in normalized_names:
+                matches.append(CandidateMatch(locality, "normalized exact", 0.98))
+            elif normalized_query == normalized_place_code:
+                matches.append(CandidateMatch(locality, "place code exact", 0.98))
+
+        return matches
+
+
 class EntityMatcher:
-    default_providers = [CourtEntityProvider, JudgeEntityProvider]
+    default_providers = [
+        CourtEntityProvider,
+        JudgeEntityProvider,
+        LocalityEntityProvider,
+    ]
     max_query_length = 50
     _instance = None
 

--- a/peachjam_search/entity_matcher.py
+++ b/peachjam_search/entity_matcher.py
@@ -3,6 +3,7 @@ import string
 from dataclasses import dataclass
 from typing import Iterable
 
+from django.core.cache import cache
 from django.db.models import Model, QuerySet
 from django.utils.translation import gettext_lazy as _
 
@@ -12,15 +13,12 @@ from peachjam.models import Court, Judge
 @dataclass(frozen=True)
 class EntitySearchHit:
     entity_type: str
+    type_label: str
     entity_id: int
     label: str
     url: str
     match_type: str
     confidence: float
-
-    @property
-    def type_label(self):
-        return ENTITY_TYPE_LABELS.get(self.entity_type, self.entity_type)
 
 
 @dataclass(frozen=True)
@@ -32,10 +30,21 @@ class CandidateMatch:
 
 class EntityProvider:
     entity_type = ""
+    type_label = ""
     model = None
+    fields = ("id", "name")
+    cache_timeout = 60 * 60
 
     def get_queryset(self) -> QuerySet:
         return self.model.objects.all()
+
+    def get_entities(self) -> list[Model]:
+        cache_key = f"peachjam-search-entity-provider:{self.entity_type}:v1"
+        return cache.get_or_set(
+            cache_key,
+            lambda: list(self.get_queryset().only(*self.fields)),
+            self.cache_timeout,
+        )
 
     def get_label(self, entity) -> str:
         return entity.name
@@ -50,6 +59,7 @@ class EntityProvider:
         entity = match.entity
         return EntitySearchHit(
             entity_type=self.entity_type,
+            type_label=self.type_label,
             entity_id=entity.pk,
             label=self.get_label(entity),
             url=self.get_url(entity),
@@ -60,12 +70,14 @@ class EntityProvider:
 
 class CourtEntityProvider(EntityProvider):
     entity_type = "court"
+    type_label = _("Court")
     model = Court
+    fields = ("id", "name", "code")
 
     def match(self, query: str, normalized_query: str) -> list[CandidateMatch]:
         matches = []
 
-        for court in self.get_queryset().only("id", "name", "code"):
+        for court in self.get_entities():
             normalized_name = normalize(court.name)
             normalized_code = normalize(court.code)
 
@@ -81,6 +93,7 @@ class CourtEntityProvider(EntityProvider):
 
 class JudgeEntityProvider(EntityProvider):
     entity_type = "judge"
+    type_label = _("Judge")
     model = Judge
 
     def match(self, query: str, normalized_query: str) -> list[CandidateMatch]:
@@ -88,7 +101,7 @@ class JudgeEntityProvider(EntityProvider):
         token_matches = []
         query_tokens = tokenize(normalized_query)
 
-        for judge in self.get_queryset().only("id", "name"):
+        for judge in self.get_entities():
             normalized_name = normalize(judge.name)
             name_tokens = tokenize(normalized_name)
 
@@ -96,7 +109,7 @@ class JudgeEntityProvider(EntityProvider):
                 matches.append(CandidateMatch(judge, "exact", 1.0))
             elif normalized_query == normalized_name:
                 matches.append(CandidateMatch(judge, "normalized exact", 0.98))
-            elif is_judge_token_match(query_tokens, name_tokens):
+            elif self.is_token_match(query_tokens, name_tokens):
                 token_matches.append(judge)
 
         if len(token_matches) == 1:
@@ -104,9 +117,27 @@ class JudgeEntityProvider(EntityProvider):
 
         return matches
 
+    def is_token_match(self, query_tokens: list[str], name_tokens: list[str]) -> bool:
+        """Match judge names conservatively by token.
+
+        A single-token query must be at least four characters and match one
+        name token. Multi-token queries must all be present in the judge name.
+        The caller only promotes token matches when exactly one judge matches,
+        so common or ambiguous names are not surfaced as entity hits.
+        """
+        if not query_tokens:
+            return False
+
+        if len(query_tokens) == 1:
+            return len(query_tokens[0]) >= 4 and query_tokens[0] in name_tokens
+
+        return set(query_tokens).issubset(set(name_tokens))
+
 
 class EntityMatcher:
     default_providers = [CourtEntityProvider, JudgeEntityProvider]
+    max_query_length = 50
+    _instance = None
 
     def __init__(self, providers: Iterable[EntityProvider] | None = None):
         self.providers = (
@@ -115,8 +146,17 @@ class EntityMatcher:
             else [provider() for provider in self.default_providers]
         )
 
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
     def match(self, query: str) -> list[EntitySearchHit]:
         query = (query or "").strip()
+        if len(query) > self.max_query_length:
+            return []
+
         normalized_query = normalize(query)
         if not normalized_query:
             return []
@@ -132,6 +172,7 @@ class EntityMatcher:
 
 
 def normalize(value: str) -> str:
+    # Canonicalize names and queries so exact matching is case- and punctuation-insensitive.
     value = value.casefold()
     value = value.translate(str.maketrans("", "", string.punctuation))
     value = re.sub(r"\s+", " ", value).strip()
@@ -140,19 +181,3 @@ def normalize(value: str) -> str:
 
 def tokenize(value: str) -> list[str]:
     return [token for token in value.split() if len(token) >= 3]
-
-
-def is_judge_token_match(query_tokens: list[str], name_tokens: list[str]) -> bool:
-    if not query_tokens:
-        return False
-
-    if len(query_tokens) == 1:
-        return len(query_tokens[0]) >= 4 and query_tokens[0] in name_tokens
-
-    return set(query_tokens).issubset(set(name_tokens))
-
-
-ENTITY_TYPE_LABELS = {
-    "court": _("Court"),
-    "judge": _("Judge"),
-}

--- a/peachjam_search/templates/peachjam_search/_entity_search_hit.html
+++ b/peachjam_search/templates/peachjam_search/_entity_search_hit.html
@@ -1,10 +1,8 @@
 <article class="card h-100">
-  <div class="card-body">
-    <div class="mb-2">
-      <span class="badge text-bg-secondary">{{ entity_hit.type_label }}</span>
-    </div>
-    <h5 class="card-title">
+  <div class="card-body d-flex align-items-start gap-2 bg-light">
+    <h5 class="card-title mb-0 flex-grow-1">
       <a class="h5 text-primary" href="{{ entity_hit.url }}">{{ entity_hit.label }}</a>
     </h5>
+    <span class="badge text-bg-secondary ms-auto">{{ entity_hit.type_label }}</span>
   </div>
 </article>

--- a/peachjam_search/templates/peachjam_search/_entity_search_hit_list.html
+++ b/peachjam_search/templates/peachjam_search/_entity_search_hit_list.html
@@ -1,0 +1,7 @@
+{% if entity_hits %}
+  <div class="row g-3 my-3">
+    {% for entity_hit in entity_hits %}
+      <div class="col-12 col-md-4">{% include "peachjam_search/_entity_search_hit.html" %}</div>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/peachjam_search/templates/peachjam_search/_entity_search_hit_list.html
+++ b/peachjam_search/templates/peachjam_search/_entity_search_hit_list.html
@@ -1,7 +1,11 @@
 {% if entity_hits %}
-  <div class="row g-3 my-3">
-    {% for entity_hit in entity_hits %}
-      <div class="col-12 col-md-4">{% include "peachjam_search/_entity_search_hit.html" %}</div>
-    {% endfor %}
-  </div>
+  <ul class="list-unstyled search-result-list p-2 bg-light rounded my-3">
+    <li class="mb-0">
+      <div class="row g-3">
+        {% for entity_hit in entity_hits %}
+          <div class="col-12 col-md-4">{% include "peachjam_search/_entity_search_hit.html" %}</div>
+        {% endfor %}
+      </div>
+    </li>
+  </ul>
 {% endif %}

--- a/peachjam_search/templates/peachjam_search/_search_hit_list.html
+++ b/peachjam_search/templates/peachjam_search/_search_hit_list.html
@@ -1,15 +1,4 @@
 <ul class="list-unstyled search-result-list">
-  {% if entity_hits %}
-    <li class="mb-4">
-      <div class="row g-3">
-        {% for entity_hit in entity_hits %}
-          <div class="{% if entity_hits|length > 1 %}col-md-6{% else %}col-12{% endif %}">
-            {% include "peachjam_search/_entity_search_hit.html" %}
-          </div>
-        {% endfor %}
-      </div>
-    </li>
-  {% endif %}
   {% for hit in hits %}
     {% include "peachjam_search/_search_hit.html" %}
   {% endfor %}

--- a/peachjam_search/tests/test_entity_matcher.py
+++ b/peachjam_search/tests/test_entity_matcher.py
@@ -1,6 +1,8 @@
+from urllib.parse import urlencode
+
 from django.core.cache import cache
-from django.test import TestCase
-from django.urls import reverse
+from django.test import TestCase, override_settings
+from django.urls import NoReverseMatch, reverse
 
 from peachjam.models import Court, Judge, Locality
 from peachjam_search.entity_matcher import EntityMatcher
@@ -44,12 +46,7 @@ class EntityMatcherTest(TestCase):
         self.assertEqual("locality", hits[0].entity_type)
         self.assertEqual("African Union (AU)", hits[0].label)
         self.assertEqual("exact", hits[0].match_type)
-        self.assertEqual(
-            reverse(
-                "locality_legislation_list", kwargs={"code": locality.place_code()}
-            ),
-            hits[0].url,
-        )
+        self.assertEqual(self.locality_legislation_url(locality), hits[0].url)
 
     def test_matches_locality_name_when_normalized(self):
         hits = EntityMatcher().match("african union au")
@@ -72,6 +69,16 @@ class EntityMatcherTest(TestCase):
         self.assertEqual(1, len(hits))
         self.assertEqual("locality", hits[0].entity_type)
         self.assertEqual("place code exact", hits[0].match_type)
+
+    @override_settings(ROOT_URLCONF="peachjam.urls.i18n")
+    def test_matches_locality_without_locality_legislation_url(self):
+        hits = EntityMatcher().match("African Union")
+
+        self.assertEqual(1, len(hits))
+        self.assertEqual(
+            f"{reverse('legislation_list')}?{urlencode({'localities': 'African Union (AU)'})}",
+            hits[0].url,
+        )
 
     def test_matches_judge_name_exactly(self):
         Judge.objects.create(name="Mwangi")
@@ -120,3 +127,11 @@ class EntityMatcherTest(TestCase):
 
         self.assertEqual([], hits)
         self.assertFalse(provider.called)
+
+    def locality_legislation_url(self, locality):
+        try:
+            return reverse(
+                "locality_legislation_list", kwargs={"code": locality.place_code()}
+            )
+        except NoReverseMatch:
+            return f"{reverse('legislation_list')}?{urlencode({'localities': locality.name})}"

--- a/peachjam_search/tests/test_entity_matcher.py
+++ b/peachjam_search/tests/test_entity_matcher.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.test import TestCase
 
 from peachjam.models import Court, Judge
@@ -6,6 +7,9 @@ from peachjam_search.entity_matcher import EntityMatcher
 
 class EntityMatcherTest(TestCase):
     fixtures = ["tests/countries", "tests/courts"]
+
+    def setUp(self):
+        cache.clear()
 
     def test_matches_court_name_exactly(self):
         hits = EntityMatcher().match("East African Court of Justice")
@@ -62,3 +66,18 @@ class EntityMatcherTest(TestCase):
         hits = EntityMatcher().match("african")
 
         self.assertEqual([], hits)
+
+    def test_ignores_long_queries_before_checking_providers(self):
+        class Provider:
+            called = False
+
+            def match(self, query, normalized_query):
+                self.called = True
+                return []
+
+        provider = Provider()
+
+        hits = EntityMatcher(providers=[provider]).match("x" * 51)
+
+        self.assertEqual([], hits)
+        self.assertFalse(provider.called)

--- a/peachjam_search/tests/test_entity_matcher.py
+++ b/peachjam_search/tests/test_entity_matcher.py
@@ -1,7 +1,8 @@
 from django.core.cache import cache
 from django.test import TestCase
+from django.urls import reverse
 
-from peachjam.models import Court, Judge
+from peachjam.models import Court, Judge, Locality
 from peachjam_search.entity_matcher import EntityMatcher
 
 
@@ -33,6 +34,44 @@ class EntityMatcherTest(TestCase):
         self.assertEqual("court", hits[0].entity_type)
         self.assertEqual(Court.objects.get(code="EACJ").pk, hits[0].entity_id)
         self.assertEqual("code exact", hits[0].match_type)
+
+    def test_matches_locality_name_exactly(self):
+        locality = Locality.objects.get(name="African Union (AU)")
+
+        hits = EntityMatcher().match("African Union (AU)")
+
+        self.assertEqual(1, len(hits))
+        self.assertEqual("locality", hits[0].entity_type)
+        self.assertEqual("African Union (AU)", hits[0].label)
+        self.assertEqual("exact", hits[0].match_type)
+        self.assertEqual(
+            reverse(
+                "locality_legislation_list", kwargs={"code": locality.place_code()}
+            ),
+            hits[0].url,
+        )
+
+    def test_matches_locality_name_when_normalized(self):
+        hits = EntityMatcher().match("african union au")
+
+        self.assertEqual(1, len(hits))
+        self.assertEqual("locality", hits[0].entity_type)
+        self.assertEqual("normalized exact", hits[0].match_type)
+
+    def test_matches_locality_name_without_parenthetical_suffix(self):
+        hits = EntityMatcher().match("African Union")
+
+        self.assertEqual(1, len(hits))
+        self.assertEqual("locality", hits[0].entity_type)
+        self.assertEqual("African Union (AU)", hits[0].label)
+        self.assertEqual("normalized exact", hits[0].match_type)
+
+    def test_matches_locality_place_code(self):
+        hits = EntityMatcher().match("aa-au")
+
+        self.assertEqual(1, len(hits))
+        self.assertEqual("locality", hits[0].entity_type)
+        self.assertEqual("place code exact", hits[0].match_type)
 
     def test_matches_judge_name_exactly(self):
         Judge.objects.create(name="Mwangi")

--- a/peachjam_search/tests/test_views.py
+++ b/peachjam_search/tests/test_views.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -21,6 +22,7 @@ class SearchViewsTest(TestCase):
     fixtures = ["tests/countries", "tests/users", "documents/sample_documents"]
 
     def setUp(self):
+        cache.clear()
         self.user = User.objects.get(username="officer@example.com")
         # ensure user has the correct permission
         self.user.user_permissions.add(
@@ -186,18 +188,17 @@ class SearchViewsTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        results_html = response.json()["results_html"]
-        self.assertIn("ECOWAS Community Court of Justice", results_html)
-        self.assertIn("Court", results_html)
-        self.assertLess(
-            results_html.index("ECOWAS Community Court of Justice"),
-            results_html.index(doc.title),
-        )
+        data = response.json()
+        self.assertIn("ECOWAS Community Court of Justice", data["entity_results_html"])
+        self.assertIn("Court", data["entity_results_html"])
+        self.assertNotIn("ECOWAS Community Court of Justice", data["results_html"])
+        self.assertIn(doc.title, data["results_html"])
 
     def test_entity_hit_does_not_use_document_click_tracking_attributes(self):
         request = RequestFactory().get("/search/?search=test")
         entity_hit = EntitySearchHit(
             entity_type="court",
+            type_label="Court",
             entity_id=1,
             label="ECOWAS Community Court of Justice",
             url="/court/ecowascj/",

--- a/peachjam_search/views/search.py
+++ b/peachjam_search/views/search.py
@@ -125,11 +125,17 @@ class DocumentSearchView(TemplateView):
         response = {
             "count": es_response.hits.total.value,
             "facets": es_response.aggregations.to_dict(),
+            "entity_results_html": render_to_string(
+                "peachjam_search/_entity_search_hit_list.html",
+                {
+                    "request": request,
+                    "entity_hits": entity_hits,
+                },
+            ),
             "results_html": render_to_string(
                 "peachjam_search/_search_hit_list.html",
                 {
                     "request": request,
-                    "entity_hits": entity_hits,
                     "hits": hits,
                     "can_debug": self.use_explain,
                     "show_jurisdiction": settings.PEACHJAM[
@@ -235,7 +241,7 @@ class DocumentSearchView(TemplateView):
         return engine
 
     def make_entity_matcher(self):
-        return EntityMatcher()
+        return EntityMatcher.get_instance()
 
     def match_entities(self, engine):
         if engine.page != 1 or engine.field_queries:


### PR DESCRIPTION
Search now keeps the existing document search flow intact, but also matches the raw query against known Court and Judge records. Strong entity matches are rendered above the normal document results using the existing server rendered `results_html` path.

<img width="1555" height="655" alt="Screenshot 2026-06-15 at 7 57 38 PM" src="https://github.com/user-attachments/assets/7e7516fb-005e-42e4-afe5-14a898990065" />


<img width="1514" height="675" alt="Screenshot 2026-06-15 at 8 56 01 PM" src="https://github.com/user-attachments/assets/faf060c5-5b9e-4bfb-81c6-93f396ad21d1" />

